### PR TITLE
Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,10 @@ Optional Dependencies:
    * numdifftools
    * scipy
 
+Note:
+   The cython extensions are currently not supported on windows. Please install
+   using the ``--nocython`` option.
+
 Install:
    Until ``dit`` is available on PyPI, the easiest way to install is:
 
@@ -172,15 +176,15 @@ Enjoy!
 .. |build| image:: https://travis-ci.org/dit/dit.png?branch=master
    :target: https://travis-ci.org/dit/dit
    :alt: Continuous Integration Status
-   
+
 .. |coverage| image:: https://coveralls.io/repos/dit/dit/badge.svg?branch=master
    :target: https://coveralls.io/r/dit/dit?branch=master
    :alt: Test Coverage Status
-   
+
 .. |docs| image:: https://readthedocs.org/projects/dit/badge/?version=latest
    :target: http://dit.readthedocs.org/en/latest/?badge=latest
    :alt: Documentation Status
-   
+
 .. |health| image:: https://landscape.io/github/dit/dit/master/landscape.svg?style=flat
    :target: https://landscape.io/github/dit/dit/master
    :alt: Code Health

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,8 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose scipy cvxopt
+  - conda install cython nose scipy numdifftools
   - pip install .
-  - pip install -r requirements_optional.txt
 
 test_script:
   # Change to a non-source folder to make sure we run the tests on the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "nosetests --verbosity=2 -a '!windows' --exclude='.*3\.py' --with-coverage --cover-package=dit dit"
+  - "nosetests --verbosity=2 -a '!windows' --exclude=.*3\.py --with-coverage --cover-package=dit dit"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,22 +13,25 @@ environment:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86"
       CYTHON: false
+    - PY_MAJOR_VER: 2
+      PYTHON_ARCH: "x86"
+      CYTHON: true
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
       CYTHON: false
     - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86_64"
+      CYTHON: true
+    - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
       CYTHON: false
-    - allow_failures:
-      - PY_MAJOR_VER: 2
-        PYTHON_ARCH: "x86"
-        CYTHON: true
-      - PY_MAJOR_VER: 3
-        PYTHON_ARCH: "x86_64"
-        CYTHON: true
-      - PY_MAJOR_VER: 3
-        PYTHON_ARCH: "x86"
-        CYTHON: true
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86"
+      CYTHON: true
+
+matrix:
+  allow_failures:
+    - CYTHON: true
 
 build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
       CYTHON: false
-    allow_failures:
+    - allow_failures:
       - PY_MAJOR_VER: 2
         PYTHON_ARCH: "x86"
         CYTHON: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "nosetests --verbosity=2 -a '!windows' --exclude=.*3\.py --with-coverage --cover-package=dit dit"
+  - nosetests --verbosity=2 -a '!windows' --exclude=''.*3\.py' --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,4 +48,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!windows' --ignore-files='(?:^\.|^_,|^setup\.py|^.*3\.py$)' --with-coverage --cover-package=dit dit
+  - nosetests --verbosity=2 -a '!windows' --ignore-files="(?:^\.|^_,|^setup\.py|^.*3\.py$)" --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,26 +12,26 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86"
-      CYTHON: false
+      CYTHON: 0
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86"
-      CYTHON: true
+      CYTHON: 1
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
-      CYTHON: false
+      CYTHON: 0
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
-      CYTHON: true
+      CYTHON: 1
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
-      CYTHON: false
+      CYTHON: 0
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
-      CYTHON: true
+      CYTHON: 1
 
 matrix:
   allow_failures:
-    - CYTHON: true
+    - CYTHON: 1
 
 build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install nose scipy
-  - ps: if ($env:CYTHON) { conda install cython }
+  - ps: if ($env:CYTHON == '1') { conda install cython }
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose scipy
+  - conda install nose scipy
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!windows' -I='dit/utils/tests/test_bindargs3.py' --with-coverage --cover-package=dit dit
+  - nosetests --verbosity=2 -a '!windows' --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,66 +3,32 @@
 # https://ci.appveyor.com/project/dit/dit
 
 environment:
-  global:
-    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+  # global:
+  #   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+  #   # /E:ON and /V:ON options are not enabled in the batch script intepreter
+  #   # See: http://stackoverflow.com/a/13751649/163740
+  #   CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.9"
-      PYTHON_ARCH: "32"
+    - PY_MAJOR_VER: 2
+      PYTHON_ARCH: "x86"
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86_64"
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.9"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.5"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.5"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.3"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.3"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
-      PYTHON_ARCH: "64"
-
-install:
-  # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
-  - "powershell .\\appveyor\\install.ps1"
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-
-  # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-
-  # Install the build and runtime dependencies of the project.
-  # - "%CMD_IN_ENV% pip install --timeout=60 -r requirements.txt"
-  - "pip install ."
-
-  - "pip install nose"
-
-# Not a .NET project, we build networkx in the install step instead
-build: false
+build_script:
+  - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
+  - cmd: C:\Miniconda.exe /S /D=C:\Py
+  - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
+  - conda config --set always_yes yes
+  - conda update conda
+  - conda install cython nose scipy cvxopt
+  - pip install .
+  - pip install -r requirements_optional.txt
 
 test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "nosetests --verbosity=2 dit"
