### PR TITLE
Extropy partition

### DIFF
--- a/dit/algorithms/__init__.py
+++ b/dit/algorithms/__init__.py
@@ -4,7 +4,6 @@ distributions.
 """
 
 from .channelcapacity import channel_capacity
-from .information_partitions import ShannonPartition
 from .lattice import insert_join, insert_meet
 from .maxentropy import *
 from .maxentropyfw import *

--- a/dit/profiles/__init__.py
+++ b/dit/profiles/__init__.py
@@ -7,5 +7,6 @@ This module contains various information ``profiles'', decomposing the total inf
 
 from .complexity_profile import ComplexityProfile
 from .entropy_triangle import *
+from .information_partitions import *
 from .marginal_utility_of_information import MUIProfile
 from .schneidman import SchneidmanProfile

--- a/dit/profiles/complexity_profile.py
+++ b/dit/profiles/complexity_profile.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from ..algorithms import ShannonPartition
+from .information_partitions import ShannonPartition
 from .base_profile import BaseProfile, profile_docstring
 
 class ComplexityProfile(BaseProfile):

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -5,6 +5,8 @@ distribution.
 
 from __future__ import absolute_import
 
+from abc import ABCMeta, abstractmethod
+
 from itertools import islice
 from iterutils import powerset
 
@@ -12,10 +14,13 @@ from prettytable import PrettyTable
 
 from networkx import DiGraph, dfs_preorder_nodes as children, topological_sort
 
-from ..shannon import entropy as H
+import dit
+from ..shannon import entropy
+from ..other import extropy
 from ..math import close
 
 __all__ = ['ShannonPartition',
+           'ExtropyPartition',
           ]
 
 
@@ -36,9 +41,9 @@ def poset_lattice(elements):
     return lattice
 
 
-class ShannonPartition(object):
+class BaseInformationPartition(object):
     """
-    Construct an I-Diagram from a given joint distribution.
+    Construct an I-Diagram-like partition from a given joint distribution.
     """
 
     def __init__(self, dist):
@@ -55,7 +60,14 @@ class ShannonPartition(object):
         self._partition()
 
     @staticmethod
-    def _stringify(rvs, crvs):
+    @abstractmethod
+    def _symbol(rvs, crvs):
+        """
+        This method should return the information symbol for an atom.
+        """
+        pass
+
+    def _stringify(self, rvs, crvs):
         """
         Construct a string representation of a measure, e.g. I[X:Y|Z]
 
@@ -70,7 +82,7 @@ class ShannonPartition(object):
         crvs = [str(_) for _ in crvs]
         a = ':'.join(rvs)
         b = ','.join(crvs)
-        symbol = 'H' if len(rvs) == 1 else 'I'
+        symbol = self._symbol(rvs, crvs)
         sep = '|' if len(crvs) > 0 else ''
         s = "{0}[{1}{2}{3}]".format(symbol, a, sep, b)
         return s
@@ -97,7 +109,7 @@ class ShannonPartition(object):
 
         # Entropies
         for node in lattice:
-            Hs[node] = H(self.dist, node)
+            Hs[node] = self._measure(self.dist, node)
 
         # Subset-sum type thing, basically co-information calculations.
         for node in lattice:
@@ -132,6 +144,11 @@ class ShannonPartition(object):
 
         return sum(value for atom, value in self.atoms.items() if is_part(atom, *item))
 
