### PR TITLE
Provide a generic function for building a constraint matrix.

### DIFF
--- a/dit/algorithms/maxentropy.py
+++ b/dit/algorithms/maxentropy.py
@@ -31,6 +31,7 @@ import dit
 
 from dit.abstractdist import AbstractDenseDistribution, get_abstract_dist
 
+from ..helpers import parse_rvs
 from .optutil import as_full_rank, CVXOPT_Template, prepare_dist, Bunch
 
 __all__ = [
@@ -79,6 +80,66 @@ def isolate_zeros(dist, k):
     variables = Bunch(nonzero=nonzero, zero=zero)
 
     return variables
+
+def marginal_constraints_generic(dist, rvs, rv_mode=None,
+                                 with_normalization=True):
+    """
+    Returns `A` and `b` in `A x = b`, for a system of marginal constraints.
+
+    In general, the resulting matrix `A` will not have full rank.
+
+    Parameters
+    ----------
+    dist : distribution
+        The distribution used to calculate the marginal constraints.
+
+    rvs : sequence
+        A sequence whose elements are also sequences.  Each inner sequence
+        specifies a marginal distribution as a set of random variable from
+        `dist`. The inner sequences need not be pairwise mutually exclusive
+        with one another. A random variable can only appear once within
+        each inner sequence, but it can occur in multiple inner sequences.
+
+    rv_mode : str, None
+        Specifies how to interpret the elements of `rvs`. Valid options
+        are: {'indices', 'names'}. If equal to 'indices', then the elements
+        of `rvs` are interpreted as random variable indices. If equal to
+        'names', the the elements are interpreted as random variable names.
+        If `None`, then the value of `dist._rv_mode` is consulted.
+
+    """
+    assert dist.is_dense()
+    assert dist.get_base() == 'linear'
+
+    parse = lambda rv: parse_rvs(dist, rv, rv_mode=rv_mode,
+                                 unique=True, sort=True)[1]
+    indexes = [parse(rv) for rv in rvs]
+
+    pmf = dist.pmf
+
+    d = get_abstract_dist(dist)
+
+    A = []
+    b = []
+
+    # Begin with the normalization constraint.
+    if with_normalization:
+        A.append(np.ones(d.n_elements))
+        b.append(1)
+
+    # Now add all the marginal constraints.
+    cache = {}
+    for rvec in indexes:
+        for idx in d.parameter_array(rvec, cache=cache):
+            bvec = np.zeros(d.n_elements)
+            bvec[idx] = 1
+            A.append(bvec)
+            b.append(pmf[idx].sum())
+
+    A = np.asarray(A, dtype=float)
+    b = np.asarray(b, dtype=float)
+
+    return A, b
 
 
 def marginal_constraints(dist, m, with_normalization=True):

--- a/dit/algorithms/tests/test_marginal_constraints.py
+++ b/dit/algorithms/tests/test_marginal_constraints.py
@@ -1,0 +1,38 @@
+from __future__ import division
+
+from nose.tools import *
+import numpy as np
+
+import dit
+from dit.algorithms.maxentropy import (
+    marginal_constraints_generic, marginal_constraints
+)
+
+
+def test_marginal_constraints():
+    d = dit.uniform_distribution(3, 2)
+    d.make_dense()
+
+    A, b = marginal_constraints(d, 2)
+
+    A_ = np.array([
+        [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
+        [ 1.,  1.,  0.,  0.,  0.,  0.,  0.,  0.],
+        [ 0.,  0.,  1.,  1.,  0.,  0.,  0.,  0.],
+        [ 0.,  0.,  0.,  0.,  1.,  1.,  0.,  0.],
+        [ 0.,  0.,  0.,  0.,  0.,  0.,  1.,  1.],
+        [ 1.,  0.,  1.,  0.,  0.,  0.,  0.,  0.],
+        [ 0.,  1.,  0.,  1.,  0.,  0.,  0.,  0.],
+        [ 0.,  0.,  0.,  0.,  1.,  0.,  1.,  0.],
+        [ 0.,  0.,  0.,  0.,  0.,  1.,  0.,  1.],
+        [ 1.,  0.,  0.,  0.,  1.,  0.,  0.,  0.],
+        [ 0.,  1.,  0.,  0.,  0.,  1.,  0.,  0.],
+        [ 0.,  0.,  1.,  0.,  0.,  0.,  1.,  0.],
+        [ 0.,  0.,  0.,  1.,  0.,  0.,  0.,  1.]
+    ])
+
+    b_ = np.array([1] + [0.25] * 12)
+
+    assert_true(np.allclose(A, A_))
+    assert_true(np.allclose(b, b_))
+


### PR DESCRIPTION
This provides `marginal_constraints_generic`.  Bad name, I know.

It takes a list of lists of random variables. So for example, `rvs=[[0,1],[0,2]]` would constrain P_opt(X, Y) = P(X, Y) and P_opt(X, Z) = P(X,Z).

I didn't hook it in to the existing API maxentropy, as the entire API there might need to be rethought.

Here's a quick verification that it does the right thing when you constrain the entire distribution:

```
In [1]: d = dit.random_distribution(3, 2)                                                                                                                    

In [2]: d.make_dense()
Out[2]: 0

In [3]: from dit.algorithms.maxentropy import marginal_constraints_generic

In [4]: marginal_constraints_generic(d, [[0,1,2]])
Out[4]: 
(array([[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
        [ 1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
        [ 0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.],
        [ 0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.],
        [ 0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
        [ 0.,  0.,  0.,  0.,  1.,  0.,  0.,  0.],
        [ 0.,  0.,  0.,  0.,  0.,  1.,  0.,  0.],
        [ 0.,  0.,  0.,  0.,  0.,  0.,  1.,  0.],
        [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  1.]]),
 array([  1.00000000e+00,   4.05662745e-01,   2.48969239e-02,
          2.38551597e-04,   1.38169223e-01,   4.22373191e-02,
          2.78055078e-01,   6.84307454e-02,   4.23094144e-02]))

In [5]: d.pmf
Out[5]: 
array([  4.05662745e-01,   2.48969239e-02,   2.38551597e-04,
         1.38169223e-01,   4.22373191e-02,   2.78055078e-01,
         6.84307454e-02,   4.23094144e-02])

```

Note that this matrix will be redundant.  `dit.algorithms.optutil.as_full_rank` is used in the maximum entropy framework to return an equivalent linear system that does have full rank.