+  - "nosetests --verbosity=2 --with-coverage --cover-package=dit dit"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!windows' --exclude='.*3\.py' --with-coverage --cover-package=dit dit
+  - nosetests --verbosity=2 -a '!windows' -I='dit/utils/tests/test_bindargs3.py' --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!windows' --exclude=''.*3\.py' --with-coverage --cover-package=dit dit
+  - nosetests --verbosity=2 -a '!windows' --exclude='.*3\.py' --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install nose scipy
-  - ps: if ($env:CYTHON == '1') { conda install cython }
+  - ps: if ($env:CYTHON -eq '1') { conda install cython }
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "nosetests --verbosity=2 --with-coverage --cover-package=dit dit"
+  - "nosetests --verbosity=2 -a '!windows' --with-coverage --cover-package=dit dit"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,23 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86"
+      CYTHON: false
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
+      CYTHON: false
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
+      CYTHON: false
+    allow_failures:
+      - PY_MAJOR_VER: 2
+        PYTHON_ARCH: "x86"
+        CYTHON: true
+      - PY_MAJOR_VER: 3
+        PYTHON_ARCH: "x86_64"
+        CYTHON: true
+      - PY_MAJOR_VER: 3
+        PYTHON_ARCH: "x86"
+        CYTHON: true
 
 build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
@@ -24,10 +37,11 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install nose scipy
+  - ps: if ($env:CYTHON) { conda install cython }
   - pip install .
 
 test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "nosetests --verbosity=2 -a '!windows' --with-coverage --cover-package=dit dit"
+  - "nosetests --verbosity=2 -a '!windows' --exclude='.*3\.py' --with-coverage --cover-package=dit dit"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ environment:
       CYTHON: 1
 
 matrix:
+  fast_finish: true
   allow_failures:
     - CYTHON: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,9 +42,10 @@ build_script:
   - conda install nose scipy
   - ps: if ($env:CYTHON -eq '1') { conda install cython }
   - pip install .
+  - pip install nose-cov
 
 test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!windows' --with-coverage --cover-package=dit dit
+  - nosetests --verbosity=2 -a '!windows' --ignore-files='(?:^\.|^_,|^setup\.py|^.*3\.py$)' --with-coverage --cover-package=dit dit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,68 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+# https://ci.appveyor.com/project/dit/dit
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.9"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.9"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.5"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.3"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.3"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+
+install:
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - "powershell .\\appveyor\\install.ps1"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Install the build and runtime dependencies of the project.
+  # - "%CMD_IN_ENV% pip install --timeout=60 -r requirements.txt"
+  - "pip install ."
+
+  - "pip install nose"
+
+# Not a .NET project, we build networkx in the install step instead
+build: false
+
+test_script:
+  # Change to a non-source folder to make sure we run the tests on the
+  # installed library.
+  - "pushd %TEMP%"
+  - "nosetests --verbosity=2 dit"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose scipy numdifftools
+  - conda install cython nose scipy
   - pip install .
 
 test_script:

--- a/dit/math/_close.pyx
+++ b/dit/math/_close.pyx
@@ -5,11 +5,22 @@
 Low level implementation of scalar `allclose`.
 
 """
+import sys
 
-cdef extern from "math.h":
-    double fabs(double)
-    int isinf(double)
-    int isnan(double)
+if sys.platform in ('win32', 'cygwin'):
+    cdef extern from "float.h":
+        double fabs(double)
+        int _isnan(double)
+        int _isfinite(double)
+    def isnan(double x):
+        return _isnan(x)
+    def isinf(double x):
+        return not _isfinite(x)
+else:
+    cdef extern from "math.h":
+        double fabs(double)
+        int isinf(double)
+        int isnan(double)
 
 def close(double x, double y, double rtol, double atol):
     """Returns True if the scalars x and y are close.
@@ -37,4 +48,3 @@ def close(double x, double y, double rtol, double atol):
     else:
         # Otherwise, make sure they are close.
         return fabs(x-y) <= atol + rtol * fabs(y)
-

--- a/dit/math/_close.pyx
+++ b/dit/math/_close.pyx
@@ -7,20 +7,23 @@ Low level implementation of scalar `allclose`.
 """
 import sys
 
+cdef extern from "math.h":
+    double fabs(double)
+    int isinf(double)
+    int isnan(double)
+
+cdef extern from "float.h":
+    double fabs(double)
+    int _isnan(double)
+    int _isfinite(double)
+
+
 if sys.platform in ('win32', 'cygwin'):
-    cdef extern from "float.h":
-        double fabs(double)
-        int _isnan(double)
-        int _isfinite(double)
     def isnan(double x):
         return _isnan(x)
     def isinf(double x):
         return not _isfinite(x)
-else:
-    cdef extern from "math.h":
-        double fabs(double)
-        int isinf(double)
-        int isnan(double)
+
 
 def close(double x, double y, double rtol, double atol):
     """Returns True if the scalars x and y are close.