+    def __repr__(self):
+        """
+        Represent using the str().
+        """
+        return str(self)
 
     def __str__(self):
         """
@@ -143,10 +160,10 @@ class ShannonPartition(object):
         """
         Use PrettyTable to create a nice table.
         """
-        table = PrettyTable(['measure', 'bits'])
+        table = PrettyTable(['measure', self.unit])
         ### TODO: add some logic for the format string, so things look nice
         # with arbitrary values
-        table.float_format['bits'] = ' 5.{0}'.format(digits)
+        table.float_format[self.unit] = ' 5.{0}'.format(digits)
         key_function = lambda row: (len(row[0][0]), row[0][0], row[0][1])
         items = self.atoms.items()
         for (rvs, crvs), value in sorted(items, key=key_function):
@@ -171,3 +188,37 @@ class ShannonPartition(object):
             f = lambda a, b: (a, b)
 
         return set([f(rvs, crvs) for rvs, crvs in self.atoms.keys()])
+
+
+class ShannonPartition(BaseInformationPartition):
+    """
+    Construct an I-Diagram from a given joint distribution.
+    """
+
+    _measure = staticmethod(entropy)
+    unit = 'bits'
+
+    @staticmethod
+    def _symbol(rvs, crvs):
+        """
+        Returns H for a conditional entropy, and I for all other atoms.
+        """
+        return 'H' if len(rvs) == 1 else 'I'
+
+
+class ExtropyPartition(BaseInformationPartition):
+    """
+    Construct an X-Diagram from a given joint distribution. One important
+    distinction regarding X-Diagrams vs I-Diagrams is that the atoms of an
+    X-Diagram are strictly positive.
+    """
+
+    _measure = staticmethod(extropy)
+    unit = 'exits'
+
+    @staticmethod
+    def _symbol(rvs, crvs):
+        """
+        Returns X for all atoms.
+        """
+        return 'X'

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -45,6 +45,7 @@ class BaseInformationPartition(object):
     """
     Construct an I-Diagram-like partition from a given joint distribution.
     """
+    __metaclass__ = ABCMeta
 
     def __init__(self, dist):
         """

--- a/dit/profiles/marginal_utility_of_information.py
+++ b/dit/profiles/marginal_utility_of_information.py
@@ -13,10 +13,10 @@ from iterutils import powerset
 import numpy as np
 from scipy.optimize import linprog
 
-from dit.algorithms import ShannonPartition
-from dit.math import close
-from dit.multivariate import entropy as H
-from dit.utils import flatten
+from .information_partitions import ShannonPartition
+from ..math import close
+from ..multivariate import entropy as H
+from ..utils import flatten
 
 __all__ = ['MUIProfile']
 

--- a/dit/profiles/tests/test_information_partitions.py
+++ b/dit/profiles/tests/test_information_partitions.py
@@ -8,7 +8,7 @@ from iterutils import powerset
 
 from dit.multivariate import coinformation as I
 from dit.utils import partitions
-from dit.algorithms.information_partitions import ShannonPartition
+from dit.profiles.information_partitions import *
 from dit.example_dists import n_mod_m
 
 def all_info_measures(vars):
