### PR TITLE
f-divergence, various PEP8 fixes, more tests

### DIFF
--- a/dit/divergences/__init__.py
+++ b/dit/divergences/__init__.py
@@ -21,6 +21,7 @@ from .generalized_divergences import (
     hellinger_divergence,
     renyi_divergence,
     tsallis_divergence,
+    f_divergence,
     hellinger_sum,
 )
 

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -151,7 +151,7 @@ def hellinger_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=No
         None, if `dist2` has an outcome length different than `dist1`.
 
     """
-    
+
     if alpha == 1:
         return kullback_leibler_divergence(dist1, dist2, rvs=rvs,
                                            crvs=crvs, rv_mode=rv_mode)
@@ -255,9 +255,9 @@ def renyi_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
 
 def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
-    The alpha divergence of `dist1` and `dist2`, as used in Information 
-    Geometry. Note there is more than one inequivalent definition of 
-    "alpha divergence" in the literature, this one comes 
+    The alpha divergence of `dist1` and `dist2`, as used in Information
+    Geometry. Note there is more than one inequivalent definition of
+    "alpha divergence" in the literature, this one comes
     from http://en.wikipedia.org/wiki/Information_geometry .
 
     Parameters
@@ -294,12 +294,12 @@ def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
 
     if alpha == 1:
-        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, 
+        return kullback_leibler_divergence(dist1, dist2, rvs=rvs,
                                            crvs=crvs, rv_mode=rv_mode)
     if alpha == -1:
-        return kullback_leibler_divergence(dist2, dist1, rvs=rvs, 
+        return kullback_leibler_divergence(dist2, dist1, rvs=rvs,
                                            crvs=crvs, rv_mode=rv_mode)
-    s = double_power_sum(dist1, dist2, (1.-alpha)/2, (1.+alpha)/2, 
+    s = double_power_sum(dist1, dist2, (1.-alpha)/2, (1.+alpha)/2,
                          rvs=rvs, crvs=crvs, rv_mode=rv_mode)
     return 4*(1.-s)/(1.-alpha*alpha)
 
@@ -308,7 +308,7 @@ def f_divergence(dist1, dist2, f, rvs=None, crvs=None, rv_mode=None):
     The Csiszar f-divergence of `dist1` and `dist2`. Note that it is typically
     more accurate to use a specialized divergence function when available
     due to roundoff errors and small probability effects.
-    
+
     Parameters
     ----------
     dist1 : Distribution
@@ -319,7 +319,7 @@ def f_divergence(dist1, dist2, f, rvs=None, crvs=None, rv_mode=None):
         The auxillary function defining the f-divergence
     rvs : list, None
         The indexes of the random variable used to calculate the
-        f-divergence between. If None, then the 
+        f-divergence between. If None, then the
         f-divergence is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
@@ -341,7 +341,7 @@ def f_divergence(dist1, dist2, f, rvs=None, crvs=None, rv_mode=None):
         None, if `dist2` has an outcome length different than `dist1`.
 
     """
-    
+
     rvs, crvs, rv_mode = normalize_rvs(dist1, rvs, crvs, rv_mode)
     rvs, crvs = list(flatten(rvs)), list(flatten(crvs))
     normalize_rvs(dist2, rvs, crvs, rv_mode)

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -28,17 +28,15 @@ def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
-    dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
+        The first distribution in the sum.
+        The second distribution in the sum.
     exp1 : float, 1
         Exponent used in the power sum
     exp2 : float, 1
         Exponent used in the power sum
     rvs : list, None
-        The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
-        divergence is calculated over all random variables.
+        The indexes of the random variable used to calculate the sum.
+        If None, then the sum is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
         {'indices', 'names'}. If equal to 'indices', then the elements of