--- a/dit/math/_close.pyx
+++ b/dit/math/_close.pyx
@@ -22,7 +22,7 @@ if sys.platform in ('win32', 'cygwin'):
     def isnan(double x):
         return _isnan(x)
     def isinf(double x):
-        return not _finite(x)
+        return 1 - _finite(x)
 
 
 def close(double x, double y, double rtol, double atol):

--- a/dit/math/_close.pyx
+++ b/dit/math/_close.pyx
@@ -15,14 +15,14 @@ cdef extern from "math.h":
 cdef extern from "float.h":
     double fabs(double)
     int _isnan(double)
-    int _isfinite(double)
+    int _finite(double)
 
 
 if sys.platform in ('win32', 'cygwin'):
     def isnan(double x):
         return _isnan(x)
     def isinf(double x):
-        return not _isfinite(x)
+        return not _finite(x)
 
 
 def close(double x, double y, double rtol, double atol):

--- a/dit/profiles/tests/test_schneidman.py
+++ b/dit/profiles/tests/test_schneidman.py
@@ -5,6 +5,7 @@ Tests for dit.profiles.SchneidmanProfile. Known examples taken from http://arxiv
 from __future__ import division
 
 from nose.tools import assert_dict_equal
+from nose.plubins.attrib import attr
 from numpy.testing import assert_array_almost_equal
 
 from dit import Distribution
@@ -16,7 +17,7 @@ ex3 = Distribution(['000', '001', '110', '111'], [1/4]*4)
 ex4 = Distribution(['000', '011', '101', '110'], [1/4]*4)
 examples = [ex1, ex2, ex3, ex4]
 
-
+@attr('windows')
 def test_schneidman_profile():
     """
     Test against known examples.

--- a/dit/profiles/tests/test_schneidman.py
+++ b/dit/profiles/tests/test_schneidman.py
@@ -5,7 +5,7 @@ Tests for dit.profiles.SchneidmanProfile. Known examples taken from http://arxiv
 from __future__ import division
 
 from nose.tools import assert_dict_equal
-from nose.plubins.attrib import attr
+from nose.plugins.attrib import attr
 from numpy.testing import assert_array_almost_equal
 
 from dit import Distribution

--- a/dit/utils/tests/test_bindargs3.py
+++ b/dit/utils/tests/test_bindargs3.py
@@ -1,6 +1,6 @@
 from dit.utils.bindargs import bindcallargs
 
-from nose.tools import *
+from nose.tools import assert_equal, assert_raises
 
 def F1(a, b, c=2, *, d, e, f=5, **kwargs):
     pass

--- a/dit/utils/tests/test_context.py
+++ b/dit/utils/tests/test_context.py
@@ -4,25 +4,29 @@ Tests for dit.utils.context.
 
 from __future__ import unicode_literals
 
+import sys
+
 from nose.tools import assert_equal, assert_false, assert_true
 import os
 from dit.utils import cd, named_tempfile, tempdir
 
 import tempfile
 
+root = 'C:\\' if sys.platform in ('win32', 'cygwin') else '/'
+
 def test_cd():
-    with cd('/'):
-        assert_equal(os.getcwd(), '/')
+    with cd(root):
+        assert_equal(os.getcwd(), root)
 
 def test_cd_bad_oldcwd():
     # Test attempting to go back to a directory that no longer exists.
     name = tempfile.mkdtemp()
     with cd(name):
         assert_equal(os.getcwd(), os.path.realpath(name))
-        with cd('/'):
-            assert_equal(os.getcwd(), '/')
+        with cd(root):
+            assert_equal(os.getcwd(), root)
             os.rmdir(name)
-        assert_equal(os.getcwd(), '/')
+        assert_equal(os.getcwd(), root)
 
 def test_named_tempfile1():
     name = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@ cover-erase=1
 cover-package=dit
 # Skip any file that ends with 3.py. Such module names are assumed to
 # make use of Python 3 syntax and will cause a SyntaxError in 2.x.
-exclude=.*3\.py
+#exclude=.*3\.py
+ignore-files = (?:^\.|^_,|^setup\.py|^.*3\.py$)


### PR DESCRIPTION
With this branch, dit will build and run on windows.

a few issues though:
* cython on windows can't build pycounts, not sure why. in light of this, builds with cython are considered "known failures" and the main readme states to build with --nocython enabled.
* neither cvxopt nor numdifftools are available via conda on windows, so none of the maxent stuff works. tests that depend on these packages are marked with @attr('windows') now, and nose skips those on windows.

This should close #90 