@@ -67,3 +67,23 @@ def test_sp4():
 | I[0:1:2] | -1.000 |
 +----------+--------+"""
     assert_equal(str(ip), string)
+
+def test_ep1():
+    """
+    Test against known values.
+    """
+    d = n_mod_m(3, 2)
+    ep = ExtropyPartition(d)
+    string = """\
++----------+--------+
+| measure  | exits  |
++----------+--------+
+| X[0|1,2] |  0.000 |
+| X[1|0,2] |  0.000 |
+| X[2|0,1] |  0.000 |
+| X[0:1|2] |  0.245 |
+| X[0:2|1] |  0.245 |
+| X[1:2|0] |  0.245 |
+| X[0:1:2] |  0.510 |
++----------+--------+"""
+    assert_equal(str(ep), string)

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -19,25 +19,29 @@ There are several ways to decompose the information contained in a joint distrib
 
    In [5]: ex4 = dit.Distribution(['000', '011', '101', '110'], [1/4]*4)
 
+.. py:module:: dit.profiles.information_partitions
+
+:class:`ShannonPartition` and :class:`ExtropyPartition`
+=======================================================
+
 The I-diagrams for these four examples can be computed thusly:
 
 .. ipython::
+   :doctest:
 
-   @doctest
    In [6]: ShannonPartition(ex1)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
-   | H[0|1,2] |  1.000 |
-   | H[1|0,2] |  1.000 |
-   | H[2|0,1] |  1.000 |
-   | I[0:1|2] |  0.000 |
-   | I[0:2|1] |  0.000 |
-   | I[1:2|0] |  0.000 |
-   | I[0:1:2] |  0.000 |
+   | H[0|1,2] |  0.103 |
+   | H[1|0,2] |  0.103 |
+   | H[2|0,1] |  0.103 |
+   | I[0:1|2] |  0.142 |
+   | I[0:2|1] |  0.142 |
+   | I[1:2|0] |  0.142 |
+   | I[0:1:2] |  0.613 |
    +----------+--------+
 
-   @doctest
    In [7]: ShannonPartition(ex2)
    +----------+--------+
    | measure  |  bits  |
@@ -51,21 +55,19 @@ The I-diagrams for these four examples can be computed thusly:
    | I[0:1:2] |  1.000 |
    +----------+--------+
 
-   @doctest
    In [8]: ShannonPartition(ex3)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
    | H[0|1,2] |  0.000 |
    | H[1|0,2] |  0.000 |
-   | H[2|0,1] |  1.000 |
-   | I[0:1|2] |  1.000 |
+   | H[2|0,1] |  0.245 |
+   | I[0:1|2] |  0.245 |
    | I[0:2|1] |  0.000 |
    | I[1:2|0] |  0.000 |
-   | I[0:1:2] |  0.000 |
+   | I[0:1:2] |  0.755 |
    +----------+--------+
 
-   @doctest
    In [9]: ShannonPartition(ex4)
    +----------+--------+
    | measure  |  bits  |
@@ -73,16 +75,73 @@ The I-diagrams for these four examples can be computed thusly:
    | H[0|1,2] |  0.000 |
    | H[1|0,2] |  0.000 |
    | H[2|0,1] |  0.000 |
-   | I[0:1|2] |  1.000 |
-   | I[0:2|1] |  1.000 |
-   | I[1:2|0] |  1.000 |
-   | I[0:1:2] | -1.000 |
+   | I[0:1|2] |  0.245 |
+   | I[0:2|1] |  0.245 |
+   | I[1:2|0] |  0.245 |
+   | I[0:1:2] |  0.510 |
    +----------+--------+
 
-.. py:class:: dit.profiles.ComplexityProfile
+And their X-diagrams can be computed like so:
 
-Complexity Profile
-==================
+.. ipython::
+   :doctest:
+
+   In [10]: ExtropyPartition(ex1)
+   +----------+--------+
+   | measure  | exits  |
+   +----------+--------+
+   | X[0|1,2] |  1.000 |
+   | X[1|0,2] |  1.000 |
+   | X[2|0,1] |  1.000 |
+   | X[0:1|2] |  0.000 |
+   | X[0:2|1] |  0.000 |
+   | X[1:2|0] |  0.000 |
+   | X[0:1:2] |  0.000 |
+   +----------+--------+
+
+   In [11]: ExtropyPartition(ex2)
+   +----------+--------+
+   | measure  | exits  |
+   +----------+--------+
+   | X[0|1,2] |  0.000 |
+   | X[1|0,2] |  0.000 |
+   | X[2|0,1] |  0.000 |
+   | X[0:1|2] |  0.000 |
+   | X[0:2|1] |  0.000 |
+   | X[1:2|0] |  0.000 |
+   | X[0:1:2] |  1.000 |
+   +----------+--------+
+
+   In [12]: ExtropyPartition(ex3)
+   +----------+--------+
+   | measure  | exits  |
+   +----------+--------+
+   | X[0|1,2] |  0.000 |
+   | X[1|0,2] |  0.000 |
+   | X[2|0,1] |  1.000 |
+   | X[0:1|2] |  1.000 |
+   | X[0:2|1] |  0.000 |
+   | X[1:2|0] |  0.000 |
+   | X[0:1:2] |  0.000 |
+   +----------+--------+
+
+   In [13]: ExtropyPartition(ex4)
+   +----------+--------+
+   | measure  | exits  |
+   +----------+--------+
+   | X[0|1,2] |  0.000 |
+   | X[1|0,2] |  0.000 |
+   | X[2|0,1] |  0.000 |
+   | X[0:1|2] |  1.000 |
+   | X[0:2|1] |  1.000 |
+   | X[1:2|0] |  1.000 |
+   | X[0:1:2] | -1.000 |
+   +----------+--------+
+
+.. py:module:: dit.profiles.complexity_profile
+
+:class:`ComplexityProfile`
+==========================
 
 The complexity profile is simply the amount of information at scale :math:`\geq k` of each "layer" of the I-diagram :cite:`Baryam2004`.
 
@@ -91,33 +150,33 @@ Consider example 1, which contains three independent bits. Each of these bits ar
 .. ipython::
 
    @savefig complexity_profile_example_1.png width=500 align=center
-   In [10]: ComplexityProfile(ex1).draw();
+   In [14]: ComplexityProfile(ex1).draw();
 
 Whereas in example 2, all the information is in the center, and so each scale of the complexity profile picks up that one bit:
 
 .. ipython::
 
    @savefig complexity_profile_example_2.png width=500 align=center
-   In [11]: ComplexityProfile(ex2).draw();
+   In [15]: ComplexityProfile(ex2).draw();
 
 Both bits in example 3 are at a scale of at least 1, but only the shared bit persists to scale 2:
 
 .. ipython::
 
    @savefig complexity_profile_example_3.png width=500 align=center
-   In [12]: ComplexityProfile(ex3).draw();
+   In [16]: ComplexityProfile(ex3).draw();
 
 Finally, example 4 (where each variable is the ``exclusive or`` of the other two):
 
 .. ipython::
 
    @savefig complexity_profile_example_4.png width=500 align=center
-   In [13]: ComplexityProfile(ex4).draw();
+   In [17]: ComplexityProfile(ex4).draw();
 
-.. py:class:: dit.profiles.MUIProfile
+.. py:module:: dit.profiles.marginal_utility_of_information
 
-Marginal Utility of Information
-===============================
+:class:`MUIProfile`
+===================
 
 The marginal utility of information (MUI) :cite:`Allen2014` takes a different approach. It asks, given an amount of information :math:`\I[d : \{X\}] = y`, what is the maximum amount of information one can extract using an auxilliary variable :math:`d` as measured by the sum of the pairwise mutual informations, :math:`\sum \I[d : X_i]`. The MUI is then the rate of this maximum as a function of :math:`y`.
 
@@ -126,33 +185,33 @@ For the first example, each bit is independent and so basically must be extracte
 .. ipython::
 
    @savefig mui_profile_example_1.png width=500 align=center
-   In [14]: MUIProfile(ex1).draw();
+   In [18]: MUIProfile(ex1).draw();
 
 In the second example, there is only one bit total to be extracted, but it is shared by each pairwise mutual information. Therefore, for each increase in :math:`y` we get a threefold increase in the amount extracted:
 
 .. ipython::
 
    @savefig mui_profile_example_2.png width=500 align=center
-   In [15]: MUIProfile(ex2).draw();
+   In [19]: MUIProfile(ex2).draw();
 
 For the third example, for the first one bit of :math:`y` we can pull from the shared bit, but after that one must pull from the independent bit, so we see a step in the MUI profile:
 
 .. ipython::
 
    @savefig mui_profile_example_3.png width=500 align=center
-   In [16]: MUIProfile(ex3).draw();
+   In [20]: MUIProfile(ex3).draw();
 
 Lastly, the ``xor`` example:
 
 .. ipython::
 
    @savefig mui_profile_example_4.png width=500 align=center
-   In [17]: MUIProfile(ex4).draw();
+   In [21]: MUIProfile(ex4).draw();
 
-.. py:class:: dit.profiles.SchneidmanProfile
+.. py:module:: dit.profiles.schneidman
 
-Schneidman Profile
-==================
+:class:`SchneidmanProfile`
+==========================
 
 Also known as the *connected information* or *network informations*, the Schneidman profile exposes how much information is learned about the distribution when considering :math:`k`-way dependencies :cite:`Amari2001,Schneidman2003`. In all the following examples, each individual marginal is already uniformly distributed, and so the connected information at scale 1 is 0.
 
@@ -161,36 +220,36 @@ In the first example, all the random variables are independent already, so fixin
 .. ipython::
 
    @savefig schneidman_profile_example_1.png width=500 align=center
-   In [18]: SchneidmanProfile(ex1).draw();
+   In [22]: SchneidmanProfile(ex1).draw();
 
    @suppress
-   In [19]: plt.ylim((0, 1))
+   In [22]: plt.ylim((0, 1))
 
 In the second example, by learning the pairwise marginals, we reduce the entropy of the distribution by two bits (from three independent bits, to one giant bit):
 
 .. ipython::
 
    @savefig schneidman_profile_example_2.png width=500 align=center
-   In [20]: SchneidmanProfile(ex2).draw();
+   In [23]: SchneidmanProfile(ex2).draw();
 
 For the third example, learning pairwise marginals only reduces the entropy by one bit:
 
 .. ipython::
 
    @savefig schneidman_profile_example_3.png width=500 align=center
-   In [21]: SchneidmanProfile(ex3).draw();
+   In [24]: SchneidmanProfile(ex3).draw();
 
 And for the ``xor``, all bits appear independent until fixing the three-way marginals at which point one bit about the distribution is learned:
 
 .. ipython::
 
    @savefig schneidman_profile_example_4.png width=500 align=center
-   In [22]: SchneidmanProfile(ex4).draw();
+   In [25]: SchneidmanProfile(ex4).draw();
 
-.. py:class:: dit.profiles.EntropyTriangle
+.. py:module:: dit.profiles.entropy_triangle
 
-Entropy Triangle
-================
+:class:`EntropyTriangle` and :class:`EntropyTriangle2`
+======================================================
 
 The entropy triangle :cite:`valverde2016multivariate` is a method of visualizing how the information in the distribution is distributed among deviation from uniformity, independence, and dependence. The deviation from independence is measured by considering the difference in entropy between a independent variables with uniform distributions, and independent variables with the same marginal distributions as the distribution in question. Independence is measured via the :doc:`measures/multivariate/residual_entropy`, and dependence is measured by the sum of the :doc:`measures/multivariate/total_correlation` and :doc:`measures/multivariate/dual_total_correlation`.
 
@@ -201,46 +260,46 @@ In the first example, the distribution is all independence because the three var
 .. ipython::
 
    @savefig entropy_triangle_example_1.png width=500 align=center
-   In [23]: EntropyTriangle(ex1).draw();
+   In [26]: EntropyTriangle(ex1).draw();
 
 In the second example, the distribution is all dependence, because the three variables are perfectly entwined:
 
 .. ipython::
 
    @savefig entropy_triangle_example_2.png width=500 align=center
-   In [24]: EntropyTriangle(ex2).draw();
+   In [27]: EntropyTriangle(ex2).draw();
 
 Here, there is a mix of independence and dependence:
 
 .. ipython::
 
    @savefig entropy_triangle_example_3.png width=500 align=center
-   In [25]: EntropyTriangle(ex3).draw();
+   In [28]: EntropyTriangle(ex3).draw();
 
 And finally, in the case of ``xor``, the variables are completely dependent again:
 
 .. ipython::
 
    @savefig entropy_triangle_example_4.png width=500 align=center
-   In [26]: EntropyTriangle(ex4).draw();
+   In [29]: EntropyTriangle(ex4).draw();
 
 We can also plot all four on the same entropy triangle:
 
 .. ipython::
 
    @savefig entropy_triangle_all_examples.png width=500 align=center
-   In [27]: EntropyTriangle([ex1, ex2, ex3, ex4]).draw();
+   In [30]: EntropyTriangle([ex1, ex2, ex3, ex4]).draw();
 
 .. ipython::
 
-   In [28]: dists = [ dit.random_distribution(3, 2, alpha=(0.5,)*8) for _ in range(250) ]
+   In [31]: dists = [ dit.random_distribution(3, 2, alpha=(0.5,)*8) for _ in range(250) ]
 
    @savefig entropy_triangle_example.png width=500 align=center
-   In [29]: EntropyTriangle(dists).draw();
+   In [32]: EntropyTriangle(dists).draw();
 
 We can plot these same distributions on a slightly different entropy triangle as well, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/dual_total_correlation`:
 
 .. ipython::
 
    @savefig entropy_triangle2_example.png width=500 align=center
-   In [30]: EntropyTriangle2(dists).draw();
+   In [33]: EntropyTriangle2(dists).draw();

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -23,10 +23,8 @@ The I-diagrams for these four examples can be computed thusly:
 
 .. ipython::
 
-   In [6]: from dit.algorithms import ShannonPartition
-
    @doctest
-   In [7]: print(ShannonPartition(ex1))
+   In [6]: ShannonPartition(ex1)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
@@ -40,7 +38,7 @@ The I-diagrams for these four examples can be computed thusly:
    +----------+--------+
 
    @doctest
-   In [8]: print(ShannonPartition(ex2))
+   In [7]: ShannonPartition(ex2)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
@@ -54,7 +52,7 @@ The I-diagrams for these four examples can be computed thusly:
    +----------+--------+
 
    @doctest
-   In [9]: print(ShannonPartition(ex3))
+   In [8]: ShannonPartition(ex3)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
@@ -68,7 +66,7 @@ The I-diagrams for these four examples can be computed thusly:
    +----------+--------+
 
    @doctest
-   In [10]: print(ShannonPartition(ex4))
+   In [9]: ShannonPartition(ex4)
    +----------+--------+
    | measure  |  bits  |
    +----------+--------+
@@ -93,28 +91,28 @@ Consider example 1, which contains three independent bits. Each of these bits ar
 .. ipython::
 
    @savefig complexity_profile_example_1.png width=500 align=center
-   In [11]: ComplexityProfile(ex1).draw();
+   In [10]: ComplexityProfile(ex1).draw();
 
 Whereas in example 2, all the information is in the center, and so each scale of the complexity profile picks up that one bit:
 
 .. ipython::
 
    @savefig complexity_profile_example_2.png width=500 align=center
-   In [12]: ComplexityProfile(ex2).draw();
+   In [11]: ComplexityProfile(ex2).draw();
 
 Both bits in example 3 are at a scale of at least 1, but only the shared bit persists to scale 2:
 
 .. ipython::
 
    @savefig complexity_profile_example_3.png width=500 align=center
-   In [13]: ComplexityProfile(ex3).draw();
+   In [12]: ComplexityProfile(ex3).draw();
 
 Finally, example 4 (where each variable is the ``exclusive or`` of the other two):
 
 .. ipython::
 
    @savefig complexity_profile_example_4.png width=500 align=center
-   In [14]: ComplexityProfile(ex4).draw();
+   In [13]: ComplexityProfile(ex4).draw();
 
 .. py:class:: dit.profiles.MUIProfile
 
@@ -128,28 +126,28 @@ For the first example, each bit is independent and so basically must be extracte
 .. ipython::
 
    @savefig mui_profile_example_1.png width=500 align=center
-   In [15]: MUIProfile(ex1).draw();
+   In [14]: MUIProfile(ex1).draw();
 
 In the second example, there is only one bit total to be extracted, but it is shared by each pairwise mutual information. Therefore, for each increase in :math:`y` we get a threefold increase in the amount extracted:
 
 .. ipython::
 
    @savefig mui_profile_example_2.png width=500 align=center
-   In [16]: MUIProfile(ex2).draw();
+   In [15]: MUIProfile(ex2).draw();
 
 For the third example, for the first one bit of :math:`y` we can pull from the shared bit, but after that one must pull from the independent bit, so we see a step in the MUI profile:
 
 .. ipython::
 
    @savefig mui_profile_example_3.png width=500 align=center
-   In [17]: MUIProfile(ex3).draw();
+   In [16]: MUIProfile(ex3).draw();
 
 Lastly, the ``xor`` example:
 
 .. ipython::
 
    @savefig mui_profile_example_4.png width=500 align=center
-   In [18]: MUIProfile(ex4).draw();
+   In [17]: MUIProfile(ex4).draw();
 
 .. py:class:: dit.profiles.SchneidmanProfile
 
@@ -163,10 +161,10 @@ In the first example, all the random variables are independent already, so fixin
 .. ipython::
 
    @savefig schneidman_profile_example_1.png width=500 align=center
-   In [19]: SchneidmanProfile(ex1).draw();
+   In [18]: SchneidmanProfile(ex1).draw();
 
    @suppress
-   In [20]: plt.ylim((0, 1))
+   In [19]: plt.ylim((0, 1))
 
 In the second example, by learning the pairwise marginals, we reduce the entropy of the distribution by two bits (from three independent bits, to one giant bit):
 
@@ -240,7 +238,7 @@ We can also plot all four on the same entropy triangle:
    @savefig entropy_triangle_example.png width=500 align=center
    In [29]: EntropyTriangle(dists).draw();
 
-We can plot these same distributions on a slightly different entropy triangle as well, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/binding_information`:
+We can plot these same distributions on a slightly different entropy triangle as well, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/dual_total_correlation`:
 
 .. ipython::
 


### PR DESCRIPTION
This PR moves information partitions to the profiles module, adds the "ExtropyPartition", and improves the documentation.

The extropy partition is of interest because, unlike an i-diagram, all atoms are non-negative.