### PR TITLE
Finish transition from `rv_names` to `rv_mode`

### DIFF
--- a/dit/multivariate/binding_information.py
+++ b/dit/multivariate/binding_information.py
@@ -5,7 +5,7 @@ The binding information and residual entropy.
 from ..shannon import conditional_entropy as H
 from ..helpers import normalize_rvs
 
-def binding_information(dist, rvs=None, crvs=None, rv_names=None):
+def binding_information(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Parameters
     ----------
@@ -18,11 +18,13 @@ def binding_information(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -34,18 +36,19 @@ def binding_information(dist, rvs=None, crvs=None, rv_names=None):
     ditException
         Raised if `dist` is not a joint distribution.
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
 
     others = lambda rv, rvs: set(set().union(*rvs)) - set(rv)
 
-    one = H(dist, set().union(*rvs), crvs, rv_names)
-    two = sum(H(dist, rv, others(rv, rvs).union(crvs), rv_names) for rv in rvs)
+    one = H(dist, set().union(*rvs), crvs, rv_mode=rv_mode)
+    two = sum(H(dist, rv, others(rv, rvs).union(crvs), rv_mode=rv_mode)
+              for rv in rvs)
     B = one - two
 
     return B
 
 
-def residual_entropy(dist, rvs=None, crvs=None, rv_names=None):
+def residual_entropy(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Parameters
     ----------
@@ -58,11 +61,13 @@ def residual_entropy(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -74,10 +79,11 @@ def residual_entropy(dist, rvs=None, crvs=None, rv_names=None):
     ditException
         Raised if `dist` is not a joint distribution.
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
 
     others = lambda rv, rvs: set(set().union(*rvs)) - set(rv)
 
-    R = sum(H(dist, rv, others(rv, rvs).union(crvs), rv_names) for rv in rvs)
+    R = sum(H(dist, rv, others(rv, rvs).union(crvs), rv_mode=rv_mode)
+            for rv in rvs)
 
     return R

--- a/dit/multivariate/coinformation.py
+++ b/dit/multivariate/coinformation.py
@@ -7,7 +7,7 @@ from iterutils import powerset
 from ..helpers import normalize_rvs
 from ..shannon import conditional_entropy as H
 
-def coinformation(dist, rvs=None, crvs=None, rv_names=None):
+def coinformation(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Calculates the coinformation.
 
@@ -22,11 +22,13 @@ def coinformation(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -46,35 +48,113 @@ def coinformation(dist, rvs=None, crvs=None, rv_names=None):
     >>> d = dit.example_dists.Xor()
     >>> d.set_rv_names(['X', 'Y', 'Z'])
 
-    The 3-way mutual information I[X:Y:Z] is:
+    To calculate coinformations, recall that `rvs` specifies which groups of
+    random variables are involved. For example, the 3-way mutual information
+    I[X:Y:Z] is calculated as:
+
+    >>> dit.multivariate.coinformation(d, ['X', 'Y', 'Z'])
+    -1.0
+
+    It is a quirk of strings that each element of a string is also an iterable.
+    So an equivalent way to calculate the 3-way mutual information I[X:Y:Z] is:
 
     >>> dit.multivariate.coinformation(d, 'XYZ')
     -1.0
 
-    Using random variable indexes instead of random variable names:
+    The reason this works is that list('XYZ') == ['X', 'Y', 'Z']. If we want
+    to use random variable indexes, we need to have explicit groupings:
 
-    >>> dit.multivariate.coinformation(d, [0,1,2], rv_mode='indexes')
+    >>> dit.multivariate.coinformation(d, [[0], [1], [2]], rv_mode='indexes')
     -1.0
+
+
+
+    To calculate the mutual information I[X, Y : Z], we use explicit groups:
+
+    >>> dit.multivariate.coinformation(d, ['XY', 'Z'])
+
+    Using indexes, this looks like:
+
+    >>> dit.multivariate.coinformation(d, [[0, 1], [2]], rv_mode='indexes')
+
+
 
     The mutual information I[X:Z] is given by:
 
     >>> dit.multivariate.coinformation(d, 'XZ')
     0.0
 
-    Conditional entropy can be calculated by passing in the conditional
-    random variables. The conditional entropy I[X:Y|Z] is:
+    Equivalently,
+
+    >>> dit.multivariate.coinformation(d, ['X', 'Z'])
+    0.0
+
+    Using indexes, this becomes:
+
+    >>> dit.multivariate.coinformation(d, [[0], [2]])
+    0.0
+
+
+
+    Conditional mutual informations can be calculated by passing in the
+    conditional random variables. The conditional entropy I[X:Y|Z] is:
 
     >>> dit.multivariate.coinformation(d, 'XY', 'Z')
     1.0
 
-    """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    Using indexes, this becomes:
 
-    def entropy(rvs, dist=dist, crvs=crvs, rv_names=rv_names):
+    >>> rvs = [[0], [1]]
+    >>> crvs = [[2]] # broken
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    1.0
+
+    For the conditional random variables, groupings have no effect, so you
+    can also obtain this as:
+
+    >>> rvs = [[0], [1]]
+    >>> crvs = [2]
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    1.0
+
+
+
+    Finally, note that entropy can also be calculated. The entropy H[Z|XY]
+    is obtained as:
+
+    >>> rvs = [[2]]
+    >>> crvs = [[0], [1]] # broken
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    0.0
+
+    >>> crvs = [[0, 1]] # broken
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    0.0
+
+    >>> crvs = [0, 1]
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    0.0
+
+    >>> rvs = 'Z'
+    >>> crvs = 'XY'
+    >>> dit.multivariate.coinformation(d, rvs, crvs, rv_mode='indexes')
+    0.0
+
+    Note that [[0], [1]] says to condition on two groups. But conditioning
+    is a flat operation and doesn't respect the groups, so it is equal to
+    a single group of 2 random variables: [[0, 1]]. With random variable
+    names 'XY' is acceptable because list('XY') = ['X', 'Y'], which is
+    species two singleton groups. By the previous argument, this is will
+    be treated the same as ['XY'].
+
+    """
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
+
+    def entropy(rvs, dist=dist, crvs=crvs, rv_mode=rv_mode):
         """
         Helper function to aid in computing the entropy of subsets.
         """
-        return H(dist, set().union(*rvs), crvs, rv_names)
+        return H(dist, set().union(*rvs), crvs, rv_mode=rv_mode)
 
     I = sum((-1)**(len(Xs)+1) * entropy(Xs) for Xs in powerset(rvs))
 

--- a/dit/multivariate/entropy.py
+++ b/dit/multivariate/entropy.py
@@ -3,9 +3,10 @@ A version of the entropy with signature common to the other multivariate
 measures.
 """
 
+from ..helpers import RV_MODES
 from ..shannon import conditional_entropy, entropy as shannon_entropy
 
-def entropy(dist, rvs=None, crvs=None, rv_names=None):
+def entropy(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Compute the conditional joint entropy.
 
@@ -19,11 +20,13 @@ def entropy(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -64,10 +67,10 @@ def entropy(dist, rvs=None, crvs=None, rv_names=None):
         if rvs is None:
             # Set to entropy of entire distribution
             rvs = list(range(dist.outcome_length()))
-            rv_names = False
+            rv_mode = RV_MODES.INDICES
         if crvs is None:
             crvs = []
     else:
         return shannon_entropy(dist)
 
-    return conditional_entropy(dist, rvs, crvs, rv_names)
+    return conditional_entropy(dist, rvs, crvs, rv_mode=rv_mode)

--- a/dit/multivariate/gk_common_information.py
+++ b/dit/multivariate/gk_common_information.py
@@ -7,7 +7,7 @@ from ..npdist import Distribution
 from ..algorithms import insert_meet
 from ..shannon import conditional_entropy as H
 
-def gk_common_information(dist, rvs=None, crvs=None, rv_names=None):
+def gk_common_information(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Returns the Gacs-Korner common information K[X1:X2...] over the random
     variables in `rvs`.
@@ -23,11 +23,13 @@ def gk_common_information(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition the common information
         by. If none, than there is no conditioning.
-    rv_names : bool, None
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -35,8 +37,8 @@ def gk_common_information(dist, rvs=None, crvs=None, rv_names=None):
         The Gacs-Korner common information of the distribution.
 
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
-    crvs = parse_rvs(dist, crvs, rv_names)[1]
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
+    crvs = parse_rvs(dist, crvs, rv_mode)[1]
 
     outcomes, pmf = zip(*dist.zipped(mode='patoms'))
     # The GK-common information is sensitive to zeros in the sample space.
@@ -44,7 +46,7 @@ def gk_common_information(dist, rvs=None, crvs=None, rv_names=None):
     d = Distribution(outcomes, pmf, sample_space=outcomes)
     d.set_rv_names(dist.get_rv_names())
 
-    d2 = insert_meet(d, -1, rvs, rv_names)
+    d2 = insert_meet(d, -1, rvs, rv_mode=rv_mode)
 
     common = [d2.outcome_length() - 1]
 

--- a/dit/multivariate/interaction_information.py
+++ b/dit/multivariate/interaction_information.py
@@ -6,7 +6,7 @@ from ..helpers import normalize_rvs
 
 from .coinformation import coinformation
 
-def interaction_information(dist, rvs=None, crvs=None, rv_names=None):
+def interaction_information(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Calculates the interaction information.
 
@@ -21,11 +21,13 @@ def interaction_information(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -37,8 +39,8 @@ def interaction_information(dist, rvs=None, crvs=None, rv_names=None):
     ditException
         Raised if `dist` is not a joint distribution.
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
 
-    II = (-1)**len(rvs) * coinformation(dist, rvs, crvs, rv_names)
+    II = (-1)**len(rvs) * coinformation(dist, rvs, crvs, rv_mode)
 
     return II

--- a/dit/multivariate/total_correlation.py
+++ b/dit/multivariate/total_correlation.py
@@ -5,7 +5,7 @@ The total correlation, aka the multi-information or the integration.
 from ..helpers import normalize_rvs
 from ..shannon import conditional_entropy as H
 
-def total_correlation(dist, rvs=None, crvs=None, rv_names=None):
+def total_correlation(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Parameters
     ----------
@@ -18,11 +18,13 @@ def total_correlation(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool, None
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -34,10 +36,10 @@ def total_correlation(dist, rvs=None, crvs=None, rv_names=None):
     ditException
         Raised if `dist` is not a joint distribution.
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
 
-    one = sum([H(dist, rv, crvs, rv_names) for rv in rvs])
-    two = H(dist, set().union(*rvs), crvs, rv_names)
+    one = sum([H(dist, rv, crvs, rv_mode=rv_mode) for rv in rvs])
+    two = H(dist, set().union(*rvs), crvs, rv_mode=rv_mode)
     T = one - two
 
     return T

--- a/dit/multivariate/tse_complexity.py
+++ b/dit/multivariate/tse_complexity.py
@@ -9,7 +9,7 @@ from ..shannon import conditional_entropy as H
 from ..helpers import normalize_rvs
 from ..math.misc import combinations as nCk
 
-def tse_complexity(dist, rvs=None, crvs=None, rv_names=None):
+def tse_complexity(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Calculates the TSE complexity.
 
@@ -24,11 +24,13 @@ def tse_complexity(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If equal
+        to 'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted, which
+        defaults to 'indices'.
 
     Returns
     -------
@@ -40,9 +42,9 @@ def tse_complexity(dist, rvs=None, crvs=None, rv_names=None):
     ditException
         Raised if `dist` is not a joint distribution.
     """
-    rvs, crvs, rv_names = normalize_rvs(dist, rvs, crvs, rv_names)
+    rvs, crvs, rv_mode = normalize_rvs(dist, rvs, crvs, rv_mode)
 
-    joint = H(dist, set().union(*rvs), crvs, rv_names)
+    joint = H(dist, set().union(*rvs), crvs, rv_mode=rv_mode)
     N = len(rvs)
 
     def sub_entropies(k):
@@ -50,7 +52,7 @@ def tse_complexity(dist, rvs=None, crvs=None, rv_names=None):
         Compute the average entropy of all subsets of `rvs` of size `k`.
         """
         sub_rvs = (set().union(*rv) for rv in combinations(rvs, k))
-        subH = sum(H(dist, rv, crvs, rv_names) for rv in sub_rvs)
+        subH = sum(H(dist, rv, crvs, rv_mode=rv_mode) for rv in sub_rvs)
         subH /= nCk(N, k)
         return subH
 

--- a/dit/other/extropy.py
+++ b/dit/other/extropy.py
@@ -2,11 +2,12 @@
 The extropy
 """
 
-from ..math.ops import LogOperations
+from ..helpers import RV_MODES
+from ..math.ops import get_ops
 
 import numpy as np
 
-def extropy(dist, rvs=None, rv_names=None):
+def extropy(dist, rvs=None, rv_mode=None):
     """
     Returns the extropy J[X] over the random variables in `rvs`.
 
@@ -22,11 +23,12 @@ def extropy(dist, rvs=None, rv_names=None):
         The indexes of the random variable used to calculate the extropy.
         If None, then the extropy is calculated over all random variables.
         This should remain `None` for ScalarDistributions.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret the elements of `rvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `rvs` are interpreted as random variable indices. If equal to 'names',
+        the the elements are interpreted as random variable names. If `None`,
+        then the value of `dist._rv_mode` is consulted.
 
     Returns
     -------
@@ -44,15 +46,15 @@ def extropy(dist, rvs=None, rv_names=None):
         import dit
         dist = dit.ScalarDistribution([dist, 1-dist])
         rvs = None
-        rv_names = False
+        rv_mode = RV_MODES.INDICES
 
     if dist.is_joint():
         if rvs is None:
             # Set to entropy of entire distribution
             rvs = list(range(dist.outcome_length()))
-            rv_names = False
+            rv_mode = RV_MODES.INDICES
 
-        d = dist.marginal(rvs, rv_names=rv_names)
+        d = dist.marginal(rvs, rv_mode=rv_mode)
     else:
         d = dist
 
@@ -63,7 +65,7 @@ def extropy(dist, rvs=None, rv_names=None):
         terms = -base**npmf * npmf
     else:
         # Calculate entropy in bits.
-        log = LogOperations(2).log
+        log = get_ops(2).log
         npmf = 1 - pmf
         terms = -npmf * log(npmf)
 

--- a/dit/other/perplexity.py
+++ b/dit/other/perplexity.py
@@ -2,10 +2,11 @@
 The perplexity of a distribution.
 """
 
+from ..helpers import RV_MODES
 from ..shannon import conditional_entropy, entropy
 from ..utils.misc import flatten
 
-def perplexity(dist, rvs=None, crvs=None, rv_names=None):
+def perplexity(dist, rvs=None, crvs=None, rv_mode=None):
     """
     Parameters
     ----------
@@ -17,11 +18,12 @@ def perplexity(dist, rvs=None, crvs=None, rv_names=None):
     crvs : list, None
         The indexes of the random variables to condition on. If None, then no
         variables are condition on.
-    rv_names : bool
-        If `True`, then the elements of `rvs` are treated as random variable
-        names. If `False`, then the elements of `rvs` are treated as random
-        variable indexes.  If `None`, then the value `True` is used if the
-        distribution has specified names for its random variables.
+    rv_mode : str, None
+        Specifies how to interpret the elements of `rvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `rvs` are interpreted as random variable indices. If equal to 'names',
+        the the elements are interpreted as random variable names. If `None`,
+        then the value of `dist._rv_mode` is consulted.
 
     Returns
     -------
@@ -35,7 +37,7 @@ def perplexity(dist, rvs=None, crvs=None, rv_names=None):
         if rvs is None:
             # Set to entropy of entire distribution
             rvs = list(range(dist.outcome_length()))
-            rv_names = False
+            rv_mode = RV_MODES.INDICES
         else:
             # this will allow inputs of the form [0, 1, 2] or [[0, 1], [2]],
             # allowing uniform behavior with the mutual information like
@@ -46,4 +48,4 @@ def perplexity(dist, rvs=None, crvs=None, rv_names=None):
     else:
         return base**entropy(dist)
 
-    return base**conditional_entropy(dist, rvs, crvs, rv_names)
+    return base**conditional_entropy(dist, rvs, crvs, rv_mode=rv_mode)

--- a/dit/samplespace.py
+++ b/dit/samplespace.py
@@ -10,10 +10,10 @@ Consider the following distribution:
 When we marginalize, we only iterate over the elements explicitly stored in
 the pmf. Before this module was implemented, whenever the sample space of a
 distribution was not explicitly specified, we took the outcomes to be the
-sample space. This had undesirable side effects. For example, d.marginal([0])
-would only have a sample space of ['0']. What we really would like is to be
-able to marginalize the sample space as well, so that we get a marginal
-sample space of ['0', '1'].
+sample space, in this case ['00', '01']. This had undesirable side effects.
+For example, d.marginal([0]) would only have a sample space of ['0']. What we
+really would like is to be able to marginalize the sample space as well, so
+that we get a marginal sample space of ['0', '1'].
 
 However, the only way to achieve that is the iterate over the entire sample
 space.  But while coalescing, we chose to iterate through the explicitly stored
@@ -36,7 +36,8 @@ experience the penalty discussed above.
 
 """
 from .helpers import (
-    parse_rvs, get_outcome_ctor, construct_alphabets, get_product_func
+    parse_rvs, get_outcome_ctor, construct_alphabets, get_product_func,
+    RV_MODES,
 )
 from .utils import OrderedDict
 
@@ -169,7 +170,7 @@ class SampleSpace(ScalarSampleSpace):
 
         """
         # We allow repeats and want to keep the order. We don't need the names.
-        parse = lambda rv: parse_rvs(self, rv, rv_names=False,
+        parse = lambda rv: parse_rvs(self, rv, rv_mode=RV_MODES.INDICES,
                                                unique=False, sort=False)[1]
         indexes = [parse(rv) for rv in rvs]
 
@@ -209,8 +210,8 @@ class SampleSpace(ScalarSampleSpace):
         """
         # For marginals, we must have unique indexes. Additionally, we do
         # not allow the order of the random variables to change. So we sort.
-        rv_names = False
-        rvs, indexes = parse_rvs(self, rvs, rv_names, unique=True, sort=True)
+        rv_mode = RV_MODES.INDICES
+        rvs, indexes = parse_rvs(self, rvs, rv_mode, unique=True, sort=True)
 
         # Marginalization is a special case of coalescing where there is only
         # one new random variable and it is composed of a strict subset of
@@ -234,7 +235,8 @@ class SampleSpace(ScalarSampleSpace):
             A new sample space with indexes in `rvs` marginalized away.
 
         """
-        rvs, indexes = parse_rvs(self, rvs, rv_names=False)
+        rv_mode = RV_MODES.INDICES
+        rvs, indexes = parse_rvs(self, rvs, rv_mode=rv_mode)
         indexes = set(indexes)
         all_indexes = range(self.outcome_length())
         marginal_indexes = [i for i in all_indexes if i not in indexes]
@@ -363,7 +365,8 @@ class CartesianProduct(SampleSpace):
 
         """
         # We allow repeats and want to keep the order. We don't need the names.
-        parse = lambda rv: parse_rvs(self, rv, rv_names=False,
+        rv_mode = RV_MODES.INDICES
+        parse = lambda rv: parse_rvs(self, rv, rv_mode=rv_mode,
                                                unique=False, sort=False)[1]
         indexes = [parse(rv) for rv in rvs]
 


### PR DESCRIPTION
This PR completes the unfinished transition from `rv_names` to `rv_mode`. It's a pain that we have to copy the docstring parameter everywhere. Makes me want to have processed docstrings, as matplotlib does.