### PR TITLE
coverage uses a json file format now, not pickle

### DIFF
--- a/fixcoverage.py
+++ b/fixcoverage.py
@@ -5,19 +5,19 @@ import sys
 def main(argv):
     source = argv[1]
     dest = argv[2]
-    cd = coverage.CoverageData()
-    cd.read_file('.coverage')
+    coverage_data = coverage.CoverageData()
+    coverage_data.read_file('.coverage')
 
     # Prefilter to filenames in dit
-    filenames = [filename for filename in cd._lines.keys()
+    filenames = [filename for filename in coverage_data._lines.keys()
                  if 'dit' in filename]
 
     for filename in filenames:
         new_filename = re.sub(source, dest, filename)
         if new_filename != filename:
-            cd._lines[new_filename] = cd._lines.pop(filename)
+            coverage_data._lines[new_filename] = coverage_data._lines.pop(filename)
 
-    cd.write_file('.coverage')
+    coverage_data.write_file('.coverage')
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/fixcoverage.py
+++ b/fixcoverage.py
@@ -1,24 +1,23 @@
-import pickle
+import coverage
 import re
 import sys
 
 def main(argv):
     source = argv[1]
     dest = argv[2]
-    with open('.coverage', 'rb') as f:
-        coverage_data = pickle.load(f)
+    cd = coverage.CoverageData()
+    cd.read_file('.coverage')
 
     # Prefilter to filenames in dit
-    filenames = [filename for filename in coverage_data['lines'].keys()
+    filenames = [filename for filename in cd._lines.keys()
                  if 'dit' in filename]
 
     for filename in filenames:
         new_filename = re.sub(source, dest, filename)
         if new_filename != filename:
-            coverage_data['lines'][new_filename] = coverage_data['lines'].pop(filename)
+            cd._lines[new_filename] = cd._lines.pop(filename)
 
-    with open('.coverage', 'wb') as f:
-        pickle.dump(coverage_data, f)
+    cd.write_file('.coverage')
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
coverage changed their file format a while back, so the fixcoverage.py script has been failing. this applies to networkx too, so you might want to copy this fix over.

i'm also probably doing it the wrong way -- directly modifying the _lines property. the file isn't standard json, so python's json module won't load it. i think the first line just needs to be stripped, but i figured using the coverage package directly would probably be more robust.