@@ -80,15 +78,15 @@ def hellinger_sum(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
-    dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
-    alpha : float, 1
-        Exponent parameterizing the sum
+        The first distribution in the sum.
+        The second distribution in the sum.
+    exp1 : float, 1
+        Exponent used in the power sum
+    exp2 : float, 1
+        Exponent used in the power sum
     rvs : list, None
-        The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
-        divergence is calculated over all random variables.
+        The indexes of the random variable used to calculate the sum.
+        If None, then the sum is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
         {'indices', 'names'}. If equal to 'indices', then the elements of
@@ -120,14 +118,14 @@ def hellinger_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=No
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
+        The first distribution in the Hellinger divergence.
     dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
+        The second distribution in the Hellinger divergence.
     alpha : float, 1
         The divergence is a one parameter family
     rvs : list, None
         The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
+        Hellinger divergence between. If None, then the Hellinger
         divergence is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
@@ -162,14 +160,14 @@ def tsallis_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
+        The first distribution in the Tsallis divergence.
     dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
+        The second distribution in the Tsallis divergence.
     alpha : float, 1
         The divergence is a one parameter family
     rvs : list, None
         The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
+        Tsallis divergence between. If None, then the Tsallis
         divergence is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
@@ -205,14 +203,14 @@ def renyi_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
+        The first distribution in the Renyi divergence.
     dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
+        The second distribution in the Renyi divergence.
     alpha : float, 1
         The divergence is a one parameter family
     rvs : list, None
         The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
+        Renyi divergence between. If None, then the Renyi
         divergence is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:
@@ -247,14 +245,14 @@ def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     Parameters
     ----------
     dist1 : Distribution
-        The first distribution in the Kullback-Leibler divergence.
+        The first distribution in the alpha divergence.
     dist2 : Distribution
-        The second distribution in the Kullback-Leibler divergence.
+        The second distribution in the alpha divergence.
     alpha : float, 1
         The divergence is a one parameter family
     rvs : list, None
         The indexes of the random variable used to calculate the
-        Kullback-Leibler divergence between. If None, then the Kullback-Leibler
+        alpha divergence between. If None, then the alpha
         divergence is calculated over all random variables.
     rv_mode : str, None
         Specifies how to interpret `rvs` and `crvs`. Valid options are:

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -22,6 +22,7 @@ __all__ = ('double_power_sum',
 ## http://arxiv.org/pdf/1105.3259v1.pdf
 ## http://arxiv.org/pdf/1206.2459.pdf
 ## http://mitran-lab.amath.unc.edu:8082/subversion/grants/Proposals/2013/DOE-DataCentric/biblio/LieseVajdaDivergencesInforTheory.pdf
+## Crooks: http://threeplusone.com/on_information.pdf
 
 def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=None):
     """
@@ -345,11 +346,11 @@ def f_divergence(dist1, dist2, f, rvs=None, crvs=None, rv_mode=None):
 
     p1s, q1s = get_pmfs_like(dist1, dist2, rvs+crvs, rv_mode)
     vfunc = np.vectorize(f)
-    div = np.nansum(vfunc(p1s) * q1s - vfunc(q1s) * q1s)
+    div = np.nansum(vfunc(np.divide(p1s, q1s)) * q1s)
 
     if crvs:
         p2s, q2s = get_pmfs_like(dist1, dist2, crvs, rv_mode)
-        div = np.nansum(vfunc(p2s) * q2s - vfunc(q2s) * q2s)
+        div = np.nansum(vfunc(np.divide(p2s, q2s)) * q2s)
 
     return div
 

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -305,7 +305,9 @@ def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
 
 def f_divergence(dist1, dist2, f, rvs=None, crvs=None, rv_mode=None):
     """
-    The Csiszar f-divergence of `dist1` and `dist2`.
+    The Csiszar f-divergence of `dist1` and `dist2`. Note that it is typically
+    more accurate to use a specialized divergence function when available
+    due to roundoff errors and small probability effects.
     
     Parameters
     ----------

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -23,7 +23,9 @@ __all__ = ('double_power_sum',
 ## http://mitran-lab.amath.unc.edu:8082/subversion/grants/Proposals/2013/DOE-DataCentric/biblio/LieseVajdaDivergencesInforTheory.pdf
 
 def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=None):
-    """A common generalization of the sums needed to compute the Hellinger and alpha divergences below.
+    """
+    A common generalization of the sums needed to compute the Hellinger
+    and alpha divergences below.
 
     Parameters
     ----------
@@ -31,9 +33,9 @@ def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=
         The first distribution in the sum.
         The second distribution in the sum.
     exp1 : float, 1
-        Exponent used in the power sum
+        Fisrt exponent used in the power sum.
     exp2 : float, 1
-        Exponent used in the power sum
+        Second exponent used in the power sum.
     rvs : list, None
         The indexes of the random variable used to calculate the sum.
         If None, then the sum is calculated over all random variables.
@@ -73,17 +75,16 @@ def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=
 
 def hellinger_sum(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
-    The Hellinger sum/integral of `dist1` and `dist2`, used to define other divergences.
+    The Hellinger sum/integral of `dist1` and `dist2`, used to define other
+    divergences.
 
     Parameters
     ----------
     dist1 : Distribution
         The first distribution in the sum.
         The second distribution in the sum.
-    exp1 : float, 1
-        Exponent used in the power sum
-    exp2 : float, 1
-        Exponent used in the power sum
+    alpha : float, 1
+        Exponent used in the sum.
     rvs : list, None
         The indexes of the random variable used to calculate the sum.
         If None, then the sum is calculated over all random variables.
@@ -108,7 +109,8 @@ def hellinger_sum(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
 
     """
 
-    return double_power_sum(dist1, dist2, alpha, 1.-alpha, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
+    return double_power_sum(dist1, dist2, alpha, 1.-alpha,
+                            rvs=rvs, crvs=crvs, rv_mode=rv_mode)
 
 def hellinger_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     # http://mitran-lab.amath.unc.edu:8082/subversion/grants/Proposals/2013/DOE-DataCentric/biblio/LieseVajdaDivergencesInforTheory.pdf
@@ -122,7 +124,7 @@ def hellinger_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=No
     dist2 : Distribution
         The second distribution in the Hellinger divergence.
     alpha : float, 1
-        The divergence is a one parameter family
+        The divergence is a one parameter family in alpha.
     rvs : list, None
         The indexes of the random variable used to calculate the
         Hellinger divergence between. If None, then the Hellinger
@@ -149,8 +151,10 @@ def hellinger_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=No
     """
     
     if alpha == 1:
-        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
-    s = hellinger_sum(dist1, dist2, rvs=rvs, alpha=alpha, crvs=crvs, rv_mode=rv_mode)
+        return kullback_leibler_divergence(dist1, dist2, rvs=rvs,
+                                           crvs=crvs, rv_mode=rv_mode)
+    s = hellinger_sum(dist1, dist2, rvs=rvs, alpha=alpha,
+                      crvs=crvs, rv_mode=rv_mode)
     return (s-1.)/(alpha-1.)
 
 def tsallis_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
@@ -164,7 +168,7 @@ def tsallis_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None
     dist2 : Distribution
         The second distribution in the Tsallis divergence.
     alpha : float, 1
-        The divergence is a one parameter family
+        The divergence is a one parameter family in alpha.
     rvs : list, None
         The indexes of the random variable used to calculate the
         Tsallis divergence between. If None, then the Tsallis
@@ -192,9 +196,13 @@ def tsallis_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None
 
     # D_T = (D_alpha -1) / (alpha-1)
     if alpha == 1:
-        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
-    return np.log2(hellinger_sum(dist1, dist2, alpha=alpha, rvs=rvs, crvs=crvs, rv_mode=rv_mode)) / (alpha - 1.)
-
+        div = kullback_leibler_divergence(dist1, dist2, rvs=rvs,
+                                          crvs=crvs, rv_mode=rv_mode)
+    else:
+        s = hellinger_sum(dist1, dist2, rvs=rvs, alpha=alpha,
+                          crvs=crvs, rv_mode=rv_mode)
+        div = (s - 1.) /(alpha - 1.)
+    return div
 
 def renyi_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
@@ -207,7 +215,7 @@ def renyi_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     dist2 : Distribution
         The second distribution in the Renyi divergence.
     alpha : float, 1
-        The divergence is a one parameter family
+        The divergence is a one parameter family in alpha.
     rvs : list, None
         The indexes of the random variable used to calculate the
         Renyi divergence between. If None, then the Renyi
@@ -235,12 +243,20 @@ def renyi_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
 
     # D_R = log D_alpha / (alpha-1)
     if alpha == 1:
-        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
-    return (hellinger_sum(dist1, dist2, rvs=rvs, alpha=alpha, crvs=crvs, rv_mode=rv_mode) - 1.) /(alpha - 1.)
+        div = kullback_leibler_divergence(dist1, dist2, rvs=rvs, 
+                                          crvs=crvs, rv_mode=rv_mode)
+    else:
+        s = hellinger_sum(dist1, dist2, rvs=rvs,
+                          alpha=alpha, crvs=crvs, rv_mode=rv_mode)
+        div = np.log2(s) / (alpha - 1.)
+    return div
 
 def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
-    The alpha divergence of `dist1` and `dist2`, as used in Information Geometry. Note there is more than one inequivalent definition of "alpha divergence" in the literature, this one comes from http://en.wikipedia.org/wiki/Information_geometry .
+    The alpha divergence of `dist1` and `dist2`, as used in Information 
+    Geometry. Note there is more than one inequivalent definition of 
+    "alpha divergence" in the literature, this one comes 
+    from http://en.wikipedia.org/wiki/Information_geometry .
 
     Parameters
     ----------
@@ -249,7 +265,7 @@ def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     dist2 : Distribution
         The second distribution in the alpha divergence.
     alpha : float, 1
-        The divergence is a one parameter family
+        The divergence is a one parameter family in alpha.
     rvs : list, None
         The indexes of the random variable used to calculate the
         alpha divergence between. If None, then the alpha
@@ -276,10 +292,13 @@ def alpha_divergence(dist1, dist2, alpha=1., rvs=None, crvs=None, rv_mode=None):
     """
 
     if alpha == 1:
-        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
+        return kullback_leibler_divergence(dist1, dist2, rvs=rvs, 
+                                           crvs=crvs, rv_mode=rv_mode)
     if alpha == -1:
-        return kullback_leibler_divergence(dist2, dist1, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
-    s = double_power_sum(dist1, dist2, (1.-alpha)/2, (1.+alpha)/2, rvs=rvs, crvs=crvs, rv_mode=rv_mode)
+        return kullback_leibler_divergence(dist2, dist1, rvs=rvs, 
+                                           crvs=crvs, rv_mode=rv_mode)
+    s = double_power_sum(dist1, dist2, (1.-alpha)/2, (1.+alpha)/2, 
+                         rvs=rvs, crvs=crvs, rv_mode=rv_mode)
     return 4*(1.-s)/(1.-alpha*alpha)
 
 

--- a/dit/divergences/generalized_divergences.py
+++ b/dit/divergences/generalized_divergences.py
@@ -35,7 +35,7 @@ def double_power_sum(dist1, dist2, exp1=1, exp2=1, rvs=None, crvs=None, rv_mode=
         The first distribution in the sum.
         The second distribution in the sum.
     exp1 : float, 1
-        Fisrt exponent used in the power sum.
+        First exponent used in the power sum.
     exp2 : float, 1
         Second exponent used in the power sum.
     rvs : list, None

--- a/dit/divergences/tests/test_generalized_divergences.py
+++ b/dit/divergences/tests/test_generalized_divergences.py
@@ -168,12 +168,6 @@ def test_f_divergence(places=1):
         def f(x):
             return (np.power(x, 1. - alpha) - 1.) / (alpha - 1.)
         return f
-    
-    #f = lambda x: -np.log2(x)
-    #test_functions = [
-        #(lambda x: -np.log2(x), kullback_leibler_divergence),
-        #(lambda x: x * np.log2(x), kullback_leibler_divergence),
-        #]
     test_functions = []
     alphas = [0.1, 0.5, 1.1]
     for alpha in alphas:
@@ -188,5 +182,3 @@ def test_f_divergence(places=1):
                 div1 = f_divergence(dist1, dist2, f)
                 div2 = div_func(dist1, dist2)
                 assert_almost_equal(div1, div2, places=1)
-
-

--- a/dit/divergences/tests/test_generalized_divergences.py
+++ b/dit/divergences/tests/test_generalized_divergences.py
@@ -11,6 +11,7 @@ import numpy as np
 from dit import Distribution
 from dit.exceptions import ditException
 from dit.divergences import kullback_leibler_divergence, alpha_divergence, renyi_divergence, tsallis_divergence, hellinger_divergence, hellinger_sum
+from dit.other import renyi_entropy
 
 def get_dists_1():
     """
@@ -118,3 +119,18 @@ def test_exceptions():
         for divergence in divergences:
             for alpha in alphas:
                 yield assert_raises, ditException, divergence, first, second, alpha, rvs, crvs
+
+def test_renyi():
+    """
+    Consistency test for Renyi entropy and Renyi divergence
+    """
+    dist1 = Distribution(['0', '1', '2'], [1/4, 1/2, 1/4])
+    uniform = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
+    alphas = [0, 1, 2, 0.5]
+    for alpha in alphas:
+        h = renyi_entropy(dist1, alpha)
+        h_u = renyi_entropy(uniform, alpha)
+        div = renyi_divergence(dist1, uniform, alpha)
+        assert_almost_equal(h, h_u - div) 
+    
+

--- a/dit/divergences/tests/test_generalized_divergences.py
+++ b/dit/divergences/tests/test_generalized_divergences.py
@@ -11,7 +11,7 @@ import numpy as np
 from dit import Distribution
 from dit.exceptions import ditException
 from dit.divergences import kullback_leibler_divergence, alpha_divergence, renyi_divergence, tsallis_divergence, hellinger_divergence, hellinger_sum
-from dit.other import renyi_entropy
+from dit.other import renyi_entropy, tsallis_entropy
 
 def get_dists_1():
     """
@@ -73,7 +73,8 @@ def test_positivity():
 
 def test_alpha_symmetry():
     """
-    Tests the alpha -> -alpha symmetry for the alpha divergence, and a similar symmetry for the Hellinger divergence.
+    Tests the alpha -> -alpha symmetry for the alpha divergence, and a similar 
+    symmetry for the Hellinger and Renyi divergences.
     """
     alphas = [-1, 0, 0.5, 1, 2]
     test_dists = [get_dists_2(), get_dists_3()]
@@ -83,6 +84,7 @@ def test_alpha_symmetry():
                 for dist2 in dists:
                     assert_almost_equal(alpha_divergence(dist1, dist2, alpha), alpha_divergence(dist2, dist1, -alpha))
                     assert_almost_equal((1.-alpha)*hellinger_divergence(dist1, dist2, alpha), alpha*hellinger_divergence(dist2, dist1, 1.-alpha))
+                    assert_almost_equal((1.-alpha)*renyi_divergence(dist1, dist2, alpha), alpha*renyi_divergence(dist2, dist1, 1.-alpha))
 
 def test_divergences_to_kl():
     """
@@ -120,6 +122,18 @@ def test_exceptions():
             for alpha in alphas:
                 yield assert_raises, ditException, divergence, first, second, alpha, rvs, crvs
 
+def test_renyi_values():
+    """
+    Test specific values of the Renyi divergence.
+    """
+    d1 = Distribution(['0', '1'], [0, 1])
+    d2 = Distribution(['0', '1'], [1/2, 1/2])
+    d3 = Distribution(['0', '1'], [1, 0])
+
+    assert_almost_equal(renyi_divergence(d1, d2, 1/2), np.log2(2))
+    assert_almost_equal(renyi_divergence(d2, d3, 1/2), np.log2(2))
+    assert_almost_equal(renyi_divergence(d1, d3, 1/2), np.inf)
+
 def test_renyi():
     """
     Consistency test for Renyi entropy and Renyi divergence
@@ -132,5 +146,5 @@ def test_renyi():
         h_u = renyi_entropy(uniform, alpha)
         div = renyi_divergence(dist1, uniform, alpha)
         assert_almost_equal(h, h_u - div) 
-    
+
 

--- a/dit/divergences/tests/test_kullback_leibler_divergence.py
+++ b/dit/divergences/tests/test_kullback_leibler_divergence.py
@@ -1,5 +1,5 @@
 """
-Tests for dit.divergences.kullback_leiber_divergence.
+Tests for dit.divergences.kullback_leibler_divergence.
 """
 
 from __future__ import division


### PR DESCRIPTION
Also the names/formulas for Renyi and Tsallis divergences were swapped (oops!). I added a consistency test with the existing Renyi entropy functions for this.

The f-divergences are not quite as accurate as directly implemented divergences, but it does open up a lot of [additional possibilities](http://threeplusone.com/on_information.pdf).