### PR TITLE
Switch all testing to pytest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,18 +115,14 @@ install:
 before_script:
   ### Use this to prepare your build for testing
   - if [[ "$TRAVIS_PYTHON_VERSION" =~ (2|3)\..* ]]; then
-      conda install -n test-environment nose;
       conda install scipy cvxopt;
+      pip install --upgrade -r requirements_testing.txt;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
-      pip install nose scipy cvxopt;
+      pip install scipy cvxopt;
+      pip install --upgrade -r requirements_testing.txt;
     elif [[ "$TRAVIS_PYTHON_VERSION" =~ pypy.* ]]; then
-      sudo $TRAVIS_PYTHON_VERSION -m pip install nose;
+      sudo $TRAVIS_PYTHON_VERSION -m pip install -r requirements_testing.txt;
     fi;
-  - if ! [[ "$TRAVIS_PYTHON_VERSION" =~ pypy.* ]]; then
-      pip install --upgrade coverage coveralls codecov;
-    else
-      sudo $TRAVIS_PYTHON_VERSION -m pip install --upgrade coverage coveralls codecov;
-    fi
 
 script:
   - printenv PWD
@@ -150,10 +146,10 @@ script:
   # package (except during the report).  So to restrict coverage, we must
   # inform coverage through the .coveragerc file.
   - if ! [[ "$TRAVIS_PYTHON_VERSION" =~ pypy.* ]]; then
-      cp .coveragerc $DIT_INSTALL;
+      cp .coveragerc pytest.ini $DIT_INSTALL;
       cp setup.cfg $DIT_INSTALL;
     else
-      sudo cp .coveragerc $DIT_INSTALL;
+      sudo cp .coveragerc pytest.ini $DIT_INSTALL;
       sudo cp setup.cfg $DIT_INSTALL;
     fi
 
@@ -166,18 +162,18 @@ script:
   - cd $DIT_INSTALL
   - printenv PWD
 
-  # Run nosetests.
+  # Run pytest.
   - if [[ "$TRAVIS_PYTHON_VERSION" =~ pypy.* ]]; then
       if [ "${OPTIONAL_DEPS}" == "true" ]; then
-        sudo $TRAVIS_PYTHON_VERSION -m nose --verbosity=2 -a '!scipy' -a '!cvxopt' --with-coverage --cover-package=dit;
+        sudo $TRAVIS_PYTHON_VERSION -m pytest;
       else
-        sudo $TRAVIS_PYTHON_VERSION -m nose --verbosity=2 -a '!scipy' -a '!cvxopt' -a '!cython' --with-coverage --cover-package=dit;
+        sudo $TRAVIS_PYTHON_VERSION -m pytest -m "not cython";
       fi
     else
       if [ "${OPTIONAL_DEPS}" == "true" ]; then
-        nosetests --verbosity=2 --with-coverage --cover-package=dit;
+        pytest;
       else
-        nosetests --verbosity=2 -a '!cython' --with-coverage --cover-package=dit;
+        pytest -m "not cython";
       fi
     fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,13 +40,16 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install nose scipy
+  - conda install scipy
   - ps: if ($env:CYTHON -eq '1') { conda install cython }
   - pip install .
-  - pip install nose-cov
+  - pip install --upgrade -r requirements_testing.txt
 
 test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
-  - "pushd %TEMP%"
-  - nosetests --verbosity=2 -a '!cvxopt' -a '!cython' --ignore-files="(?:^\.|^_,|^setup\.py|^.*3\.py$)" --with-coverage --cover-package=dit dit
+  # - "pushd %TEMP%"
+  - ps: if ($env:CYTHON -eq '1')
+          { pytest }
+        else
+          { pytest -m "not cython" }

--- a/dit/algorithms/tests/test_channelcapacity.py
+++ b/dit/algorithms/tests/test_channelcapacity.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
-from nose.tools import *
+import pytest
+
 import numpy as np
 
 import dit
@@ -29,14 +30,14 @@ def test_channel_capacity_no_rvnames():
     cc, pXopt = dit.algorithms.channel_capacity(pYgX, pX)
 
     # Verify channel capacity.
-    np.testing.assert_allclose(cc, 1 - epsilon)
+    assert np.allclose(cc, 1 - epsilon)
 
     # Verify maximizing distribution.
-    assert_true(pX.is_approx_equal(pXopt))
+    assert pX.is_approx_equal(pXopt)
 
     # Verify joint distribution at channel capacity.
     pXYopt = dit.joint_from_factors(pXopt, pYgX)
-    assert_true(pXY.is_approx_equal(pXYopt))
+    assert pXY.is_approx_equal(pXYopt)
 
 def test_channel_capacity_rvnames():
     epsilon = .01
@@ -46,14 +47,14 @@ def test_channel_capacity_rvnames():
     cc, pXopt = dit.algorithms.channel_capacity(pYgX, pX)
 
     # Verify channel capacity.
-    np.testing.assert_allclose(cc, 1 - epsilon)
+    assert np.allclose(cc, 1 - epsilon)
 
     # Verify maximizing distribution.
-    assert_true(pX.is_approx_equal(pXopt))
+    assert pX.is_approx_equal(pXopt)
 
     # Verify joint distribution at channel capacity.
     pXYopt = dit.joint_from_factors(pXopt, pYgX)
-    assert_true(pXY.is_approx_equal(pXYopt))
+    assert pXY.is_approx_equal(pXYopt)
 
 def test_channel_capacity_array():
     epsilon = .3
@@ -62,10 +63,10 @@ def test_channel_capacity_array():
     cc, pXopt_pmf = dit.algorithms.channel_capacity(pYgX)
 
     # Verify channel capacity.
-    np.testing.assert_allclose(cc, 1 - epsilon)
+    assert np.allclose(cc, 1 - epsilon)
 
     # Verify maximizing distribution.
-    np.testing.assert_allclose(pX.pmf, pXopt_pmf)
+    assert np.allclose(pX.pmf, pXopt_pmf)
 
 def test_bad_marginal():
     epsilon = .01
@@ -75,5 +76,5 @@ def test_bad_marginal():
     pX['0'] = 0
     # Now make its length disagree with the number of cdists.
     pX.make_sparse()
-    assert_raises(dit.exceptions.ditException,
-                  dit.algorithms.channel_capacity, pYgX, pX)
+    with pytest.raises(dit.exceptions.ditException):
+        dit.algorithms.channel_capacity(pYgX, pX)

--- a/dit/algorithms/tests/test_lattice.py
+++ b/dit/algorithms/tests/test_lattice.py
@@ -6,10 +6,9 @@ from __future__ import division
 
 from iterutils import powerset
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 import numpy as np
-import numpy.testing as npt
 
 from dit import Distribution, ScalarDistribution
 from dit.algorithms.lattice import (dist_from_induced_sigalg, insert_join,
@@ -25,7 +24,7 @@ def test_sigalg_sort():
         frozenset([1, 2])
     ])
     sigalg_ = [(), (1,), (2,), (1, 2)]
-    assert_equal(sigalg_, sigma_algebra_sort(sigalg))
+    assert sigalg_ == sigma_algebra_sort(sigalg)
 
 def test_join_sigalg():
     """ Test join_sigalg """
@@ -34,7 +33,7 @@ def test_join_sigalg():
     d = Distribution(outcomes, pmf)
     sigalg = frozenset([frozenset(_) for _ in powerset(outcomes)])
     joined = join_sigalg(d, [[0], [1]])
-    assert_equal(sigalg, joined)
+    assert sigalg == joined
 
 def test_meet_sigalg():
     """ Test meet_sigalg """
@@ -43,7 +42,7 @@ def test_meet_sigalg():
     d = Distribution(outcomes, pmf)
     sigalg = frozenset([frozenset([]), frozenset(outcomes)])
     meeted = meet_sigalg(d, [[0], [1]])
-    assert_equal(sigalg, meeted)
+    assert sigalg == meeted
 
 def test_dist_from_induced():
     """ Test dist_from_induced_sigalg """
@@ -53,17 +52,17 @@ def test_dist_from_induced():
 
     sigalg = frozenset(map(frozenset, d.event_space()))
     d2 = dist_from_induced_sigalg(d, sigalg)
-    npt.assert_allclose(pmf, d2.pmf)
+    assert np.allclose(pmf, d2.pmf)
 
     sigalg = [(), ((0,),), ((1,), (2,)), ((0,), (1,), (2,))]
     sigalg = frozenset(map(frozenset, sigalg))
     d2 = dist_from_induced_sigalg(d, sigalg, int_outcomes=True)
     pmf = np.array([1/3, 2/3])
-    npt.assert_allclose(pmf, d2.pmf)
+    assert np.allclose(pmf, d2.pmf)
 
     d2 = dist_from_induced_sigalg(d, sigalg, int_outcomes=False)
     outcomes = (((0,),), ((1,), (2,)))
-    assert_equal(outcomes, d2.outcomes)
+    assert outcomes == d2.outcomes
 
 def test_join():
     """ Test join """
@@ -71,8 +70,8 @@ def test_join():
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     d2 = join(d, [[0], [1]])
-    assert_equal(d2.outcomes, (0, 1, 2, 3))
-    npt.assert_allclose(d2.pmf, d.pmf)
+    assert d2.outcomes == (0, 1, 2, 3)
+    assert np.allclose(d2.pmf, d.pmf)
 
 def test_meet():
     """ Test meet """
@@ -80,17 +79,18 @@ def test_meet():
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     d2 = meet(d, [[0], [1]])
-    assert_equal(d2.outcomes, (0,))
-    npt.assert_allclose(d2.pmf, [1])
+    assert d2.outcomes == (0,)
+    assert np.allclose(d2.pmf, [1])
 
 def test_insert_join():
     """ Test insert_join """
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
-    assert_raises(IndexError, insert_join, d, 5, [[0], [1]])
+    with pytest.raises(IndexError):
+        insert_join(d, 5, [[0], [1]])
 
     for idx in range(d.outcome_length()):
         d2 = insert_join(d, idx, [[0], [1]])
         m = d2.marginal([idx])
-        npt.assert_allclose(d2.pmf, m.pmf)
+        assert np.allclose(d2.pmf, m.pmf)

--- a/dit/algorithms/tests/test_marginal_constraints.py
+++ b/dit/algorithms/tests/test_marginal_constraints.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-from nose.tools import *
 import numpy as np
 
 import dit
@@ -33,6 +32,5 @@ def test_marginal_constraints():
 
     b_ = np.array([1] + [0.25] * 12)
 
-    assert_true(np.allclose(A, A_))
-    assert_true(np.allclose(b, b_))
-
+    assert np.allclose(A, A_)
+    assert np.allclose(b, b_)

--- a/dit/algorithms/tests/test_minimal_sufficient_statistic.py
+++ b/dit/algorithms/tests/test_minimal_sufficient_statistic.py
@@ -4,8 +4,6 @@ Tests for dit.algorithms.minimal_sufficient_statistic.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_true
-
 from dit import Distribution, ScalarDistribution, pruned_samplespace
 from dit.algorithms import insert_mss, mss, mss_sigalg
 
@@ -24,9 +22,9 @@ def test_mss():
     d1 = mss(d, [0, 1], [2, 3])
     d2 = mss(d, [2, 3], [0, 1])
     dist = ScalarDistribution([0, 1], [1/3, 2/3])
-    assert_true(dist.is_approx_equal(d1))
-    assert_true(dist.is_approx_equal(d2))
-    assert_true(d1.is_approx_equal(d2))
+    assert dist.is_approx_equal(d1)
+    assert dist.is_approx_equal(d2)
+    assert d1.is_approx_equal(d2)
 
 def test_insert_mss():
     """
@@ -37,4 +35,4 @@ def test_insert_mss():
     d = insert_mss(d, -1, [2, 3], [0, 1])
     d = d.marginal([4, 5])
     dist = pruned_samplespace(Distribution(['01', '10', '11'], [1/3, 1/3, 1/3]))
-    assert_true(d.is_approx_equal(dist))
+    assert d.is_approx_equal(dist)

--- a/dit/algorithms/tests/test_prune_expand.py
+++ b/dit/algorithms/tests/test_prune_expand.py
@@ -1,7 +1,9 @@
 from __future__ import division
 
-from nose.tools import *
-import numpy.testing as npt
+import pytest
+
+import numpy as np
+
 import dit
 
 def test_pruned_samplespace_scalar():
@@ -11,8 +13,8 @@ def test_pruned_samplespace_scalar():
     d2 = dit.algorithms.pruned_samplespace(d)
     ss2_ = [0, 2]
     ss2 = list(d2.sample_space())
-    assert_equal(ss2, ss2_)
-    npt.assert_allclose(d2.pmf, [1/2, 1/2])
+    assert ss2 == ss2_
+    assert np.allclose(d2.pmf, [1/2, 1/2])
 
 def test_pruned_samplespace():
     """Prune a sample space from a Distribution."""
@@ -22,8 +24,8 @@ def test_pruned_samplespace():
     d2 = dit.algorithms.pruned_samplespace(d)
     ss2_ = ['0', '2']
     ss2 = list(d2.sample_space())
-    assert_equal(ss2, ss2_)
-    npt.assert_allclose(d2.pmf, [1/2, 1/2])
+    assert ss2 == ss2_
+    assert np.allclose(d2.pmf, [1/2, 1/2])
 
 def test_pruned_samplespace2():
     """Prune a sample space while specifying a desired sample space."""
@@ -35,28 +37,28 @@ def test_pruned_samplespace2():
     # We must make it dense, since the zero element will not appear in pmf.
     d2.make_dense()
     ss2 = list(d2.sample_space())
-    assert_equal(ss2, ss2_)
-    npt.assert_allclose(d2.pmf, [1/2, 0, 1/2])
+    assert ss2 == ss2_
+    assert np.allclose(d2.pmf, [1/2, 0, 1/2])
 
 def test_expanded_samplespace():
     """Expand a sample space from a Distribution."""
     outcomes = ['01', '10']
     pmf = [1/2, 1/2]
     d = dit.Distribution(outcomes, pmf, sample_space=outcomes)
-    assert_equal(list(d.sample_space()), ['01', '10'])
+    assert list(d.sample_space()) == ['01', '10']
     d2 = dit.algorithms.expanded_samplespace(d)
     ss = ['00', '01', '10', '11']
-    assert_equal(list(d2.sample_space()), ss)
+    assert list(d2.sample_space()) == ss
 
 def test_expanded_samplespace2():
     """Expand a sample space from a ScalarDistribution."""
     pmf = [1/2, 1/2]
     ss = [0, 1]
     d = dit.ScalarDistribution(pmf)
-    assert_equal(list(d.sample_space()), ss)
+    assert list(d.sample_space()) == ss
     ss2 = [0, 1, 2]
     d2 = dit.algorithms.expanded_samplespace(d, ss2)
-    assert_equal(list(d2.sample_space()), ss2)
+    assert list(d2.sample_space()) == ss2
 
 def test_expanded_samplespace3():
     """Expand a sample space without unioning the alphabets."""
@@ -65,7 +67,7 @@ def test_expanded_samplespace3():
     d = dit.Distribution(outcomes, pmf, sample_space=outcomes)
     d2 = dit.algorithms.expanded_samplespace(d, union=False)
     ss_ = ['00a', '01a', '10a', '11a']
-    assert_equal(list(d2.sample_space()), ss_)
+    assert list(d2.sample_space()) == ss_
 
 def test_expanded_samplespace_bad():
     """Expand a sample space with wrong number of alphabets."""
@@ -73,9 +75,10 @@ def test_expanded_samplespace_bad():
     pmf = [1/2, 1/2]
     d = dit.Distribution(outcomes, pmf)
     alphabets = ['01']
-    assert_equal(d.outcome_length(), 2)
+    assert d.outcome_length() == 2
     # This fails because we need to specify two alphabets, not one.
-    assert_raises(Exception, dit.algorithms.expanded_samplespace, d, alphabets)
+    with pytest.raises(Exception):
+        dit.algorithms.expanded_samplespace(d, alphabets)
 
 def test_expanded_samplespace_bad2():
     """Expand a sample space with wrong number of alphabets."""
@@ -83,7 +86,7 @@ def test_expanded_samplespace_bad2():
     pmf = [1/2, 1/2]
     d = dit.Distribution(outcomes, pmf)
     alphabets = '0'
-    assert_equal(d.outcome_length(), 1)
+    assert d.outcome_length() == 1
     # This fails because the sample space is too small, doesn't contain '1'.
-    e = dit.exceptions.InvalidOutcome
-    assert_raises(e, dit.algorithms.expanded_samplespace, d, alphabets)
+    with pytest.raises(dit.exceptions.InvalidOutcome):
+        dit.algorithms.expanded_samplespace(d, alphabets)

--- a/dit/algorithms/tests/test_stats.py
+++ b/dit/algorithms/tests/test_stats.py
@@ -4,8 +4,7 @@ Tests for dit.algorithms.stats
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises, assert_true
-from numpy.testing import assert_array_almost_equal
+import pytest
 
 from itertools import product
 
@@ -22,69 +21,64 @@ from dit.algorithms.stats import _numerical_test
 def test__numerical_test1():
     """ test _numerical_test on a good distribution """
     d = D([(0, 0), (1, 0), (2, 1), (3, 1)], [1/8, 1/8, 3/8, 3/8])
-    assert_true(_numerical_test(d) is None)
+    assert _numerical_test(d) is None
 
 def test__numerical_test2():
     """ Test _numerical_test on a bad distribution """
     # A bad distribution is one with a non-numerical alphabet
     d = D([(0, '0'), (1, '0'), (2, '1'), (3, '1')], [1/8, 1/8, 3/8, 3/8])
-    assert_raises(TypeError, _numerical_test, d)
+    with pytest.raises(TypeError):
+        _numerical_test(d)
 
-def test_mean1():
+@pytest.mark.parametrize("n", range(2, 10))
+@pytest.mark.parametrize("p", np.linspace(0, 1, 11))
+def test_mean1(n, p):
     """ Test mean on binomial distribution """
-    ns = range(2, 10)
-    ps = np.linspace(0, 1, 11)
-    for n, p in product(ns, ps):
-        d = binomial(n, p)
-        yield assert_almost_equal, mean(d), n*p
+    d = binomial(n, p)
+    assert mean(d) == pytest.approx(n*p)
 
 def test_mean2():
     """ Test mean on a generic distribution """
     d = D([(0, 0), (1, 0), (2, 1), (3, 1)], [1/8, 1/8, 3/8, 3/8])
-    assert_array_almost_equal(mean(d), [2, 3/4])
+    assert np.allclose(mean(d), [2, 3/4])
 
-def test_median1():
+@pytest.mark.parametrize("n", range(2, 10))
+@pytest.mark.parametrize("p", np.linspace(0, 1, 11))
+def test_median1(n, p):
     """ Test median on binomial distribution """
-    ns = range(2, 10)
-    ps = np.linspace(0, 1, 11)
-    for n, p in product(ns, ps):
-        d = binomial(n, p)
-        yield assert_true, median(d) in [floor(n*p), n*p, ceil(n*p)]
+    d = binomial(n, p)
+    assert median(d) in [floor(n*p), n*p, ceil(n*p)]
 
 def test_median2():
     """ Test median on a generic distribution """
     d = D([(0, 0), (1, 0), (2, 1), (3, 1)], [1/8, 1/8, 3/8, 3/8])
-    assert_array_almost_equal(median(d), [2, 1])
+    assert np.allclose(median(d), [2, 1])
 
-def test_mode1():
+@pytest.mark.parametrize("n", range(2, 10))
+@pytest.mark.parametrize("p", np.linspace(0, 1, 11))
+def test_mode1(n, p):
     """ Test mode on binomial distribution """
-    ns = range(2, 10)
-    ps = np.linspace(0, 1, 11)
-    for n, p in product(ns, ps):
-        d = binomial(n, p)
-        yield assert_true, mode(d)[0][0] in [floor((n+1)*p), floor((n+1)*p)-1]
+    d = binomial(n, p)
+    assert mode(d)[0][0] in [floor((n+1)*p), floor((n+1)*p)-1]
 
 def test_mode2():
     """ Test mode on a generic distribution """
     d = D([(0, 0), (1, 0), (2, 1), (3, 1)], [1/8, 1/8, 3/8, 3/8])
     modes = [np.array([2, 3]), np.array([1])]
     for m1, m2 in zip(mode(d), modes):
-        yield assert_array_almost_equal, m1, m2
+        assert np.allclose(m1, m2)
 
-def test_standard_deviation1():
+@pytest.mark.parametrize("n", range(2, 10))
+@pytest.mark.parametrize("p", np.linspace(0, 1, 11))
+def test_standard_deviation1(n, p):
     """ Test standard_deviation on binomial distribution """
-    ns = range(2, 10)
-    ps = np.linspace(0, 1, 11)
-    for n, p in product(ns, ps):
-        d = binomial(n, p)
-        yield assert_almost_equal, standard_deviation(d), np.sqrt(n*p*(1-p))
+    d = binomial(n, p)
+    assert standard_deviation(d) == pytest.approx(np.sqrt(n*p*(1-p)))
 
-
-def test_standard_moment1():
+@pytest.mark.parametrize("n", range(3, 10))
+@pytest.mark.parametrize("p", np.linspace(0.1, 0.9, 9))
+def test_standard_moment1(n, p):
     """ Test standard_moment on binomial distribution """
-    ns = range(3, 10)
-    ps = np.linspace(0.1, 0.9, 9)
-    for n, p in product(ns, ps):
-        d = binomial(n, p)
-        for i, m in {1: 0, 2: 1, 3: (1-2*p)/np.sqrt(n*p*(1-p))}.items():
-            yield assert_almost_equal, standard_moment(d, i), m, 5
+    d = binomial(n, p)
+    for i, m in {1: 0, 2: 1, 3: (1-2*p)/np.sqrt(n*p*(1-p))}.items():
+        assert standard_moment(d, i) == pytest.approx(m)

--- a/dit/divergences/tests/test_cross_entropy.py
+++ b/dit/divergences/tests/test_cross_entropy.py
@@ -4,7 +4,7 @@ Tests for dit.divergences.cross_entropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 import numpy as np
 
@@ -13,56 +13,56 @@ from dit.divergences import cross_entropy
 from dit.exceptions import ditException
 from dit.multivariate import entropy
 
-def get_dists():
-    """
-    Construct several example distributions.
-    """
-    d1 = Distribution(['0', '1'], [1/2, 1/2])
-    d2 = Distribution(['0', '2'], [1/2, 1/2])
-    d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
-    d4 = Distribution(['00', '11'], [2/5, 3/5])
-    d5 = Distribution(['00', '11'], [1/2, 1/2])
-    return d1, d2, d3, d4, d5
 
-def test_cross_entropy_1():
+d1 = Distribution(['0', '1'], [1/2, 1/2])
+d2 = Distribution(['0', '2'], [1/2, 1/2])
+d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
+d4 = Distribution(['00', '11'], [2/5, 3/5])
+d5 = Distribution(['00', '11'], [1/2, 1/2])
+
+
+@pytest.mark.parametrize(('args', 'expected'), [
+    ([d1, d3], 1.5849625007211563),
+    ([d1, d4], 1.0294468445267841),
+    ([d1, d3, [0]], 1.5849625007211563),
+    ([d1, d4, [0]], 1.0294468445267841),
+    ([d4, d1, [0]], 1),
+    ([d4, d5], 1),
+    ([d5, d4], 1.0294468445267841),
+    ([d4, d5, [0], [1]], 0),
+    ([d4, d5, [1], [0]], 0),
+    ([d1, d2], np.inf),
+    ([d2, d1], np.inf),
+    ([d3, d1], np.inf),
+])
+def test_cross_entropy_1(args, expected):
     """
     Test against several known values.
     """
-    d1, d2, d3, d4, d5 = get_dists()
-    tests = [([d1, d3], 1.5849625007211563),
-             ([d1, d4], 1.0294468445267841),
-             ([d1, d3, [0]], 1.5849625007211563),
-             ([d1, d4, [0]], 1.0294468445267841),
-             ([d4, d1, [0]], 1),
-             ([d4, d5], 1),
-             ([d5, d4], 1.0294468445267841),
-             ([d4, d5, [0], [1]], 0),
-             ([d4, d5, [1], [0]], 0),
-             ([d1, d2], np.inf),
-             ([d2, d1], np.inf),
-             ([d3, d1], np.inf)]
-    for args, val in tests:
-        yield assert_almost_equal, cross_entropy(*args), val
+    assert cross_entropy(*args) ==  pytest.approx(expected)
 
-def test_cross_entropy_2():
+
+@pytest.mark.parametrize('d', [d1, d2, d3, d4, d5])
+def test_cross_entropy_2(d):
     """
     Test that xH(d, d) = H(d).
     """
-    ds = get_dists()
-    for d in ds:
-        yield assert_almost_equal, cross_entropy(d, d), entropy(d)
+    assert cross_entropy(d, d) == pytest.approx(entropy(d))
 
-def test_cross_entropy_3():
+
+@pytest.mark.parametrize('args', [
+    [d4, d1, None, None],
+    [d4, d2, None, None],
+    [d4, d3, None, None],
+    [d1, d2, [0, 1], None],
+    [d3, d4, [1], None],
+    [d5, d1, [0], [1]],
+    [d4, d3, [1], [0]],
+])
+def test_cross_entropy_3(args):
     """
     Test that when p has outcomes that q doesn't have, that we raise an exception.
     """
-    d1, d2, d3, d4, d5 = get_dists()
-    tests = [[d4, d1, None, None],
-             [d4, d2, None, None],
-             [d4, d3, None, None],
-             [d1, d2, [0, 1], None],
-             [d3, d4, [1], None],
-             [d5, d1, [0], [1]],
-             [d4, d3, [1], [0]]]
-    for first, second, rvs, crvs in tests:
-        yield assert_raises, ditException, cross_entropy, first, second, rvs, crvs
+    first, second, rvs, crvs = args
+    with pytest.raises(ditException):
+        cross_entropy(first, second, rvs, crvs)

--- a/dit/divergences/tests/test_generalized_divergences.py
+++ b/dit/divergences/tests/test_generalized_divergences.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from itertools import combinations, product
 
-from nose.tools import assert_almost_equal, assert_not_equal, assert_raises, assert_greater
+import pytest
 
 import numpy as np
 
@@ -18,16 +18,12 @@ from dit.other import renyi_entropy, tsallis_entropy
 
 divergences = [alpha_divergence, renyi_divergence, tsallis_divergence, hellinger_divergence]
 
-def get_dists_1():
-    """
-    Construct several example distributions.
-    """
-    d1 = Distribution(['0', '1'], [1/2, 1/2])
-    d2 = Distribution(['0', '2'], [1/2, 1/2])
-    d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
-    d4 = Distribution(['00', '11'], [2/5, 3/5])
-    d5 = Distribution(['00', '11'], [1/2, 1/2])
-    return d1, d2, d3, d4, d5
+
+d1 = Distribution(['0', '1'], [1/2, 1/2])
+d2 = Distribution(['0', '2'], [1/2, 1/2])
+d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
+d4 = Distribution(['00', '11'], [2/5, 3/5])
+d5 = Distribution(['00', '11'], [1/2, 1/2])
 
 def get_dists_2():
     """
@@ -48,80 +44,78 @@ def get_dists_3():
     d4 = Distribution(['0', '1', '2'], [1/6, 2/6, 3/6])
     return d1, d2, d3, d4
 
-def test_positive_definite():
+@pytest.mark.parametrize('dist', [d1, d2, d3, d4, d5])
+@pytest.mark.parametrize('alpha', [0, 1, 2, 0.5])
+@pytest.mark.parametrize('divergence', divergences)
+def test_positive_definite(dist, alpha, divergence):
     """
     Tests that divergences are zero when the input distributions are the same, and that the Hellinger sum is equal to 1.
     """
-    alphas = [0, 1, 2, 0.5]
-    for dist in get_dists_1():
-        for alpha in alphas:
-            for divergence in divergences:
-                assert_almost_equal(divergence(dist, dist, alpha), 0)
-            assert_almost_equal(hellinger_sum(dist, dist, alpha), 1)
+    assert divergence(dist, dist, alpha) == pytest.approx(0)
+    assert hellinger_sum(dist, dist, alpha) == pytest.approx(1)
 
-def test_positivity():
+@pytest.mark.parametrize('alpha', [0.1, 0.5, 1, 1.5])
+@pytest.mark.parametrize('dists', [get_dists_2(), get_dists_3()])
+@pytest.mark.parametrize('divergence', divergences)
+def test_positivity(alpha, dists, divergence):
     """
     Tests that the divergence functions return positive values for non-equal arguments.
     """
-    alphas = [0.1, 0.5, 1, 1.5]
-    test_dists = [get_dists_2(), get_dists_3()]
-    for alpha in alphas:
-        for dists in test_dists:
-            for dist1, dist2 in combinations(dists, 2):
-                for divergence in divergences:
-                    assert_greater(divergence(dist1, dist2, alpha), 0)
+    for dist1, dist2 in combinations(dists, 2):
+        assert divergence(dist1, dist2, alpha) > 0
 
-def test_alpha_symmetry():
+
+@pytest.mark.parametrize('alpha', [-1, 0, 0.5, 1, 2])
+@pytest.mark.parametrize('dists', [get_dists_2(), get_dists_3()])
+def test_alpha_symmetry(alpha, dists):
     """
     Tests the alpha -> -alpha symmetry for the alpha divergence, and a similar
     symmetry for the Hellinger and Renyi divergences.
     """
-    alphas = [-1, 0, 0.5, 1, 2]
-    test_dists = [get_dists_2(), get_dists_3()]
-    for alpha in alphas:
-        for dists in test_dists:
-            for dist1, dist2 in product(dists, repeat=2):
-                assert_almost_equal(alpha_divergence(dist1, dist2, alpha), alpha_divergence(dist2, dist1, -alpha))
-                assert_almost_equal((1.-alpha)*hellinger_divergence(dist1, dist2, alpha), alpha*hellinger_divergence(dist2, dist1, 1.-alpha))
-                assert_almost_equal((1.-alpha)*renyi_divergence(dist1, dist2, alpha), alpha*renyi_divergence(dist2, dist1, 1.-alpha))
+    for dist1, dist2 in product(dists, repeat=2):
+        assert alpha_divergence(dist1, dist2, alpha) == pytest.approx(alpha_divergence(dist2, dist1, -alpha))
+        assert (1.-alpha)*hellinger_divergence(dist1, dist2, alpha) == pytest.approx(alpha*hellinger_divergence(dist2, dist1, 1.-alpha))
+        assert (1.-alpha)*renyi_divergence(dist1, dist2, alpha) == pytest.approx(alpha*renyi_divergence(dist2, dist1, 1.-alpha))
 
-def test_divergences_to_kl():
+
+@pytest.mark.parametrize('dists', [get_dists_2(), get_dists_3()])
+def test_divergences_to_kl(dists):
     """
     Tests that the generalized divergences properly fall back to KL for the appropriate values of alpha, and not otherwise.
     """
-    test_dists = [get_dists_2(), get_dists_3()]
-    for dists in test_dists:
-        for dist1, dist2 in product(dists, repeat=2):
-            assert_almost_equal(alpha_divergence(dist1, dist2, alpha=-1), kullback_leibler_divergence(dist2, dist1))
+    for dist1, dist2 in combinations(dists, 2):
+        assert alpha_divergence(dist1, dist2, alpha=-1) == pytest.approx(kullback_leibler_divergence(dist2, dist1))
 
-            if dist1 is not dist2:
-                assert_not_equal(alpha_divergence(dist1, dist2, alpha=0), kullback_leibler_divergence(dist2, dist1))
+        assert alpha_divergence(dist1, dist2, alpha=0) != pytest.approx(kullback_leibler_divergence(dist2, dist1))
+        assert alpha_divergence(dist1, dist2, alpha=2) != pytest.approx(kullback_leibler_divergence(dist2, dist1))
 
-            for divergence in divergences:
+@pytest.mark.parametrize('dists', [get_dists_2(), get_dists_3()])
+@pytest.mark.parametrize('divergence', divergences)
+def test_divergences_to_kl2(dists, divergence):
+    """
+    Tests that the generalized divergences properly fall back to KL for the appropriate values of alpha.
+    """
+    for dist1, dist2 in combinations(dists, 2):
+        assert divergence(dist1, dist2, alpha=1) == pytest.approx(kullback_leibler_divergence(dist1, dist2))
 
-                assert_almost_equal(divergence(dist1, dist2, alpha=1), kullback_leibler_divergence(dist1, dist2))
-
-                if dist1 is not dist2:
-                    assert_not_equal(alpha_divergence(dist1, dist2, alpha=0), kullback_leibler_divergence(dist2, dist1))
-                    assert_not_equal(alpha_divergence(dist1, dist2, alpha=2), kullback_leibler_divergence(dist2, dist1))
-
-def test_exceptions():
+@pytest.mark.parametrize('args', [
+    [d4, d1, None, None],
+    [d4, d2, None, None],
+    [d4, d3, None, None],
+    [d1, d2, [0, 1], None],
+    [d3, d4, [1], None],
+    [d5, d1, [0], [1]],
+    [d4, d3, [1], [0]]
+])
+@pytest.mark.parametrize('divergence', divergences)
+@pytest.mark.parametrize('alpha', [0, 1, 2, 0.5])
+def test_exceptions(args, divergence, alpha):
     """
     Test that when p has outcomes that q doesn't have, that we raise an exception.
     """
-    d1, d2, d3, d4, d5 = get_dists_1()
-    tests = [[d4, d1, None, None],
-             [d4, d2, None, None],
-             [d4, d3, None, None],
-             [d1, d2, [0, 1], None],
-             [d3, d4, [1], None],
-             [d5, d1, [0], [1]],
-             [d4, d3, [1], [0]]]
-    alphas = [0, 1, 2, 0.5]
-    for first, second, rvs, crvs in tests:
-        for divergence in divergences:
-            for alpha in alphas:
-                yield assert_raises, ditException, divergence, first, second, alpha, rvs, crvs
+    first, second, rvs, crvs = args
+    with pytest.raises(ditException):
+        divergence(first, second, alpha, rvs, crvs)
 
 def test_renyi_values():
     """
@@ -131,24 +125,24 @@ def test_renyi_values():
     d2 = Distribution(['0', '1'], [1/2, 1/2])
     d3 = Distribution(['0', '1'], [1, 0])
 
-    assert_almost_equal(renyi_divergence(d1, d2, 1/2), np.log2(2))
-    assert_almost_equal(renyi_divergence(d2, d3, 1/2), np.log2(2))
-    assert_almost_equal(renyi_divergence(d1, d3, 1/2), np.inf)
+    assert renyi_divergence(d1, d2, 1/2) == pytest.approx(np.log2(2))
+    assert renyi_divergence(d2, d3, 1/2) == pytest.approx(np.log2(2))
+    assert renyi_divergence(d1, d3, 1/2) == pytest.approx(np.inf)
 
-def test_renyi():
+@pytest.mark.parametrize('alpha', [0, 1, 2, 0.5])
+def test_renyi(alpha):
     """
     Consistency test for Renyi entropy and Renyi divergence
     """
     dist1 = Distribution(['0', '1', '2'], [1/4, 1/2, 1/4])
     uniform = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
-    alphas = [0, 1, 2, 0.5]
-    for alpha in alphas:
-        h = renyi_entropy(dist1, alpha)
-        h_u = renyi_entropy(uniform, alpha)
-        div = renyi_divergence(dist1, uniform, alpha)
-        assert_almost_equal(h, h_u - div)
+    h = renyi_entropy(dist1, alpha)
+    h_u = renyi_entropy(uniform, alpha)
+    div = renyi_divergence(dist1, uniform, alpha)
+    assert h == pytest.approx(h_u - div)
 
-def test_f_divergence(places=1):
+@pytest.mark.parametrize('alpha', [0.1, 0.5, 1.1])
+def test_f_divergence(alpha, places=1):
     """
     Tests various known relations of f-divergences to other divergences.
     """
@@ -169,13 +163,13 @@ def test_f_divergence(places=1):
             return (np.power(x, 1. - alpha) - 1.) / (alpha - 1.)
         return f
     test_functions = []
-    alphas = [0.1, 0.5, 1.1]
-    for alpha in alphas:
-        test_functions.append((f_alpha(alpha), partial(alpha_divergence, alpha=alpha)))
-        test_functions.append((f_tsallis(alpha), partial(tsallis_divergence, alpha=alpha)))
+    test_functions.append((f_alpha(alpha), partial(alpha_divergence, alpha=alpha)))
+    test_functions.append((f_tsallis(alpha), partial(tsallis_divergence, alpha=alpha)))
+
     dists = get_dists_3()
+
     for dist1, dist2 in combinations(dists, 2):
         for f, div_func in test_functions:
             div1 = f_divergence(dist1, dist2, f)
             div2 = div_func(dist1, dist2)
-            assert_almost_equal(div1, div2, places=1)
+            assert div1 == pytest.approx(div2, abs=1e-1)

--- a/dit/divergences/tests/test_jensen_shannon_divergence.py
+++ b/dit/divergences/tests/test_jensen_shannon_divergence.py
@@ -1,8 +1,7 @@
 """
 Tests for dit.divergences.jensen_shannon_divergence.
 """
-
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 from dit import Distribution
 from dit.exceptions import ditException
@@ -14,70 +13,73 @@ from dit.divergences.jensen_shannon_divergence import (
 def test_jsd0():
     """ Test the JSD of a distribution but with weights misspecified."""
     d1 = Distribution("AB", [0.5, 0.5])
-    assert_raises(ditException, JSD, d1, d1)
+    with pytest.raises(ditException):
+        JSD(d1, d1)
 
 def test_jsd1():
     """ Test the JSD of a distribution with itself """
     d1 = Distribution("AB", [0.5, 0.5])
     jsd = JSD([d1, d1])
-    assert_almost_equal(jsd, 0)
+    assert jsd == pytest.approx(0)
 
 def test_jsd2():
     """ Test the JSD with half-overlapping distributions """
     d1 = Distribution("AB", [0.5, 0.5])
     d2 = Distribution("BC", [0.5, 0.5])
     jsd = JSD([d1, d2])
-    assert_almost_equal(jsd, 0.5)
+    assert jsd == pytest.approx(0.5)
 
 def test_jsd3():
     """ Test the JSD with disjoint distributions """
     d1 = Distribution("AB", [0.5, 0.5])
     d2 = Distribution("CD", [0.5, 0.5])
     jsd = JSD([d1, d2])
-    assert_almost_equal(jsd, 1.0)
+    assert jsd == pytest.approx(1.0)
 
 def test_jsd4():
     """ Test the JSD with half-overlapping distributions with weights """
     d1 = Distribution("AB", [0.5, 0.5])
     d2 = Distribution("BC", [0.5, 0.5])
     jsd = JSD([d1, d2], [0.25, 0.75])
-    assert_almost_equal(jsd, 0.40563906222956625)
+    assert jsd == pytest.approx(0.40563906222956625)
 
 def test_jsd5():
     """ Test that JSD fails when more weights than dists are given """
     d1 = Distribution("AB", [0.5, 0.5])
     d2 = Distribution("BC", [0.5, 0.5])
-    assert_raises(ditException, JSD, [d1, d2], [0.1, 0.6, 0.3])
+    with pytest.raises(ditException):
+        JSD([d1, d2], [0.1, 0.6, 0.3])
 
 def test_jsd_pmf1():
     """ Test the JSD of a distribution with itself """
     d1 = [0.5, 0.5]
     jsd = JSD_pmf([d1, d1])
-    assert_almost_equal(jsd, 0)
+    assert jsd == pytest.approx(0)
 
 def test_jsd_pmf2():
     """ Test the JSD with half-overlapping distributions """
     d1 = [0.5, 0.5, 0.0]
     d2 = [0.0, 0.5, 0.5]
     jsd = JSD_pmf([d1, d2])
-    assert_almost_equal(jsd, 0.5)
+    assert jsd == pytest.approx(0.5)
 
 def test_jsd_pmf3():
     """ Test the JSD with disjoint distributions """
     d1 = [0.5, 0.5, 0.0, 0.0]
     d2 = [0.0, 0.0, 0.5, 0.5]
     jsd = JSD_pmf([d1, d2])
-    assert_almost_equal(jsd, 1.0)
+    assert jsd == pytest.approx(1.0)
 
 def test_jsd_pmf4():
     """ Test the JSD with half-overlapping distributions with weights """
     d1 = [0.5, 0.5, 0.0]
     d2 = [0.0, 0.5, 0.5]
     jsd = JSD_pmf([d1, d2], [0.25, 0.75])
-    assert_almost_equal(jsd, 0.40563906222956625)
+    assert jsd == pytest.approx(0.40563906222956625)
 
 def test_jsd_pmf5():
     """ Test that JSD fails when more weights than dists are given """
     d1 = [0.5, 0.5, 0.0]
     d2 = [0.0, 0.5, 0.5]
-    assert_raises(ditException, JSD_pmf, [d1, d2], [0.1, 0.6, 0.2, 0.1])
+    with pytest.raises(ditException):
+        JSD_pmf([d1, d2], [0.1, 0.6, 0.2, 0.1])

--- a/dit/divergences/tests/test_kullback_leibler_divergence.py
+++ b/dit/divergences/tests/test_kullback_leibler_divergence.py
@@ -4,7 +4,7 @@ Tests for dit.divergences.kullback_leibler_divergence.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 import numpy as np
 
@@ -12,56 +12,53 @@ from dit import Distribution
 from dit.divergences import kullback_leibler_divergence
 from dit.exceptions import ditException
 
-def get_dists():
-    """
-    Construct several example distributions.
-    """
-    d1 = Distribution(['0', '1'], [1/2, 1/2])
-    d2 = Distribution(['0', '2'], [1/2, 1/2])
-    d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
-    d4 = Distribution(['00', '11'], [2/5, 3/5])
-    d5 = Distribution(['00', '11'], [1/2, 1/2])
-    return d1, d2, d3, d4, d5
 
-def test_dkl_1():
+d1 = Distribution(['0', '1'], [1/2, 1/2])
+d2 = Distribution(['0', '2'], [1/2, 1/2])
+d3 = Distribution(['0', '1', '2'], [1/3, 1/3, 1/3])
+d4 = Distribution(['00', '11'], [2/5, 3/5])
+d5 = Distribution(['00', '11'], [1/2, 1/2])
+
+@pytest.mark.parametrize(('args', 'expected'), [
+    ([d1, d3], 0.5849625007211563),
+    ([d1, d4], 0.0294468445267841),
+    ([d1, d3, [0]], 0.5849625007211563),
+    ([d1, d4, [0]], 0.0294468445267841),
+    ([d4, d1, [0]], 0.029049405545331419),
+    ([d4, d5], 0.029049405545331419),
+    ([d5, d4], 0.0294468445267841),
+    ([d4, d5, [0], [1]], 0),
+    ([d4, d5, [1], [0]], 0),
+    ([d1, d2], np.inf),
+    ([d2, d1], np.inf),
+    ([d3, d1], np.inf),
+])
+def test_dkl_1(args, expected):
     """
     Test against several known values.
     """
-    d1, d2, d3, d4, d5 = get_dists()
-    tests = [([d1, d3], 0.5849625007211563),
-             ([d1, d4], 0.0294468445267841),
-             ([d1, d3, [0]], 0.5849625007211563),
-             ([d1, d4, [0]], 0.0294468445267841),
-             ([d4, d1, [0]], 0.029049405545331419),
-             ([d4, d5], 0.029049405545331419),
-             ([d5, d4], 0.0294468445267841),
-             ([d4, d5, [0], [1]], 0),
-             ([d4, d5, [1], [0]], 0),
-             ([d1, d2], np.inf),
-             ([d2, d1], np.inf),
-             ([d3, d1], np.inf)]
-    for args, val in tests:
-        yield assert_almost_equal, kullback_leibler_divergence(*args), val
+    assert kullback_leibler_divergence(*args) == pytest.approx(expected)
 
-def test_dkl_2():
+@pytest.mark.parametrize('d', [d1, d2, d3, d4, d5])
+def test_dkl_2(d):
     """
     Test that DKL(d, d) = 0.
     """
-    ds = get_dists()
-    for d in ds:
-        yield assert_almost_equal, kullback_leibler_divergence(d, d), 0
+    assert kullback_leibler_divergence(d, d) == pytest.approx(0)
 
-def test_dkl_3():
+@pytest.mark.parametrize('args', [
+    [d4, d1, None, None],
+    [d4, d2, None, None],
+    [d4, d3, None, None],
+    [d1, d2, [0, 1], None],
+    [d3, d4, [1], None],
+    [d5, d1, [0], [1]],
+    [d4, d3, [1], [0]]
+])
+def test_dkl_3(args):
     """
     Test that when p has outcomes that q doesn't have, that we raise an exception.
     """
-    d1, d2, d3, d4, d5 = get_dists()
-    tests = [[d4, d1, None, None],
-             [d4, d2, None, None],
-             [d4, d3, None, None],
-             [d1, d2, [0, 1], None],
-             [d3, d4, [1], None],
-             [d5, d1, [0], [1]],
-             [d4, d3, [1], [0]]]
-    for first, second, rvs, crvs in tests:
-        yield assert_raises, ditException, kullback_leibler_divergence, first, second, rvs, crvs
+    first, second, rvs, crvs = args
+    with pytest.raises(ditException):
+        kullback_leibler_divergence(first, second, rvs, crvs)

--- a/dit/divergences/tests/test_nonmerge.py
+++ b/dit/divergences/tests/test_nonmerge.py
@@ -1,10 +1,9 @@
 """
 Tests for dit.divergences._kl_nonmerge.
 """
-
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit.divergences import pmf
 
@@ -13,17 +12,17 @@ ds = [ [1/2, 1/2], [3/5, 2/5]]
 def test_cross_entropy():
     ce1 = pmf.cross_entropy(ds[0], ds[1])
     ce2 = pmf.cross_entropy(ds[1], ds[0])
-    assert_almost_equal(ce1, 1.0294468445267841)
-    assert_almost_equal(ce2, 1.0)
+    assert ce1 == pytest.approx(1.0294468445267841)
+    assert ce2 == pytest.approx(1.0)
 
 def test_entropy():
     e1 = pmf.cross_entropy(ds[0])
     e2 = pmf.cross_entropy(ds[1])
-    assert_almost_equal(e1, 1.0)
-    assert_almost_equal(e2, 0.97095059445466858)
+    assert e1 == pytest.approx(1.0)
+    assert e2 == pytest.approx(0.97095059445466858)
 
 def test_dkl():
     dkl1 = pmf.relative_entropy(ds[0], ds[1])
     dkl2 = pmf.relative_entropy(ds[1], ds[0])
-    assert_almost_equal(dkl1, 0.029446844526784144)
-    assert_almost_equal(dkl2, 0.029049405545331419)
+    assert dkl1 == pytest.approx(0.029446844526784144)
+    assert dkl2 == pytest.approx(0.029049405545331419)

--- a/dit/example_dists/tests/test_circuits.py
+++ b/dit/example_dists/tests/test_circuits.py
@@ -1,8 +1,7 @@
 """
 Tests for dit.example_dists.circuits.
 """
-
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit.example_dists import (Unq, Rdn, Xor, RdnXor, ImperfectRdn, Subtle, And,
                                Or)
@@ -19,10 +18,10 @@ def test_unq():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 1)
-    assert_almost_equal(i2, 1)
-    assert_almost_equal(i12, 2)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(1)
+    assert i2 == pytest.approx(1)
+    assert i12 == pytest.approx(2)
+    assert r == pytest.approx(0)
 
 def test_rdn():
     """ Test the Rdn distribution """
@@ -33,10 +32,10 @@ def test_rdn():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 1)
-    assert_almost_equal(i2, 1)
-    assert_almost_equal(i12, 1)
-    assert_almost_equal(r, 1)
+    assert i1 == pytest.approx(1)
+    assert i2 == pytest.approx(1)
+    assert i12 == pytest.approx(1)
+    assert r == pytest.approx(1)
 
 def test_xor():
     """ Test the Xor distribution """
@@ -47,10 +46,10 @@ def test_xor():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 0)
-    assert_almost_equal(i2, 0)
-    assert_almost_equal(i12, 1)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(0)
+    assert i2 == pytest.approx(0)
+    assert i12 == pytest.approx(1)
+    assert r == pytest.approx(0)
 
 def test_and():
     """ Test the And distribution """
@@ -61,10 +60,10 @@ def test_and():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 0.31127812445913294)
-    assert_almost_equal(i2, 0.31127812445913294)
-    assert_almost_equal(i12, 0.81127812445913294)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(0.31127812445913294)
+    assert i2 == pytest.approx(0.31127812445913294)
+    assert i12 == pytest.approx(0.81127812445913294)
+    assert r == pytest.approx(0)
 
 def test_or():
     """ Test the Or distribution """
@@ -75,10 +74,10 @@ def test_or():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 0.31127812445913294)
-    assert_almost_equal(i2, 0.31127812445913294)
-    assert_almost_equal(i12, 0.81127812445913294)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(0.31127812445913294)
+    assert i2 == pytest.approx(0.31127812445913294)
+    assert i12 == pytest.approx(0.81127812445913294)
+    assert r == pytest.approx(0)
 
 def test_rdnxor():
     """ Test the RdnXor distribution """
@@ -89,10 +88,10 @@ def test_rdnxor():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 1)
-    assert_almost_equal(i2, 1)
-    assert_almost_equal(i12, 2)
-    assert_almost_equal(r, 1)
+    assert i1 == pytest.approx(1)
+    assert i2 == pytest.approx(1)
+    assert i12 == pytest.approx(2)
+    assert r == pytest.approx(1)
 
 def test_imperfectrdn():
     """ Test the ImperfectRdn distribution """
@@ -103,10 +102,10 @@ def test_imperfectrdn():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 1)
-    assert_almost_equal(i2, 0.98959007894024409)
-    assert_almost_equal(i12, 1)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(1)
+    assert i2 == pytest.approx(0.98959007894024409)
+    assert i12 == pytest.approx(1)
+    assert r == pytest.approx(0)
 
 def test_subtle():
     """ Test the Subtle distribution """
@@ -117,7 +116,7 @@ def test_subtle():
     i2 = mutual_information(d, [1], [2])
     i12 = mutual_information(d, [0, 1], [2])
     r = mutual_information(d, [2], [3])
-    assert_almost_equal(i1, 0.91829583405448956)
-    assert_almost_equal(i2, 0.91829583405448956)
-    assert_almost_equal(i12, 1.5849625007211561)
-    assert_almost_equal(r, 0)
+    assert i1 == pytest.approx(0.91829583405448956)
+    assert i2 == pytest.approx(0.91829583405448956)
+    assert i12 == pytest.approx(1.5849625007211561)
+    assert r == pytest.approx(0)

--- a/dit/example_dists/tests/test_n_mod_m.py
+++ b/dit/example_dists/tests/test_n_mod_m.py
@@ -3,8 +3,7 @@ Tests for dit.example_dists.n_mod_m.
 """
 
 from __future__ import division
-
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 from numpy import log2
 
@@ -13,28 +12,32 @@ from dit.example_dists import n_mod_m
 
 def test_n_mod_m1():
     """ Test that n < 1 fails """
-    assert_raises(ValueError, n_mod_m, -1, 1)
+    with pytest.raises(ValueError):
+        n_mod_m(-1, 1)
 
 def test_n_mod_m2():
     """ Test that m < 1 fails """
-    assert_raises(ValueError, n_mod_m, 1, -1)
+    with pytest.raises(ValueError):
+        n_mod_m(1, -1)
 
 def test_n_mod_m3():
     """ Test that noninteger n failes """
-    assert_raises(ValueError, n_mod_m, 3/2, 1)
+    with pytest.raises(ValueError):
+        n_mod_m(3/2, 1)
 
 def test_n_mod_m4():
     """ Test that noninteger m fails """
-    assert_raises(ValueError, n_mod_m, 1, 3/2)
+    with pytest.raises(ValueError):
+        n_mod_m(1, 3/2)
 
-def test_n_mod_m5():
+@pytest.mark.parametrize('n', range(3, 6))
+def test_n_mod_m5(n):
     """ Test that the interaction information is always 1 """
-    for n in range(3, 6):
-        d = n_mod_m(n, 2)
-        yield assert_almost_equal, II(d), 1.0
+    d = n_mod_m(n, 2)
+    assert II(d) == pytest.approx(1.0)
 
-def test_n_mod_m6():
+@pytest.mark.parametrize('m', range(2, 5))
+def test_n_mod_m6(m):
     """ Test that II is the log of m """
-    for m in range(2, 5):
-        d = n_mod_m(3, m)
-        yield assert_almost_equal, II(d), log2(m)
+    d = n_mod_m(3, m)
+    assert II(d) == pytest.approx(log2(m))

--- a/dit/example_dists/tests/test_numeric.py
+++ b/dit/example_dists/tests/test_numeric.py
@@ -4,7 +4,7 @@ Tests for dit.example_dists.numeric.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_equal, assert_raises
+import pytest
 
 import numpy as np
 
@@ -14,76 +14,86 @@ from dit.example_dists import bernoulli, binomial, hypergeometric, uniform
 def test_bernoulli1():
     """ Test bernoulli distribution """
     d = bernoulli(1/2)
-    assert_equal(d.outcomes, (0, 1))
-    assert_almost_equal(sum(d.pmf), 1)
+    assert d.outcomes == (0, 1)
+    assert sum(d.pmf) == pytest.approx(1)
 
-def test_bernoulli2():
+@pytest.mark.parametrize('p', [i/10 for i in range(0, 11)])
+def test_bernoulli2(p):
     """ Test bernoulli distribution """
-    for p in [i/10 for i in range(0, 11)]:
-        d = bernoulli(p)
-        assert_almost_equal(d[0], 1-p)
-        assert_almost_equal(d[1], p)
+    d = bernoulli(p)
+    assert d[0] == pytest.approx(1-p)
+    assert d[1] == pytest.approx(p)
 
-def test_bernoulli3():
+@pytest.mark.parametrize('p', [-1, 1.5, 'a', int, []])
+def test_bernoulli3(p):
     """ Test bernoulli distribution failures """
-    for p in [-1, 1.5, 'a', int, []]:
-        assert_raises(ValueError, bernoulli, p)
+    with pytest.raises(ValueError):
+        bernoulli(p)
 
-def test_binomial1():
+@pytest.mark.parametrize('n', range(1, 10))
+def test_binomial1(n):
     """ Test binomial distribution """
-    for n in range(1, 10):
-        d = binomial(n, 1/2)
-        assert_equal(d.outcomes, tuple(range(n+1)))
-        assert_almost_equal(sum(d.pmf), 1)
+    d = binomial(n, 1/2)
+    assert d.outcomes == tuple(range(n+1))
+    assert sum(d.pmf) == pytest.approx(1)
 
-def test_binomial2():
+@pytest.mark.parametrize('n', [-1, 1.5, 'a', int, []])
+def test_binomial2(n):
     """ Test binomial distribution failures """
-    for n in [-1, 1.5, 'a', int, []]:
-        assert_raises(ValueError, binomial, n, 1/2)
+    with pytest.raises(ValueError):
+        binomial(n, 1/2)
 
 def test_uniform1():
     """ Test uniform distribution """
     for n in range(2, 10):
         d = uniform(n)
-        assert_equal(d.outcomes, tuple(range(n)))
-        assert_almost_equal(d[0], 1/n)
-        assert_almost_equal(entropy(d), np.log2(n))
+        assert d.outcomes == tuple(range(n))
+        assert d[0] == pytest.approx(1/n)
+        assert entropy(d) == pytest.approx(np.log2(n))
 
-def test_uniform2():
+@pytest.mark.parametrize('v', [-1, 1.5, 'a', int, []])
+def test_uniform2(v):
     """ Test uniform distribution failures """
-    for v in [-1, 1.5, 'a', int, []]:
-        assert_raises(ValueError, uniform, v)
+    with pytest.raises(ValueError):
+        uniform(v)
 
-def test_uniform3():
+@pytest.mark.parametrize(('a', 'b'), zip([1, 2, 3, 4, 5], [5, 7, 9, 11, 13]))
+def test_uniform3(a, b):
     """ Test uniform distribution construction """
-    _as = [1, 2, 3, 4, 5]
-    _bs = [5, 7, 9, 11, 13]
-    for a, b in zip(_as, _bs):
-        d = uniform(a, b)
-        assert_equal(len(d.outcomes), b-a)
-        assert_almost_equal(d[a], 1/(b-a))
+    d = uniform(a, b)
+    assert len(d.outcomes) == b-a
+    assert d[a] == pytest.approx(1/(b-a))
 
-def test_uniform4():
+@pytest.mark.parametrize(('a', 'b'), [(2, 0), (0, [])])
+def test_uniform4(a, b):
     """ Test uniform distribution failures """
-    assert_raises(ValueError, uniform, 2, 0)
-
-def test_uniform5():
-    """ Test uniform distribution failures """
-    assert_raises(ValueError, uniform, 0, [])
+    with pytest.raises(ValueError):
+        uniform(a, b)
 
 def test_hypergeometric1():
     """ Test hypergeometric distribution """
     d = hypergeometric(50, 5, 10)
-    assert_almost_equal(d[4], 0.003964583)
-    assert_almost_equal(d[5], 0.0001189375)
+    assert d[4] == pytest.approx(0.003964583)
+    assert d[5] == pytest.approx(0.0001189375)
 
-def test_hypergeometric2():
+@pytest.mark.parametrize('vals', [
+    (50, 5, -1),
+    (50, -1, 10),
+    (-1, 5, 10),
+    (50, 5, 1.5),
+    (50, 1.5, 10),
+    (1.5, 5, 10),
+    (50, 5, 'a'),
+    (50, 'a', 10),
+    ('a', 5, 10),
+    (50, 5, int),
+    (50, int, 10),
+    (int, 5, 10),
+    (50, 5, []),
+    (50, [], 10),
+    ([], 5, 10),
+])
+def test_hypergeometric2(vals):
     """ Test hypergeometric distribution failures """
-    vals = [(50, 5, -1), (50, -1, 10), (-1, 5, 10),
-            (50, 5, 1.5), (50, 1.5, 10), (1.5, 5, 10),
-            (50, 5, 'a'), (50, 'a', 10), ('a', 5, 10),
-            (50, 5, int), (50, int, 10), (int, 5, 10),
-            (50, 5, []), (50, [], 10), ([], 5, 10),
-            ]
-    for val in vals:
-        assert_raises(ValueError, hypergeometric, *val)
+    with pytest.raises(ValueError):
+        hypergeometric(*vals)

--- a/dit/inference/tests/test_pycounts.py
+++ b/dit/inference/tests/test_pycounts.py
@@ -4,12 +4,11 @@ Tests for dit.inference.pycounts
 
 from __future__ import division
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_true
+import pytest
 
 from dit import Distribution
 
-@attr('cython')
+@pytest.mark.cython
 def test_dfd():
     """
     Test distribution_from_data.
@@ -20,5 +19,5 @@ def test_dfd():
     d2 = Distribution([(0,0), (0,1), (1,1)], [2/5, 1/5, 2/5])
     d1_ = distribution_from_data(data, 1, base='linear')
     d2_ = distribution_from_data(data, 2, base='linear')
-    assert_true(d1.is_approx_equal(d1_))
-    assert_true(d2.is_approx_equal(d2_))
+    assert d1.is_approx_equal(d1_)
+    assert d2.is_approx_equal(d2_)

--- a/dit/math/tests/test_aitchison.py
+++ b/dit/math/tests/test_aitchison.py
@@ -1,16 +1,9 @@
 
 from __future__ import division
 
-from nose.tools import (
-    assert_almost_equal,
-    assert_equal,
-    assert_true,
-    assert_raises
-)
+import pytest
 
 import numpy as np
-
-from numpy import allclose
 
 import dit
 from dit.exceptions import ditException
@@ -23,34 +16,28 @@ from dit.math.aitchison import (alr, alr_inv, basis, closure, clr, clr_inv,
                                 dist, ilr, ilr_inv, inner, norm, perturbation,
                                 power, subcomposition, _gm, _log2_gm)
 
-def assert_almost_equal_array(x, y):
-    for i, j in zip(x.ravel(), y.ravel()):
-        assert_almost_equal(i, j)
-
-def assert_equal_shape(x, y):
-    assert_equal(x.shape, y.shape)
 
 def test_closure():
     # 1D
     x = np.array([1.0, 1.0])
     y = np.array([0.5, 0.5])
     cl_x = closure(x)
-    assert_equal_shape(x, cl_x)
-    assert_almost_equal_array(cl_x, y)
+    assert x.shape == cl_x.shape
+    assert np.allclose(cl_x, y)
 
     # 2D with multiple rows
     x = np.array([[1.0, 1.0], [1.0, 2.0]])
     y = np.array([[0.5, 0.5], [1/3.0, 2/3.0]])
     cl_x = closure(x)
-    assert_equal_shape(x, cl_x)
-    assert_almost_equal_array(cl_x, y)
+    assert x.shape == cl_x.shape
+    assert np.allclose(cl_x, y)
 
     # 2D with one row
     x = np.array([[1.0, 1.0]])
     y = np.array([[0.5, 0.5]])
     cl_x = closure(x)
-    assert_equal_shape(x, cl_x)
-    assert_almost_equal_array(cl_x, y)
+    assert x.shape == cl_x.shape
+    assert np.allclose(cl_x, y)
 
 def test_closure_invariance():
     x = np.array([1, 2, 3, 4]) / 10
@@ -60,9 +47,9 @@ def test_closure_invariance():
     ycl = closure(y)
     zcl = closure(z)
 
-    assert_almost_equal_array(xcl, ycl)
-    assert_almost_equal_array(ycl, zcl)
-    assert_almost_equal_array(zcl, xcl)
+    assert np.allclose(xcl, ycl)
+    assert np.allclose(ycl, zcl)
+    assert np.allclose(zcl, xcl)
 
 def test_closure_unnormalizable():
     """
@@ -70,7 +57,8 @@ def test_closure_unnormalizable():
 
     """
     x = np.zeros(3)
-    assert_raises(ditException, closure, x)
+    with pytest.raises(ditException):
+        closure(x)
 
 def test_perturbation():
     # 1D
@@ -78,24 +66,24 @@ def test_perturbation():
     y = np.array([3/4.0, 1/4.0])
     pxy_ = np.array([3/5.0, 2/5.0])
     pxy = perturbation(x, y)
-    assert_true(x.shape == pxy.shape)
-    assert_true(allclose(pxy_, pxy))
+    assert x.shape == pxy.shape
+    assert np.allclose(pxy_, pxy)
 
     # 2D with multiple rows
     x = np.array([[1/3.0, 2/3.0], [3/4.0, 1/4.0]])
     y = np.array([[3/4.0, 1/4.0], [1/6.0, 5/6.0]])
     pxy_ = np.array([[3/5.0, 2/5.0], [3/8.0, 5/8.0]])
     pxy = perturbation(x, y)
-    assert_true(x.shape == pxy.shape)
-    assert_true(allclose(pxy_, pxy))
+    assert x.shape == pxy.shape
+    assert np.allclose(pxy_, pxy)
 
     # 2D with one row
     x = np.array([[1/3.0, 2/3.0]])
     y = np.array([[3/4.0, 1/4.0]])
     pxy_ = np.array([[3/5.0, 2/5.0]])
     pxy = perturbation(x, y)
-    assert_true(x.shape == pxy.shape)
-    assert_true(allclose(pxy_, pxy))
+    assert x.shape == pxy.shape
+    assert np.allclose(pxy_, pxy)
 
 def test_power():
     # 1D
@@ -103,30 +91,30 @@ def test_power():
     y = 3
     px_ = np.array([1/9.0, 8/9.0])
     px = power(x, y)
-    assert_true(px_.shape == px.shape)
-    assert_true(allclose(px_, px))
+    assert px_.shape == px.shape
+    assert np.allclose(px_, px)
     x = np.array([1/4.0, 3/4.0])
     y = 3
     px_ = np.array([1/28.0, 27/28.0])
     px = power(x, y)
-    assert_true(px_.shape == px.shape)
-    assert_true(allclose(px_, px))
+    assert px_.shape == px.shape
+    assert np.allclose(px_, px)
 
     # 2D with multiple rows
     x = np.array([[1/3.0, 2/3.0], [1/4.0, 3/4.0]])
     y = [3, 3]
     px_ = np.array([[1/9.0, 8/9.0], [1/28.0, 27/28.0]])
     px = power(x, y)
-    assert_true(px_.shape == px.shape)
-    assert_true(allclose(px_, px))
+    assert px_.shape == px.shape
+    assert np.allclose(px_, px)
 
     # 2D with one row
     x = np.array([[1/3.0, 2/3.0]])
     y = [3]
     px_ = np.array([[1/9.0, 8/9.0]])
     px = power(x, y)
-    assert_true(px_.shape == px.shape)
-    assert_true(allclose(px_, px))
+    assert px_.shape == px.shape
+    assert np.allclose(px_, px)
 
 def test_inner():
     # 1D
@@ -137,27 +125,27 @@ def test_inner():
     xy_ = 0.79248125036057804
     xy = inner(x, y)
     yx = inner(y, x)
-    assert_almost_equal(xy_, xy)
-    assert_almost_equal(xy_, yx)
+    assert xy_ == pytest.approx(xy)
+    assert xy_ == pytest.approx(yx)
 
     yz_ = 0.46357181398555231
     yz = inner(y, z)
     zy = inner(z, y)
-    assert_almost_equal(yz_, yz)
-    assert_almost_equal(yz_, zy)
+    assert yz_ == pytest.approx(yz)
+    assert yz_ == pytest.approx(zy)
 
     xz_ = 0.29248125036057804
     xz = inner(x, z)
     zx = inner(z, x)
-    assert_almost_equal(xz_, xz)
-    assert_almost_equal(xz_, zx)
+    assert xz_ == pytest.approx(xz)
+    assert xz_ == pytest.approx(zx)
 
     # 2D with multiple rows
     xx = np.array([x, y, z])
     yy = np.array([y, z, x])
     xxyy = inner(xx, yy)
     xxyy_ = np.array([xy_, yz_, xz_])
-    assert_true(allclose(xxyy_, xxyy))
+    assert np.allclose(xxyy_, xxyy)
 
     # 2D with multiple rows in x and single row in y
     yy_ = 1.2560530643461303
@@ -165,16 +153,16 @@ def test_inner():
     yy = np.array([y])
     xxyy = inner(xx, yy)
     xxyy_ = np.array([xy_, yy_, yz_])
-    assert_true(allclose(xxyy_, xxyy))
+    assert np.allclose(xxyy_, xxyy)
     yyxx = inner(yy, xx)
-    assert_true(allclose(xxyy_, yyxx))
+    assert np.allclose(xxyy_, yyxx)
 
     # 2D with single rows
     x2d = np.atleast_2d(x)
     y2d = np.atleast_2d(y)
     xy2d = inner(x2d, y2d)
     xy2d_ = np.array([xy_])
-    assert_true(allclose(xy2d_, xy2d))
+    assert np.allclose(xy2d_, xy2d)
 
 def test_clr():
     x = np.array([1/3.0, 2/3.0])
@@ -186,15 +174,15 @@ def test_clr():
     # 1D
     x1d_clr = clr(x)
     x1d_clr_ = np.array(x_clr)
-    assert_equal(x1d_clr.shape, x1d_clr_.shape)
-    assert_true(allclose(x1d_clr, x1d_clr_))
+    assert x1d_clr.shape == x1d_clr_.shape
+    assert np.allclose(x1d_clr, x1d_clr_)
 
     # 2D
     xy = np.array([x, y])
     xy_clr = clr(xy)
     xy_clr_ = np.array([x_clr, y_clr])
-    assert_equal(xy_clr.shape, xy_clr_.shape)
-    assert_true(allclose(xy_clr, xy_clr_))
+    assert xy_clr.shape == xy_clr_.shape
+    assert np.allclose(xy_clr, xy_clr_)
 
 def test_alr():
     x = np.array([1/3.0, 2/3.0])
@@ -206,15 +194,15 @@ def test_alr():
     # 1D
     x1d_alr = alr(x)
     x1d_alr_ = np.array(x_alr)
-    assert_equal(x1d_alr.shape, x1d_alr_.shape)
-    assert_true(allclose(x1d_alr, x1d_alr_))
+    assert x1d_alr.shape == x1d_alr_.shape
+    assert np.allclose(x1d_alr, x1d_alr_)
 
     # 2D
     xy = np.array([x, y])
     xy_alr = alr(xy)
     xy_alr_ = np.array([x_alr, y_alr])
-    assert_equal(xy_alr.shape, xy_alr_.shape)
-    assert_true(allclose(xy_alr, xy_alr_))
+    assert xy_alr.shape == xy_alr_.shape
+    assert np.allclose(xy_alr, xy_alr_)
 
 def test_ilr():
     # 1D
@@ -226,9 +214,9 @@ def test_ilr():
     ilrx_ = coeff * lg
     ilrx = ilr(x)
 
-    assert_equal(ilrx.shape, ilrx_.shape)
+    assert ilrx.shape == ilrx_.shape
     for i, j in zip(ilrx, ilrx_):
-        assert_almost_equal(i, j)
+        assert i == pytest.approx(j)
 
     # 2D with multiple rows
     x = np.array([1, 2, 3, 4])
@@ -239,25 +227,25 @@ def test_ilr():
     ilrxy_ = np.array([ilrx_, ilry_])
     ilrxy = ilr(xy)
 
-    assert_equal(ilrxy.shape, ilrxy_.shape)
+    assert ilrxy.shape == ilrxy_.shape
     for i, j in zip(ilrxy.ravel(), ilrxy_.ravel()):
-        assert_almost_equal(i, j)
+        assert i == pytest.approx(j)
 
     # 2D with single rows
     xy = np.array([x])
     ilrxy_ = np.array([ilrx_])
     ilrxy = ilr(xy)
 
-    assert_equal(ilrxy.shape, ilrxy_.shape)
+    assert ilrxy.shape == ilrxy_.shape
     for i, j in zip(ilrxy.ravel(), ilrxy_.ravel()):
-        assert_almost_equal(i, j)
+        assert i == pytest.approx(j)
 
 def test_equiv_inner1():
     x = np.array([1, 2, 3, 4])
     y = np.array([3, 5, 1, 1])
     aitchison_inner = inner(x, y)
     euclidean_inner = np.inner(ilr(x), ilr(y))
-    assert_almost_equal(aitchison_inner, euclidean_inner)
+    assert aitchison_inner == pytest.approx(euclidean_inner)
 
 def test_equiv_inner2():
     x = np.array([1, 2, 3, 4])
@@ -270,20 +258,20 @@ def test_equiv_inner2():
 
     z1 = inner(x, y)
     z2 = 1/D * np.dot(np.dot(clrx, M), clry[:, np.newaxis])
-    assert_almost_equal(z1, z2)
+    assert z1 == pytest.approx(z2)
 
 def test_equiv_norm():
     x = np.array([1, 2, 3, 4])
     aitchison_norm = norm(x)
     euclidean_norm = np.linalg.norm(ilr(x))
-    assert_almost_equal(aitchison_norm, euclidean_norm)
+    assert aitchison_norm == pytest.approx(euclidean_norm)
 
 def test_equiv_dist():
     x = np.array([1, 2, 3, 4])
     y = np.array([3, 5, 1, 1])
     aitchison_dist = dist(x, y)
     euclidean_dist = np.linalg.norm(ilr(x)-ilr(y))
-    assert_almost_equal(aitchison_dist, euclidean_dist)
+    assert aitchison_dist == pytest.approx(euclidean_dist)
 
 def test_clr_prop():
     x1 = np.array([1, 2, 3, 4])
@@ -293,7 +281,7 @@ def test_clr_prop():
     z1 = clr(perturbation(power(x1, a1), power(x2, a2)))
     z2 = a1 * clr(x1) + a2 * clr(x2)
 
-    assert_almost_equal_array(z1, z2)
+    assert np.allclose(z1, z2)
 
 def test_basis():
     b = np.array([[1/1.,   -1,    0,    0,  0],
@@ -303,57 +291,57 @@ def test_basis():
     b *= np.sqrt([i/(i+1) for i in range(1, 5)])[:, np.newaxis]
     b = closure(exp2(b))
     b_ = basis(4)
-    assert_equal_shape(b, b_)
-    assert_almost_equal_array(b, b_)
+    assert b.shape == b_.shape
+    assert np.allclose(b, b_)
 
 def test_basis2():
     # test orthonormality in Aitchison inner product
     b = basis(4)
     for i in range(len(b)):
         ii = inner(b[i], b[i])
-        assert_almost_equal(ii, 1.0)
+        assert ii == pytest.approx(1.0)
         for j in range(i+1, len(b)):
             ij = inner(b[i], b[j])
-            assert_almost_equal(ij, 0.0)
+            assert ij == pytest.approx(0.0)
 
 def test_clr_inv():
     x = np.array([1, 2, 3, 4]) / 10
     x_clr = clr(x)
     y = clr_inv(x_clr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
     x = np.array([[1, 2, 3, 4], [2, 2, 2, 4]]) / 10
     x_clr = clr(x)
     y = clr_inv(x_clr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
 def test_alr_inv():
     x = np.array([1, 2, 3, 4]) / 10
     x_alr = alr(x)
     y = alr_inv(x_alr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
     x = np.array([[1, 2, 3, 4], [2, 2, 2, 4]]) / 10
     x_alr = alr(x)
     y = alr_inv(x_alr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
 def test_ilr_inv():
     x = np.array([1, 2, 3, 4]) / 10
     x_ilr = ilr(x)
     y = ilr_inv(x_ilr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
     x = np.array([[1, 2, 3, 4], [2, 2, 2, 4]]) / 10
     x_ilr = ilr(x)
     y = ilr_inv(x_ilr)
-    assert_equal_shape(x, y)
-    assert_almost_equal_array(x, y)
+    assert x.shape == y.shape
+    assert np.allclose(x, y)
 
 def test_subcomposition():
     """
@@ -362,7 +350,7 @@ def test_subcomposition():
     """
     x = np.array([1, 2, 3, 4]) / 10
     y = np.array([1, 2, 3]) / 6
-    np.testing.assert_allclose(subcomposition(x, [0, 1, 2]), y)
+    assert np.allclose(subcomposition(x, [0, 1, 2]), y)
 
 def test_gm():
     """
@@ -372,7 +360,7 @@ def test_gm():
     x = np.array([1, 2, 3, 4])
     gm = _gm(x)
     loggm = _log2_gm(x)
-    np.testing.assert_allclose(np.log2(gm), loggm)
+    assert np.allclose(np.log2(gm), loggm)
 
 def test_ilr_inv_underflow():
     """
@@ -392,4 +380,4 @@ def test_ilr_inv_underflow():
     pmf_ = dit.math.pmfops.replace_zeros(d.pmf, tol, prng=prng)
     ilrpmf = dit.math.aitchison.ilr(pmf_)
     pmf = dit.math.aitchison.ilr_inv(ilrpmf)
-    np.testing.assert_allclose(pmf, pmf_)
+    assert np.allclose(pmf, pmf_)

--- a/dit/math/tests/test_combinatorics.py
+++ b/dit/math/tests/test_combinatorics.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-from nose.tools import assert_equal, assert_true, assert_raises
+import pytest
 
 import numpy as np
 
@@ -12,7 +12,7 @@ from dit.math.combinatorics import unitsum_tuples, slots
 def test_unitsum_tuples1():
     s = np.asarray(list(unitsum_tuples(3, 2, .2, .8)))
     s_ = np.asarray([[.2, .8], [.4, .6], [.6, .4], [.8, .2]])
-    assert_true( np.allclose(s, s_) )
+    assert np.allclose(s, s_)
 
 def test_unitsum_tuples2():
     s = np.asarray(list(unitsum_tuples(4, 3, -1, 3)))
@@ -33,19 +33,20 @@ def test_unitsum_tuples2():
         (2.0, 0.0, -1.0),
         (3.0, -1.0, -1.0),
     ])
-    assert_true( np.allclose(s, s_) )
+    assert np.allclose(s, s_)
 
 def test_unitsum_tuples3():
      # Violate: 1 = mx + (k-1) * mn
      g = unitsum_tuples(3, 3, 1, 0)
-     assert_raises(Exception, next, g)
+     with pytest.raises(Exception):
+         next(g)
 
 def test_slots1():
     x = list(slots(3, 2))
     x_ = [(0, 3), (1, 2), (2, 1), (3, 0)]
-    assert_equal(x, x_)
+    assert x == x_
 
 def test_slots2():
     x = np.asarray(list(slots(3, 2, normalized=True)))
     x_ = np.asarray([(0, 1), (1/3, 2/3), (2/3, 1/3), (1, 0)])
-    assert_true( np.allclose(x, x_) )
+    assert np.allclose(x, x_)

--- a/dit/math/tests/test_equal.py
+++ b/dit/math/tests/test_equal.py
@@ -4,8 +4,6 @@ Tests for dit.math.equal.
 
 from __future__ import division
 
-from nose.tools import assert_false, assert_true
-
 from numpy import inf, nan
 
 from dit.math.equal import allclose, close__python as pyclose, close
@@ -13,57 +11,57 @@ from dit.math.equal import allclose, close__python as pyclose, close
 def test_close1():
     x = 0
     y = 1
-    assert_false(close(x, y))
-    assert_false(pyclose(x, y))
+    assert not close(x, y)
+    assert not pyclose(x, y)
 
 def test_close2():
     x = 0
     y = inf
-    assert_false(close(x, y))
-    assert_false(pyclose(x, y))
+    assert not close(x, y)
+    assert not pyclose(x, y)
 
 def test_close3():
     x = -inf
     y = inf
-    assert_false(close(x, y))
-    assert_false(pyclose(x, y))
+    assert not close(x, y)
+    assert not pyclose(x, y)
 
 def test_close4():
     x = inf
     y = nan
-    assert_false(close(x, y))
-    assert_false(pyclose(x, y))
+    assert not close(x, y)
+    assert not pyclose(x, y)
 
 def test_close5():
     x = 0
     y = nan
-    assert_false(close(x, y))
-    assert_false(pyclose(x, y))
+    assert not close(x, y)
+    assert not pyclose(x, y)
 
 def test_close6():
     x = 1
     y = 1
-    assert_true(close(x, y))
-    assert_true(pyclose(x, y))
+    assert close(x, y)
+    assert pyclose(x, y)
 
 def test_close7():
     x = 0.33333333333333
     y = 1/3
-    assert_true(close(x, y))
-    assert_true(pyclose(x, y))
+    assert close(x, y)
+    assert pyclose(x, y)
 
 def test_close8():
     x = inf
     y = inf
-    assert_true(close(x, y))
-    assert_true(pyclose(x, y))
+    assert close(x, y)
+    assert pyclose(x, y)
 
 def test_allclose1():
     x = [0, 0, -inf, inf, 0]
     y = [1, inf, inf, nan, nan]
-    assert_false(allclose(x, y))
+    assert not allclose(x, y)
 
 def test_allclose2():
     x = [1, 0.333333333333333, inf]
     y = [1, 1/3, inf]
-    assert_true(allclose(x, y))
+    assert allclose(x, y)

--- a/dit/math/tests/test_fraction.py
+++ b/dit/math/tests/test_fraction.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from nose.tools import *
+import pytest
 
 from fractions import Fraction
 from dit.math.fraction import *
@@ -14,23 +14,24 @@ def test_fraction():
     yvals = map(af, xvals)
     yvals_ = map(lambda x: Fraction(x, denominator), numerators)
     for y, y_ in zip(yvals, yvals_):
-        assert_equal(y, y_)
+        assert y == y_
 
     # Negative values
     af = lambda x: approximate_fraction(-x, .01)
     yvals = map(af, xvals)
     yvals_ = map(lambda x: Fraction(-x, denominator), numerators)
     for y, y_ in zip(yvals, yvals_):
-        assert_equal(y, y_)
+        assert y == y_
 
 def test_fraction_zero():
     """Convert float to fraction when closer to 0."""
     x = .1
     y = approximate_fraction(x, .2)
     y_ = Fraction(0, 1)
-    assert_equal(y, y_)
+    assert y == y_
     y = approximate_fraction(-x, .2)
-    assert_equal(y, -y_)
+    assert y == -y_
 
 def test_fraction_emptyinterval():
-    assert_raises(ValueError, approximate_fraction, 0.1, 0)
+    with pytest.raises(ValueError):
+        approximate_fraction(0.1, 0)

--- a/dit/math/tests/test_misc.py
+++ b/dit/math/tests/test_misc.py
@@ -4,56 +4,66 @@ Tests for dit.math.misc.
 
 from __future__ import division
 
-from nose.tools import assert_equal, assert_false, assert_raises, assert_true
+import pytest
 
 from dit.math.misc import combinations, is_integer, is_number, factorial
 
-def test_number1():
-    for i in range(-10, 10):
-        assert_true(is_number(i))
 
-def test_number2():
-    for i in range(-10, 10):
-        assert_true(is_number(i/10))
+@pytest.mark.parametrize('n', range(-10, 10))
+def test_number1(n):
+        assert is_number(n)
 
-def test_number3():
-    for i in ['a', int, []]:
-        assert_false(is_number(i))
+@pytest.mark.parametrize('n', range(-10, 10))
+def test_number2(n):
+    assert is_number(n/10)
 
-def test_integer1():
-    for i in range(-10, 10):
-        assert_true(is_integer(i))
+@pytest.mark.parametrize('n', ['a', int, []])
+def test_number3(n):
+    assert not is_number(n)
 
-def test_integer2():
-    for i in range(-10, 10):
-        assert_false(is_integer(i/10))
+@pytest.mark.parametrize('n', range(-10, 10))
+def test_integer1(n):
+    assert is_integer(n)
 
-def test_integer3():
-    for i in ['a', int, []]:
-        assert_false(is_integer(i))
+@pytest.mark.parametrize('n', range(-10, 10))
+def test_integer2(n):
+    assert not is_integer(n/10)
 
-def test_factorial1():
-    vals = [0, 1, 2, 3, 4, 5]
-    facs = [1, 1, 2, 6, 24, 120]
-    for v, f in zip(vals, facs):
-        assert_equal(factorial(v), f)
+@pytest.mark.parametrize('n', ['a', int, []])
+def test_integer3(n):
+    assert not is_integer(n)
 
-def test_factorial2():
-    vals = [-1, 0.5, 1+2j]
-    for v in vals:
-        assert_raises(ValueError, factorial, v)
+@pytest.mark.parametrize(('n', 'expected'), [
+    (0, 1),
+    (1, 1),
+    (2, 2),
+    (3, 6),
+    (4, 24),
+    (5, 120),
+])
+def test_factorial1(n, expected):
+    assert factorial(n) == expected
 
-def test_factorial3():
-    vals = ['a', int, []]
-    for v in vals:
-        assert_raises(TypeError, factorial, v)
+@pytest.mark.parametrize('n', [-1, 0.5, 1+2j])
+def test_factorial2(n):
+    with pytest.raises(ValueError):
+        factorial(n)
 
-def test_combinations1():
+@pytest.mark.parametrize('n', ['a', int, []])
+def test_factorial3(n):
+    with pytest.raises(TypeError):
+        factorial(n)
+
+@pytest.mark.parametrize(('k', 'c'), [
+    (0, 1),
+    (1, 3),
+    (2, 3),
+    (3, 1),
+])
+def test_combinations1(k, c):
     n = 3
-    ks = [0, 1, 2, 3]
-    cs = [1, 3, 3, 1]
-    for k, c in zip(ks, cs):
-        assert_equal(combinations(n, k), c)
+    assert combinations(n, k) == c
 
 def test_combinations2():
-    assert_raises(ValueError, combinations, 5, 7)
+    with pytest.raises(ValueError):
+        combinations(5, 7)

--- a/dit/math/tests/test_ops.py
+++ b/dit/math/tests/test_ops.py
@@ -4,10 +4,9 @@ Tests for dit.math.ops.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises, assert_true
+import pytest
 
 import numpy as np
-import numpy.testing as npt
 
 from dit.exceptions import InvalidBase
 from dit.math.ops import (
@@ -15,11 +14,11 @@ from dit.math.ops import (
 )
 
 def test_get_ops():
-    assert_true(isinstance(get_ops('linear'), LinearOperations))
-    assert_true(isinstance(get_ops(2), LogOperations))
+    assert isinstance(get_ops('linear'), LinearOperations)
+    assert isinstance(get_ops(2), LogOperations)
 
 class TestLinear(object):
-    def setUp(self):
+    def setup_class(self):
         self.ops = LinearOperations()
 
     def test_add(self):
@@ -27,15 +26,15 @@ class TestLinear(object):
         Y = np.array([0, 0, 1, 0, -1, -1, 1, 1, -1])
         Z = np.array([0, 1, 1, -1, -1, 0, 0, 2, -2])
         for x, y, z in zip(X, Y, Z):
-            assert_almost_equal(self.ops.add(x, y), z)
-        npt.assert_allclose(self.ops.add(X, Y), Z)
+            assert self.ops.add(x, y) == pytest.approx(z)
+        assert np.allclose(self.ops.add(X, Y), Z)
 
     def test_add_inplace(self):
         X = np.array([0, 1, 0, -1, 0, 1, -1, 1, -1])
         Y = np.array([0, 0, 1, 0, -1, -1, 1, 1, -1])
         Z = np.array([0, 1, 1, -1, -1, 0, 0, 2, -2])
         self.ops.add_inplace(X, Y)
-        npt.assert_allclose(X, Z)
+        assert np.allclose(X, Z)
 
     def test_add_reduce(self):
         X = np.array([[0, 0, 0],
@@ -46,43 +45,43 @@ class TestLinear(object):
                       [-1, -1, -1]])
         Y = np.array([0, 3, 3, 0, 0, -3])
         for x, y in zip(X, Y):
-            assert_almost_equal(self.ops.add_reduce(x), y)
+            assert self.ops.add_reduce(x) == pytest.approx(y)
 
     def test_mult(self):
         X = np.array([0, 1, 0, -1, 0, 1, -1, 1, -1, 2, 2, 2])
         Y = np.array([0, 0, 1, 0, -1, -1, 1, 1, -1, 1, 2, -2])
         Z = np.array([0, 0, 0, 0, 0, -1, -1, 1, 1, 2, 4, -4])
         for x, y, z in zip(X, Y, Z):
-            assert_almost_equal(self.ops.mult(x, y), z)
-        npt.assert_allclose(self.ops.mult(X, Y), Z)
+            assert self.ops.mult(x, y) == pytest.approx(z)
+        assert np.allclose(self.ops.mult(X, Y), Z)
 
     def test_mult_inplace(self):
         X = np.array([0, 1, 0, -1, 0, 1, -1, 1, -1, 2, 2, 2])
         Y = np.array([0, 0, 1, 0, -1, -1, 1, 1, -1, 1, 2, -2])
         Z = np.array([0, 0, 0, 0, 0, -1, -1, 1, 1, 2, 4, -4])
         self.ops.mult_inplace(X, Y)
-        npt.assert_allclose(X, Z)
+        assert np.allclose(X, Z)
 
     def test_invert(self):
         X = np.array([1, 2, -1, 10], dtype=float)
         Y = np.array([1, 1/2, -1, 1/10])
         for x, y in zip(X, Y):
-            assert_almost_equal(self.ops.invert(x), y)
+            assert self.ops.invert(x) == pytest.approx(y)
 
     def test_mult_reduce(self):
         prods = [1, 2, 6, 24, 120]
         for i, p in enumerate(prods):
-            assert_almost_equal(self.ops.mult_reduce(np.arange(1, i+2)), p)
+            assert self.ops.mult_reduce(np.arange(1, i+2)) == pytest.approx(p)
 
     def test_normalize(self):
         X = np.ones(3)
         Y = self.ops.normalize(X)
         Y_ = X / 3
-        npt.assert_allclose(Y, Y_)
+        assert np.allclose(Y, Y_)
 
 
 class TestLog2(object):
-    def setUp(self):
+    def setup_class(self):
         self.ops = LogOperations(2)
 
     def test_add(self):
@@ -90,43 +89,43 @@ class TestLog2(object):
         Y = self.ops.log(np.array([0, 0, 1, 0, 2, 2, 1, 1, 2]))
         Z = self.ops.log(np.array([0, 1, 1, 2, 2, 3, 3, 2, 4]))
         for x, y, z in zip(X, Y, Z):
-            npt.assert_allclose(self.ops.add(x, y), z)
-        npt.assert_allclose(self.ops.add(X, Y), Z)
+            assert np.allclose(self.ops.add(x, y), z)
+        assert np.allclose(self.ops.add(X, Y), Z)
 
     def test_add_inplace(self):
         X = self.ops.log(np.array([0, 1, 0, 2, 0, 1, 2, 1, 2]))
         Y = self.ops.log(np.array([0, 0, 1, 0, 2, 2, 1, 1, 2]))
         Z = self.ops.log(np.array([0, 1, 1, 2, 2, 3, 3, 2, 4]))
         self.ops.add_inplace(X, Y)
-        npt.assert_allclose(X, Z)
+        assert np.allclose(X, Z)
 
     def test_add_reduce(self):
         X = self.ops.log(np.array([[0, 0, 0], [0, 1, 2], [1, 1, 1]]))
         Y = self.ops.log(np.array([0, 3, 3]))
         for x, y in zip(X, Y):
-            npt.assert_allclose(self.ops.add_reduce(x), y)
-        npt.assert_allclose(self.ops.add_reduce(np.array([])), self.ops.zero)
+            assert np.allclose(self.ops.add_reduce(x), y)
+        assert np.allclose(self.ops.add_reduce(np.array([])), self.ops.zero)
 
     def test_mult(self):
         X = self.ops.log(np.array([0, 1, 0, 0.5, 0, 1, 0.5, 1, 0.5, 2, 2, 2]))
         Y = self.ops.log(np.array([0, 0, 1, 0, 5, 0.5, 1, 1, 0.5, 1, 2, 0.5]))
         Z = self.ops.log(np.array([0, 0, 0, 0, 0, 0.5, 0.5, 1, 0.25, 2, 4, 1]))
         for x, y, z in zip(X, Y, Z):
-            npt.assert_allclose(self.ops.mult(x, y), z)
-        npt.assert_allclose(self.ops.mult(X, Y), Z)
+            assert np.allclose(self.ops.mult(x, y), z)
+        assert np.allclose(self.ops.mult(X, Y), Z)
 
     def test_mult_inplace(self):
         X = self.ops.log(np.array([0, 1, 0, 0.5, 0, 1, 0.5, 1, 0.5, 2, 2, 2]))
         Y = self.ops.log(np.array([0, 0, 1, 0, 5, 0.5, 1, 1, 0.5, 1, 2, 0.5]))
         Z = self.ops.log(np.array([0, 0, 0, 0, 0, 0.5, 0.5, 1, 0.25, 2, 4, 1]))
         self.ops.mult_inplace(X, Y)
-        npt.assert_allclose(X, Z)
+        assert np.allclose(X, Z)
 
     def test_invert(self):
         X = self.ops.log(np.array([1, 2, 0.5, 10], dtype=float))
         Y = self.ops.log(np.array([1, 1/2, 2, 1/10]))
         for x, y in zip(X, Y):
-            npt.assert_allclose(self.ops.invert(x), y)
+            assert np.allclose(self.ops.invert(x), y)
 
     def test_mult_reduce(self):
         nums = np.arange(1, 5+1)
@@ -134,8 +133,8 @@ class TestLog2(object):
         prods = self.ops.log(prods)
         nums = self.ops.log(nums)
         for i, p in enumerate(prods):
-            npt.assert_allclose(self.ops.mult_reduce(nums[:i+1]), p)
-        npt.assert_allclose(self.ops.mult_reduce(np.array([])), self.ops.one)
+            assert np.allclose(self.ops.mult_reduce(nums[:i+1]), p)
+        assert np.allclose(self.ops.mult_reduce(np.array([])), self.ops.one)
 
     def test_normalize(self):
         W = np.ones(3)
@@ -143,36 +142,35 @@ class TestLog2(object):
         Y = self.ops.normalize(X)
         Z = self.ops.exp(Y)
         Z_ = W / 3
-        npt.assert_allclose(Z, Z_)
+        assert np.allclose(Z, Z_)
 
 
 class TestLog3(TestLog2):
-    def setUp(self):
+    def setup_class(self):
         self.ops = LogOperations(3.5)
 
 class TestLogE(TestLog2):
-    def setUp(self):
+    def setup_class(self):
         self.ops = LogOperations('e')
 
 class TestLogHalf(TestLog2):
-    def setUp(self):
+    def setup_class(self):
         self.ops = LogOperations(0.5)
 
-def test_exp_func1():
-    bad_bases = ['pants', -1, 0, 1]
-    for b in bad_bases:
-        assert_raises(InvalidBase, exp_func, b)
+@pytest.mark.parametrize('base', ['pants', -1, 0, 1])
+def test_exp_func1(base):
+    with pytest.raises(InvalidBase):
+        exp_func(base)
 
 def test_exp_func2():
     ops = LogOperations(0.5)
-    npt.assert_allclose([0.5**1, 0.5**2, 0.5**3], ops.exp([1, 2, 3]))
+    assert np.allclose([0.5**1, 0.5**2, 0.5**3], ops.exp([1, 2, 3]))
 
-def test_log_func1():
-    bad_bases = ['pants', -1, 0, 1]
-    for b in bad_bases:
-        assert_raises(InvalidBase, log_func, b)
+@pytest.mark.parametrize('base', ['pants', -1, 0, 1])
+def test_log_func1(base):
+    with pytest.raises(InvalidBase):
+        log_func(base)
 
 def test_log_func2():
     ops = LogOperations(2)
-    npt.assert_allclose([np.log2(1), np.log2(2), np.log2(3)],
-                         ops.log([1, 2, 3]))
+    assert np.allclose([np.log2(1), np.log2(2), np.log2(3)], ops.log([1, 2, 3]))

--- a/dit/math/tests/test_pmfops.py
+++ b/dit/math/tests/test_pmfops.py
@@ -1,12 +1,11 @@
 # coding: utf-8
 
-from __future__ import division
-from __future__ import print_function
+from __future__ import division, print_function
 
 import dit
 import numpy as np
 
-from nose.tools import *
+import pytest
 
 module = dit.math.pmfops
 
@@ -15,55 +14,54 @@ def test_perturb_one():
     d = np.array([0, .5, .5])
     d2 = module.perturb_support(d, .00001)
     d3 = d2.round(2)
-    np.testing.assert_allclose(d, d3)
+    assert np.allclose(d, d3)
 
 def test_perturb_one_square():
     # Smoke test
     d = np.array([0, .5, .5])
     d2 = module.perturb_support(d, .00001, shape='square')
     d3 = d2.round(2)
-    np.testing.assert_allclose(d, d3)
+    assert np.allclose(d, d3)
 
 def test_perturb_many():
     # Smoke test
     d = np.array([[0, .5, .5], [.5, .5, .0]])
     d2 = module.perturb_support(d, .00001)
     d3 = d2.round(2)
-    np.testing.assert_allclose(d, d3)
+    assert np.allclose(d, d3)
 
 def test_convex_combination():
     d1 = np.array([0, .5, .5])
     d2 = np.array([.5, .5, 0])
     d3_= np.array([.25, .5, .25])
     d3 = module.convex_combination(np.array([d1, d2]))
-    np.testing.assert_allclose(d3, d3_)
+    assert np.allclose(d3, d3_)
 
 def test_convex_combination_weights():
     d1 = np.array([0, .5, .5])
     d2 = np.array([.5, .5, 0])
     weights = [1, 0]
     d3 = module.convex_combination(np.array([d1, d2]), weights)
-    np.testing.assert_allclose(d3, d1)
+    assert np.allclose(d3, d1)
 
 def test_downsample_onepmf():
     # One pmf
     d1 = np.array([0, .51, .49])
     d2_ = np.array([0, .5, .5])
     d2 = module.downsample(d1, 2)
-    np.testing.assert_allclose(d2, d2_)
+    assert np.allclose(d2, d2_)
 
 def test_downsample_twopmf():
     # Two pmf
     d1 = np.array([[0, .51, .49], [.6, .3, .1]])
     d2_ = np.array([[0, .5, .5], [.5, .5, 0]])
     d2 = module.downsample(d1, 2)
-    np.testing.assert_allclose(d2, d2_)
+    assert np.allclose(d2, d2_)
 
 def test_downsample_badmethod():
     d1 = np.array([0, .51, .49])
-    assert_raises(
-        NotImplementedError, module.downsample, d1, 2**3, method='whatever'
-    )
+    with pytest.raises(NotImplementedError):
+        module.downsample(d1, 2**3, method='whatever')
 
 def test_projections1():
     d = np.array([ 0.03231933,  0.89992681,  0.06775385])
@@ -73,7 +71,7 @@ def test_projections1():
         [ 0.        ,  0.875     ,  0.125     ]
     ])
     d2 = module.projections(d, 2**3)
-    np.testing.assert_allclose(d2, d2_)
+    assert np.allclose(d2, d2_)
 
 def test_projections2():
     d = np.array([ 0.51,  0.48,  0.01])
@@ -83,7 +81,7 @@ def test_projections2():
         [ 0.5       ,  0.5       ,  0.        ]
     ])
     d2 = module.projections(d, 2**3)
-    np.testing.assert_allclose(d2, d2_, rtol=1e-7, atol=1e-8)
+    assert np.allclose(d2, d2_, rtol=1e-7, atol=1e-8)
 
 def test_projections_max():
     d = np.array([ 0.51,  0.48,  0.01])
@@ -93,7 +91,7 @@ def test_projections_max():
         [ 0.625     ,  0.25      ,  0.125     ]
     ])
     d2 = module.projections(d, 2**3, [np.argmax, np.argmax, np.argmax])
-    np.testing.assert_allclose(d2, d2_, rtol=1e-7, atol=1e-8)
+    assert np.allclose(d2, d2_, rtol=1e-7, atol=1e-8)
 
 def test_projections_0element():
     # During projections, if an element is equal to 0, then searchsorted
@@ -123,43 +121,43 @@ def test_projections_0element():
         [ 0.25      ,  0.375     ,  0.        ,  0.375     ,  0.        , 0.        ],
         [ 0.25      ,  0.375     ,  0.        ,  0.375     ,  0.        , 0.        ],
     ])
-    np.testing.assert_allclose(x, x_good, rtol=1e-7, atol=1e-8)
+    assert np.allclose(x, x_good, rtol=1e-7, atol=1e-8)
 
 def test_clamps():
-    d = np.array([.51, .48, .01])
+    d = np.array([0.51, 0.48, 0.01])
     locs = np.linspace(0, 1, 2**3+1)
     out_ = np.array([[4, 3, 0], [5, 4, 1]])
     out = module.clamped_indexes(d, locs)
-    np.testing.assert_allclose(out, out_)
+    assert np.allclose(out, out_)
 
 def test_replace_nonzero_rand():
-    d = np.array([.25, .75, 0])
-    x = module.replace_zeros(d, .0001)
-    np.testing.assert_allclose(d, x.round(2))
+    d = np.array([0.25, 0.75, 0])
+    x = module.replace_zeros(d, 0.0001)
+    assert np.allclose(d, x.round(2))
 
 def test_replace_nonzero_norand():
-    d = np.array([.25, .75, 0])
-    x = module.replace_zeros(d, .0001, rand=False)
-    assert_true(x[2] == .0001)
-    np.testing.assert_allclose(d, x.round(2))
+    d = np.array([0.25, 0.75, 0])
+    x = module.replace_zeros(d, 0.0001, rand=False)
+    assert x[2] == 0.0001
+    assert np.allclose(d, x.round(2))
 
 def test_jittered_zeros():
-    d = np.array([.25, .75, 0])
+    d = np.array([0.25, 0.75, 0])
     prng = np.random.RandomState(1)
     x = module.jittered(d, jitter=1e-5, zeros=True, prng=prng)
     x_ = np.array([  2.49998269e-01,   7.49997561e-01,   4.17024317e-06])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_jittered():
-    d = np.array([.25, .75, 0])
+    d = np.array([0.25, 0.75, 0])
     prng = np.random.RandomState(1)
     x = module.jittered(d, jitter=1e-5, zeros=False, prng=prng)
-    x_ = np.array([ 0.24999923,  0.75000077,  0.        ])
-    np.testing.assert_allclose(x, x_)
+    x_ = np.array([ 0.24999923,  0.75000077,  0.0       ])
+    assert np.allclose(x, x_)
 
 def test_jittered_noprng():
-    d = np.array([.25, .75, 0])
+    d = np.array([0.25, 0.75, 0])
     dit.math.prng.seed(1)
     x = module.jittered(d, jitter=1e-5, zeros=False)
-    x_ = np.array([ 0.24999923,  0.75000077,  0.        ])
-    np.testing.assert_allclose(x, x_)
+    x_ = np.array([ 0.24999923,  0.75000077,  0.0       ])
+    assert np.allclose(x, x_)

--- a/dit/math/tests/test_sampling.py
+++ b/dit/math/tests/test_sampling.py
@@ -2,7 +2,7 @@
 Tests for dit.math.sampling.
 """
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 import numpy as np
 
@@ -16,72 +16,74 @@ def test_sample1():
     d = dit.example_dists.Xor()
     dit.math.prng.seed(0)
     x = module.sample(d)
-    assert_equal(x, '101')
+    assert x == '101'
 
     # with log dist
     dit.math.prng.seed(0)
     d.set_base(3.5)
     x = module.sample(d)
-    assert_equal(x, '101')
+    assert x == '101'
 
 def test_sample2():
     # Specified prng
     d = dit.example_dists.Xor()
     dit.math.prng.seed(0)
     x = module.sample(d, prng=dit.math.prng)
-    assert_equal(x, '101')
+    assert x == '101'
 
 def test_sample3():
     # Specified rand number
     d = dit.example_dists.Xor()
     x = module.sample(d, rand=.3)
-    assert_equal(x, '011')
+    assert x == '011'
 
 def test_sample4():
     # More than one random number
     d = dit.example_dists.Xor()
     dit.math.prng.seed(0)
     x = module.sample(d, 6)
-    assert_equal(x, ['101', '101', '101', '101', '011', '101'])
+    assert x == ['101', '101', '101', '101', '011', '101']
 
 def test_sample5():
     # Bad prng
     d = dit.example_dists.Xor()
-    assert_raises(ditException, module.sample, d, prng=3)
+    with pytest.raises(ditException):
+        module.sample(d, prng=3)
 
 def test_sample6():
     # Not enough rands
     d = dit.example_dists.Xor()
-    assert_raises(ditException, module.sample, d, 5, rand=[.1]*3)
+    with pytest.raises(ditException):
+        module.sample(d, 5, rand=[.1]*3)
 
 def test_sample_discrete_python1():
     # Specified rand number
     d = dit.example_dists.Xor()
     x = module._sample_discrete__python(d.pmf, .5)
-    assert_equal(x, 2)
+    assert x == 2
 
 def test_sample_discrete_python2():
     # Specified rand number
     d = dit.example_dists.Xor()
     x = module._samples_discrete__python(d.pmf, np.array([.5, .3, .2]))
-    np.testing.assert_allclose(x, np.array([2, 1, 0]))
+    assert np.allclose(x, np.array([2, 1, 0]))
 
 def test_ball_smoke():
     dit.math.prng.seed(0)
     x = module.ball(3)
     x_ = np.array([ 0.21324626,  0.4465436 , -0.65226253])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
     dit.math.prng.seed(0)
     x = module.ball(3, prng=dit.math.prng)
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_base_with_size():
     # size 3, 1
     dit.math.prng.seed(0)
     x = module.ball(3, 1)
     x_ = np.array([[ 0.21324626,  0.4465436 , -0.65226253]])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
     # size 4, 4
     dit.math.prng.seed(0)
@@ -92,7 +94,7 @@ def test_base_with_size():
         [ 0.70592518,  0.1128636 ,  0.41171971,  0.30951042],
         [ 0.72885111, -0.1000816 ,  0.15272267, -0.41665039]
     ])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_2ball():
     dit.math.prng.seed(0)
@@ -102,8 +104,8 @@ def test_2ball():
         [-0.14853979, -0.66826269],
         [-0.31184301, -0.23494632]
     ])
-    assert_equal(x.shape, (3, 2))
-    np.testing.assert_allclose(x, x_)
+    assert x.shape == (3, 2)
+    assert np.allclose(x, x_)
 
 def test_3ball_cylinder():
     dit.math.prng.seed(0)
@@ -113,8 +115,8 @@ def test_3ball_cylinder():
         [ 0.68515146, -0.55406718, -0.1526904 ],
         [ 0.77215823, -0.17942272,  0.29178823]
     ])
-    assert_equal(x.shape, (3, 3))
-    np.testing.assert_allclose(x, x_)
+    assert x.shape == (3, 3)
+    assert np.allclose(x, x_)
 
 def test_norm_smoketest():
     d = np.array([.2, .3, .5])
@@ -123,31 +125,31 @@ def test_norm_smoketest():
     dit.math.prng.seed(0)
     x = module.norm(d)
     x_ = np.array([ 0.49606291,  0.13201838,  0.37191871])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
     # prng is not None
     dit.math.prng.seed(0)
     x = module.norm(d, prng=dit.math.prng)
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
     # size is not None
     dit.math.prng.seed(0)
     x = module.norm(d, size=1)
-    np.testing.assert_allclose(x, np.asarray([x_]))
+    assert np.allclose(x, np.asarray([x_]))
 
 def test_norm_spherical_cov():
     d = np.array([.2, .3, .5])
     dit.math.prng.seed(0)
     x = module.norm(d, .3)
     x_ = np.array([ 0.34790127,  0.20240029,  0.44969844])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_norm_diagonal_cov():
     d = np.array([.2, .3, .5])
     dit.math.prng.seed(0)
     x = dit.math.norm(d, np.array([.3, .5]))
     x_ = np.array([ 0.33458841,  0.40485058,  0.26056101])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_norm_cov():
     d = np.array([.2, .3, .5])
@@ -159,32 +161,36 @@ def test_norm_cov():
         [ 0.09984353,  0.44856934,  0.45158713],
         [ 0.07260608,  0.18948779,  0.73790613]
     ])
-    np.testing.assert_allclose(x, x_)
+    assert np.allclose(x, x_)
 
 def test_norm_badshape_cov():
     d = np.array([.2, .3, .5])
     dit.math.prng.seed(0)
     ilrcov = np.array([[.3, .5, .1],[.5, .4, .3], [.2, .5, .3]])
-    assert_raises(dit.exceptions.ditException, dit.math.norm, d, ilrcov)
+    with pytest.raises(ditException):
+        dit.math.norm(d, ilrcov)
 
     ilrcov = np.array([.3, .5, .1])
-    assert_raises(dit.exceptions.ditException, dit.math.norm, d, ilrcov)
+    with pytest.raises(ditException):
+        dit.math.norm(d, ilrcov)
 
     ilrcov = np.array(np.random.rand(16).reshape(2,2,4))
-    assert_raises(dit.exceptions.ditException, dit.math.norm, d, ilrcov)
+    with pytest.raises(ditException):
+        dit.math.norm(d, ilrcov)
 
 def test_norm_toomany():
     d = np.array([[.2, .3, .5], [.5, .2, .3]])
-    assert_raises(dit.exceptions.ditException, dit.math.norm, d)
+    with pytest.raises(ditException):
+        dit.math.norm(d)
 
 def test__annulus2_nosize():
     # When size is None, it should just return the sample.
     prng = np.random.RandomState()
     samples = dit.math.sampling._annulus2(0, 1, size=None, prng=prng)
-    assert_equal(samples.shape, (2,))
+    assert samples.shape == (2,)
 
 def test__annulus2_size():
     # When size is not None, it should return an array of the samples.
     prng = np.random.RandomState()
     samples = dit.math.sampling._annulus2(0, 1, size=1, prng=prng)
-    assert_equal(samples.shape, (1,2))
+    assert samples.shape == (1,2)

--- a/dit/multivariate/tests/test_caekl_mutual_information.py
+++ b/dit/multivariate/tests/test_caekl_mutual_information.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.caekl_mutual_information.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_less_equal
+import pytest
 
 from dit import Distribution as D, ScalarDistribution as SD
 from dit.distconst import all_dist_structures, random_distribution
@@ -14,38 +14,36 @@ from dit.multivariate import (caekl_mutual_information as J,
                              )
 from dit.exceptions import ditException
 
-def test_caekl_1():
+@pytest.mark.parametrize('d', list(all_dist_structures(2, 3)) +
+                              [random_distribution(2, 3, alpha=(0.5,)*9) for _ in range(10)])
+def test_caekl_1(d):
     """
     Ensure that it reduces to the mutual information for bivariate
     distributions.
     """
-    for d in all_dist_structures(2, 3):
-        yield assert_almost_equal, I(d), J(d)
-    for d in [random_distribution(2, 3, alpha=(0.5,)*9) for _ in range(10)]:
-        yield assert_almost_equal, I(d), J(d)
+    assert I(d) == pytest.approx(J(d))
 
-def test_caekl_2():
+@pytest.mark.parametrize('d', list(all_dist_structures(3, 2)) +
+                              [random_distribution(3, 2, alpha=(0.5,)*8) for _ in range(10)])
+def test_caekl_2(d):
     """
     Ensure that it reduces to the mutual information for bivariate
     distributions reduced from multivariate.
     """
     rvs = [[0], [1]]
-    for d in all_dist_structures(3, 2):
-        yield assert_almost_equal, I(d, rvs), J(d, rvs)
-    for d in [random_distribution(3, 2, alpha=(0.5,)*8) for _ in range(10)]:
-        yield assert_almost_equal, I(d, rvs), J(d, rvs)
+    assert I(d, rvs) == pytest.approx(J(d, rvs))
 
 def test_caekl_3():
     """
     Test a known value.
     """
     d = D(['000', '011', '101', '110'], [1/4]*4)
-    assert_almost_equal(J(d), 0.5)
+    assert J(d) == pytest.approx(0.5)
 
-def test_caekl_4():
+@pytest.mark.parametrize('d', [random_distribution(4, 3, alpha=(0.5,)*3**4) for _ in range(10)])
+def test_caekl_4(d):
     """
     Test that CAEKL is always less than or equal to the normalized total
     correlation.
     """
-    for d in [random_distribution(4, 3, alpha=(0.5,)*3**4) for _ in range(10)]:
-        yield assert_less_equal, J(d), T(d)/3 + 1e-7
+    assert J(d) <= (T(d)/3) + 1e-6

--- a/dit/multivariate/tests/test_coinformation.py
+++ b/dit/multivariate/tests/test_coinformation.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.coinformation.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 from dit import Distribution as D, ScalarDistribution as SD
 from dit.multivariate import coinformation as I, entropy as H
@@ -14,52 +14,53 @@ from dit.example_dists import n_mod_m
 def test_coi1():
     """ Test I for xor """
     d = n_mod_m(3, 2)
-    assert_almost_equal(I(d), -1.0)
-    assert_almost_equal(I(d, [[0], [1], [2]]), -1.0)
-    assert_almost_equal(I(d, [[0], [1], [2]], [2]), 0.0)
-    assert_almost_equal(I(d, [[0], [1]], [2]), 1.0)
+    assert I(d) == pytest.approx(-1.0)
+    assert I(d, [[0], [1], [2]]) == pytest.approx(-1.0)
+    assert I(d, [[0], [1], [2]], [2]) == pytest.approx(0.0)
+    assert I(d, [[0], [1]], [2]) == pytest.approx(1.0)
 
 def test_coi2():
     """ Test I for larger parity distribution """
     d = n_mod_m(4, 2)
-    assert_almost_equal(I(d), 1.0)
+    assert I(d) == pytest.approx(1.0)
 
 def test_coi3():
     """ Test I for subsets of variables, with and without names """
     d = n_mod_m(4, 2)
-    assert_almost_equal(I(d, [[0], [1], [2]]), 0.0)
+    assert I(d, [[0], [1], [2]]) == pytest.approx(0.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(I(d, [['X'], ['Y'], ['Z']]), 0.0)
+    assert I(d, [['X'], ['Y'], ['Z']]) == pytest.approx(0.0)
 
 def test_coi4():
     """ Test conditional I, with and without names """
     d = n_mod_m(4, 2)
-    assert_almost_equal(I(d, [[0], [1], [2]], [3]), -1.0)
+    assert I(d, [[0], [1], [2]], [3]) == pytest.approx(-1.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(I(d, [['X'], ['Y'], ['Z']], ['W']), -1.0)
+    assert I(d, [['X'], ['Y'], ['Z']], ['W']) == pytest.approx(-1.0)
 
 def test_coi5():
     """ Test conditional I, with and without names """
     d = n_mod_m(4, 2)
-    assert_almost_equal(I(d, [[0], [1]], [2, 3]), 1.0)
+    assert I(d, [[0], [1]], [2, 3]) == pytest.approx(1.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(I(d, [['X'], ['Y']], ['Z', 'W']), 1.0)
+    assert I(d, [['X'], ['Y']], ['Z', 'W']) == pytest.approx(1.0)
 
 def test_coi6():
     """ Test conditional I, with and without names """
     d = n_mod_m(4, 2)
-    assert_almost_equal(I(d, [[0]], [1, 2, 3]), 0.0)
+    assert I(d, [[0]], [1, 2, 3]) == pytest.approx(0.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(I(d, [['X']], ['Y', 'Z', 'W']), 0.0)
+    assert I(d, [['X']], ['Y', 'Z', 'W']) == pytest.approx(0.0)
 
 def test_coi7():
     """ Test that H = I for one variable """
     outcomes = "ABC"
     pmf = [1/3]*3
     d = D(outcomes, pmf)
-    assert_almost_equal(H(d), I(d))
+    assert H(d) == pytest.approx(I(d))
 
 def test_coi8():
     """ Test that I fails on ScalarDistributions """
     d = SD([1/3]*3)
-    assert_raises(ditException, I, d)
+    with pytest.raises(ditException):
+        I(d)

--- a/dit/multivariate/tests/test_common_informations.py
+++ b/dit/multivariate/tests/test_common_informations.py
@@ -2,8 +2,7 @@
 Tests for the various common informations.
 """
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_less_equal
+import pytest
 
 from dit import random_distribution
 from dit.multivariate import (gk_common_information as K,
@@ -15,40 +14,42 @@ from dit.multivariate import (gk_common_information as K,
                              )
 
 
-@attr('scipy')
-@attr('slow')
-def test_cis1():
-    """
-    Test that the common informations are ordered correctly.
-    """
-    for d in [random_distribution(2, 3) for _ in range(5)]:
-        k = K(d)
-        b = B(d)
-        c = C(d)
-        g = G(d)
-        f = F(d)
-        m = M(d)
-        yield assert_less_equal, k, b + 1e-6
-        yield assert_less_equal, b, c + 1e-6
-        yield assert_less_equal, c, g + 1e-6
-        yield assert_less_equal, g, f + 1e-6
-        yield assert_less_equal, f, m + 1e-6
+pytest.importorskip('scipy')
 
-@attr('scipy')
-@attr('slow')
-def test_cis2():
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize('d', [random_distribution(2, 3) for _ in range(5)])
+def test_cis1(d):
     """
     Test that the common informations are ordered correctly.
     """
-    for d in [random_distribution(3, 2) for _ in range(5)]:
-        k = K(d)
-        b = B(d)
-        c = C(d)
-        g = G(d)
-        f = F(d)
-        m = M(d)
-        yield assert_less_equal, k, b + 1e-6
-        yield assert_less_equal, b, c + 1e-6
-        yield assert_less_equal, c, g + 1e-6
-        yield assert_less_equal, g, f + 1e-6
-        yield assert_less_equal, f, m + 1e-6
+    k = K(d)
+    b = B(d)
+    c = C(d)
+    g = G(d)
+    f = F(d)
+    m = M(d)
+    assert k <= b + 1e-6
+    assert b <= c + 1e-6
+    assert c <= g + 1e-6
+    assert g <= f + 1e-6
+    assert f <= m + 1e-6
+
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize('d', [random_distribution(3, 2) for _ in range(5)])
+def test_cis2(d):
+    """
+    Test that the common informations are ordered correctly.
+    """
+    k = K(d)
+    b = B(d)
+    c = C(d)
+    g = G(d)
+    f = F(d)
+    m = M(d)
+    assert k <= b + 1e-6
+    assert b <= c + 1e-6
+    assert c <= g + 1e-6
+    assert g <= f + 1e-6
+    assert f <= m + 1e-6

--- a/dit/multivariate/tests/test_dual_total_correlation.py
+++ b/dit/multivariate/tests/test_dual_total_correlation.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.dual_total_correlation.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 from dit import Distribution as D, ScalarDistribution as SD
 from dit.multivariate import (dual_total_correlation as B,
@@ -16,67 +16,69 @@ from dit.exceptions import ditException
 def test_B1():
     """ Test B for two dependent variables """
     d = D(['00', '11'], [1/2, 1/2])
-    assert_almost_equal(B(d), 1)
+    assert B(d) == pytest.approx(1)
 
 def test_B2():
     """ Test B for three dependent variables """
     d = D(['000', '111'], [1/2, 1/2])
-    assert_almost_equal(B(d), 1)
-    assert_almost_equal(B(d, [[0], [1]], [2]), 0)
+    assert B(d) == pytest.approx(1)
+    assert B(d, [[0], [1]], [2]) == pytest.approx(0)
 
 def test_B3():
     """ Test B for four dependent variables """
     d = D(['0000', '1111'], [1/2, 1/2])
-    assert_almost_equal(B(d), 1)
-    assert_almost_equal(B(d, [[0], [1, 2]], [3]), 0)
+    assert B(d) == pytest.approx(1)
+    assert B(d, [[0], [1, 2]], [3]) == pytest.approx(0)
 
 def test_B4():
     """ Test B for xor distribution """
     d = D(['000', '011', '101', '110'], [1/4]*4)
-    assert_almost_equal(B(d), 2)
-    assert_almost_equal(B(d, [[0], [1], [2]]), 2)
-    assert_almost_equal(B(d, [[0], [1]], [2]), 1)
-    assert_almost_equal(B(d, [[0], [2]], [1]), 1)
-    assert_almost_equal(B(d, [[1], [2]], [0]), 1)
+    assert B(d) == pytest.approx(2)
+    assert B(d, [[0], [1], [2]]) == pytest.approx(2)
+    assert B(d, [[0], [1]], [2]) == pytest.approx(1)
+    assert B(d, [[0], [2]], [1]) == pytest.approx(1)
+    assert B(d, [[1], [2]], [0]) == pytest.approx(1)
 
 def test_B5():
     """ Test B = I for two variables """
     d = D(['00', '01', '11'], [1/3]*3)
-    assert_almost_equal(B(d), I(d, [0], [1]))
+    assert B(d) == pytest.approx(I(d, [0], [1]))
 
 def test_B6():
     """ Test that B fails on SDs """
     d = SD([1/4]*4)
-    assert_raises(ditException, B, d)
+    with pytest.raises(ditException):
+        B(d)
 
 def test_R1():
     """ Test R for dependent variables """
     d = D(['00', '11'], [1/2, 1/2])
-    assert_almost_equal(R(d), 0)
+    assert R(d) == pytest.approx(0)
 
 def test_R2():
     """ Test R for independent variables """
     d = D(['00', '01', '10', '11'], [1/4]*4)
-    assert_almost_equal(R(d), 2)
-    assert_almost_equal(R(d, [[0], [1]]), 2)
+    assert R(d) == pytest.approx(2)
+    assert R(d, [[0], [1]]) == pytest.approx(2)
 
 def test_R3():
     """ Test R for a generic distribution """
     d = D(['000', '011', '101', '110'], [1/4]*4)
-    assert_almost_equal(R(d), 0)
-    assert_almost_equal(R(d, [[0, 1], [2]]), 1)
+    assert R(d) == pytest.approx(0)
+    assert R(d, [[0, 1], [2]]) == pytest.approx(1)
 
 def test_R4():
     """ Test that R = H - I in two variables """
     d = D(['00', '01', '11'], [1/3]*3)
-    assert_almost_equal(R(d), H(d)-I(d, [0], [1]))
+    assert R(d) == pytest.approx(H(d)-I(d, [0], [1]))
 
 def test_R5():
     """ Test that R fails on SDs """
     d = SD([1/4]*4)
-    assert_raises(ditException, R, d)
+    with pytest.raises(ditException):
+        R(d)
 
 def test_BR1():
     """ Test that B + R = H """
     d = D(['000', '001', '010', '100', '111'], [1/5]*5)
-    assert_almost_equal(B(d)+R(d), H(d))
+    assert B(d)+R(d) == pytest.approx(H(d))

--- a/dit/multivariate/tests/test_entropy.py
+++ b/dit/multivariate/tests/test_entropy.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.entropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 import numpy as np
 
@@ -15,53 +15,53 @@ from dit.multivariate import entropy as H
 def test_H1():
     """ Test H of a fair coin """
     d = D(['H', 'T'], [1/2, 1/2])
-    assert_almost_equal(H(d), 1)
+    assert H(d) == pytest.approx(1)
 
 def test_H2():
     """ Test the various entropies of two independent events """
     d = D(['00', '01', '10', '11'], [1/4]*4)
-    assert_almost_equal(H(d), 2)
-    assert_almost_equal(H(d, [0]), 1)
-    assert_almost_equal(H(d, [1]), 1)
-    assert_almost_equal(H(d, [0], [1]), 1)
-    assert_almost_equal(H(d, [1], [0]), 1)
-    assert_almost_equal(H(d, [0], [0]), 0)
-    assert_almost_equal(H(d, [0], [0, 1]), 0)
+    assert H(d) == pytest.approx(2)
+    assert H(d, [0]) == pytest.approx(1)
+    assert H(d, [1]) == pytest.approx(1)
+    assert H(d, [0], [1]) == pytest.approx(1)
+    assert H(d, [1], [0]) == pytest.approx(1)
+    assert H(d, [0], [0]) == pytest.approx(0)
+    assert H(d, [0], [0, 1]) == pytest.approx(0)
 
 def test_H3():
     """ Test the various entropies of two independent events with names """
     d = D(['00', '01', '10', '11'], [1/4]*4)
     d.set_rv_names('XY')
-    assert_almost_equal(H(d), 2)
-    assert_almost_equal(H(d, ['X']), 1)
-    assert_almost_equal(H(d, ['Y']), 1)
-    assert_almost_equal(H(d, ['X'], ['Y']), 1)
-    assert_almost_equal(H(d, ['Y'], ['X']), 1)
-    assert_almost_equal(H(d, ['X'], ['X']), 0)
-    assert_almost_equal(H(d, ['X'], ['X', 'Y']), 0)
+    assert H(d) == pytest.approx(2)
+    assert H(d, ['X']) == pytest.approx(1)
+    assert H(d, ['Y']) == pytest.approx(1)
+    assert H(d, ['X'], ['Y']) == pytest.approx(1)
+    assert H(d, ['Y'], ['X']) == pytest.approx(1)
+    assert H(d, ['X'], ['X']) == pytest.approx(0)
+    assert H(d, ['X'], ['X', 'Y']) == pytest.approx(0)
 
-def test_H4():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_H4(i):
     """ Test H for uniform distributions """
-    for i in range(2, 10):
-        d = D.from_distribution(uniform(i))
-        yield assert_almost_equal, H(d), np.log2(i)
+    d = D.from_distribution(uniform(i))
+    assert H(d) == pytest.approx(np.log2(i))
 
-def test_H5():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_H5(i):
     """ Test H for uniform distributions in various bases """
-    for i in range(2, 10):
-        d = D.from_distribution(uniform(i))
-        d.set_base(i)
-        yield assert_almost_equal, H(d), 1
+    d = D.from_distribution(uniform(i))
+    d.set_base(i)
+    assert H(d) == pytest.approx(1)
 
-def test_H6():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_H6(i):
     """ Test H for uniform distributions using ScalarDistributions """
-    for i in range(2, 10):
-        d = uniform(i)
-        yield assert_almost_equal, H(d), np.log2(i)
+    d = uniform(i)
+    assert H(d) == pytest.approx(np.log2(i))
 
-def test_H7():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_H7(i):
     """ Test H for uniform distributions using SDs in various bases """
-    for i in range(2, 10):
-        d = uniform(i)
-        d.set_base(i)
-        yield assert_almost_equal, H(d), 1
+    d = uniform(i)
+    d.set_base(i)
+    assert H(d) == pytest.approx(1)

--- a/dit/multivariate/tests/test_exact_common_information.py
+++ b/dit/multivariate/tests/test_exact_common_information.py
@@ -4,8 +4,7 @@ Tests for dit.multivariate.exact_common_information
 
 from __future__ import division
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import Distribution as D
 from dit.multivariate import exact_common_information as G
@@ -19,27 +18,37 @@ xor = D(outcomes, pmf)
 sbec = lambda p: D(['00', '0e', '1e', '11'], [(1-p)/2, p/2, p/2, (1-p)/2])
 G_sbec = lambda p: min(1, entropy(p) + 1 - p)
 
-@attr('scipy')
-@attr('slow')
-def test_eci1():
+
+pytest.importorskip('scipy')
+
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize(('rvs', 'crvs', 'val'), [
+    (None, None, 2.0),
+    ([[0], [1], [2]], None, 2.0),
+    ([[0], [1]], [2, 3], 1.0),
+    ([[0], [1]], [2], 1.0),
+    ([[0], [1]], None, 0.0),
+])
+def test_eci1(rvs, crvs, val):
     """
     Test against known values.
     """
-    assert_almost_equal(G(xor), 2.0, places=4)
-    assert_almost_equal(G(xor, [[0], [1], [2]]), 2.0, places=4)
-    assert_almost_equal(G(xor, [[0], [1]], [2, 3]), 1.0, places=4)
-    assert_almost_equal(G(xor, [[0], [1]], [2]), 1.0, places=4)
-    assert_almost_equal(G(xor, [[0], [1]]), 0.0, places=4)
+    assert G(xor, rvs, crvs) == pytest.approx(val, abs=1e-4)
 
-@attr('scipy')
-@attr('slow')
-def test_eci2():
+@pytest.fixture
+def x0():
+    return {'x0': None}
+
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize('i', range(1, 10))
+def test_eci2(i, x0):
     """
     Test the binary symmetric erasure channel.
     """
-    x0 = None
-    for p in [i/10 for i in range(1, 10)]:
-        eci = ExactCommonInformation(sbec(p))
-        eci.optimize(x0=x0, nhops=10)
-        x0 = eci._optima
-        yield assert_almost_equal, eci.objective(eci._optima), G_sbec(p), 4
+    p = i/10
+    eci = ExactCommonInformation(sbec(p))
+    eci.optimize(x0=x0['x0'], nhops=5)
+    x0['x0'] = eci._optima
+    assert eci.objective(eci._optima) == pytest.approx(G_sbec(p), abs=1e-4)

--- a/dit/multivariate/tests/test_functional_common_information.py
+++ b/dit/multivariate/tests/test_functional_common_information.py
@@ -4,8 +4,7 @@ Tests for dit.multivariate.functional_common_information.
 
 from __future__ import division
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_almost_equal, assert_less_equal
+import pytest
 
 from dit import Distribution, random_distribution
 from dit.multivariate import (functional_common_information as F,
@@ -18,9 +17,9 @@ def test_fci1():
     Test known values.
     """
     d = Distribution(['000', '011', '101', '110'], [1/4]*4)
-    assert_almost_equal(F(d), 2.0)
-    assert_almost_equal(F(d, [[0], [1]]), 0.0)
-    assert_almost_equal(F(d, [[0], [1]], [2]), 1.0)
+    assert F(d) == pytest.approx(2.0)
+    assert F(d, [[0], [1]]) == pytest.approx(0.0)
+    assert F(d, [[0], [1]], [2]) == pytest.approx(1.0)
 
 def test_fci2():
     """
@@ -28,9 +27,9 @@ def test_fci2():
     """
     d = Distribution(['000', '011', '101', '110'], [1/4]*4)
     d.set_rv_names('XYZ')
-    assert_almost_equal(F(d), 2.0)
-    assert_almost_equal(F(d, [[0], [1]]), 0.0)
-    assert_almost_equal(F(d, [[0], [1]], [2]), 1.0)
+    assert F(d) == pytest.approx(2.0)
+    assert F(d, [[0], [1]]) == pytest.approx(0.0)
+    assert F(d, [[0], [1]], [2]) == pytest.approx(1.0)
 
 def test_fci3():
     """
@@ -54,4 +53,4 @@ def test_fci3():
                 'b1c',]
     pmf = [1/16]*16
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(F(d), 2.0)
+    assert F(d) == pytest.approx(2.0)

--- a/dit/multivariate/tests/test_gk_common_information.py
+++ b/dit/multivariate/tests/test_gk_common_information.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.gk_common_information.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import Distribution
 from dit.multivariate import gk_common_information as K
@@ -14,52 +14,52 @@ def test_K1():
     outcomes = ['00', '11']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(K(d), 1.0)
-    assert_almost_equal(K(d, [[0], [1]]), 1.0)
+    assert K(d) == pytest.approx(1.0)
+    assert K(d, [[0], [1]]) == pytest.approx(1.0)
     d.set_rv_names("XY")
-    assert_almost_equal(K(d, [['X'], ['Y']]), 1.0)
+    assert K(d, [['X'], ['Y']]) == pytest.approx(1.0)
 
 def test_K2():
     """ Test conditional K for dependent events """
     outcomes = ['00', '11']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(K(d, [[0], [1]], [0]), 0.0)
-    assert_almost_equal(K(d, [[0], [1]], [1]), 0.0)
+    assert K(d, [[0], [1]], [0]) == pytest.approx(0.0)
+    assert K(d, [[0], [1]], [1]) == pytest.approx(0.0)
     d.set_rv_names("XY")
-    assert_almost_equal(K(d, [['X'], ['Y']], ['X']), 0.0)
-    assert_almost_equal(K(d, [['X'], ['Y']], ['Y']), 0.0)
+    assert K(d, [['X'], ['Y']], ['X']) == pytest.approx(0.0)
+    assert K(d, [['X'], ['Y']], ['Y']) == pytest.approx(0.0)
 
 def test_K3():
     """ Test K for mixed events """
     outcomes = ['00', '01', '11']
     pmf = [1/3, 1/3, 1/3]
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(K(d), 0.0)
-    assert_almost_equal(K(d, [[0], [1]]), 0.0)
+    assert K(d) == pytest.approx(0.0)
+    assert K(d, [[0], [1]]) == pytest.approx(0.0)
     d.set_rv_names("XY")
-    assert_almost_equal(K(d, [['X'], ['Y']]), 0.0)
+    assert K(d, [['X'], ['Y']]) == pytest.approx(0.0)
 
 def test_K4():
     """ Test K in a canonical example """
     outcomes = ['00', '01', '10', '11', '22', '33']
     pmf = [1/8, 1/8, 1/8, 1/8, 1/4, 1/4]
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(K(d), 1.5)
-    assert_almost_equal(K(d, [[0], [1]]), 1.5)
+    assert K(d) == pytest.approx(1.5)
+    assert K(d, [[0], [1]]) == pytest.approx(1.5)
     d.set_rv_names("XY")
-    assert_almost_equal(K(d, [['X'], ['Y']]), 1.5)
+    assert K(d, [['X'], ['Y']]) == pytest.approx(1.5)
 
 def test_K5():
     """ Test K on subvariables and conditionals """
     outcomes = ['000', '010', '100', '110', '221', '331']
     pmf = [1/8, 1/8, 1/8, 1/8, 1/4, 1/4]
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(K(d, [[0], [1]]), 1.5)
-    assert_almost_equal(K(d), 1.0)
-    assert_almost_equal(K(d, [[0], [1], [2]]), 1.0)
+    assert K(d, [[0], [1]]) == pytest.approx(1.5)
+    assert K(d) == pytest.approx(1.0)
+    assert K(d, [[0], [1], [2]]) == pytest.approx(1.0)
     d.set_rv_names("XYZ")
-    assert_almost_equal(K(d, [['X'], ['Y']]), 1.5)
-    assert_almost_equal(K(d, [['X'], ['Y'], ['Z']]), 1.0)
-    assert_almost_equal(K(d, ['X', 'Y'], ['Z']), 0.5)
-    assert_almost_equal(K(d, ['XY', 'YZ']), 2.0)
+    assert K(d, [['X'], ['Y']]) == pytest.approx(1.5)
+    assert K(d, [['X'], ['Y'], ['Z']]) == pytest.approx(1.0)
+    assert K(d, ['X', 'Y'], ['Z']) == pytest.approx(0.5)
+    assert K(d, ['XY', 'YZ']) == pytest.approx(2.0)

--- a/dit/multivariate/tests/test_interaction_information.py
+++ b/dit/multivariate/tests/test_interaction_information.py
@@ -4,34 +4,34 @@ Tests for dit.multivariate.interaction_information.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import Distribution as D
 from dit.multivariate import interaction_information, coinformation
 from dit.example_dists import Xor
 
-def test_ii1():
+@pytest.mark.parametrize('i', range(2, 6))
+def test_ii1(i):
     """ Test II for giant bit distributions """
-    for i in range(2, 6):
-        outcomes = ['0'*i, '1'*i]
-        pmf = [1/2, 1/2]
-        d = D(outcomes, pmf)
-        yield assert_almost_equal, interaction_information(d), (-1)**i
+    outcomes = ['0'*i, '1'*i]
+    pmf = [1/2, 1/2]
+    d = D(outcomes, pmf)
+    assert interaction_information(d) == pytest.approx((-1)**i)
 
-def test_ii2():
+@pytest.mark.parametrize('i', range(2, 6))
+def test_ii2(i):
     """ Test II = -1^n * I for giant bit distributions """
-    for i in range(2, 6):
-        outcomes = ['0'*i, '1'*i]
-        pmf = [1/2, 1/2]
-        d = D(outcomes, pmf)
-        ci = coinformation(d)
-        ii = interaction_information(d)
-        yield assert_almost_equal, ii, (-1)**i * ci
+    outcomes = ['0'*i, '1'*i]
+    pmf = [1/2, 1/2]
+    d = D(outcomes, pmf)
+    ci = coinformation(d)
+    ii = interaction_information(d)
+    assert ii == pytest.approx((-1)**i * ci)
 
 def test_ii3():
     """ Test II and conditional II for xor """
     d = Xor()
     ii1 = interaction_information(d, [[0], [1], [2]], [2])
     ii2 = interaction_information(d, [[0], [1]], [2])
-    assert_almost_equal(ii1, 0)
-    assert_almost_equal(ii2, 1)
+    assert ii1 == pytest.approx(0)
+    assert ii2 == pytest.approx(1)

--- a/dit/multivariate/tests/test_intrinsic_mutual_information.py
+++ b/dit/multivariate/tests/test_intrinsic_mutual_information.py
@@ -3,7 +3,7 @@ Tests for dit.multivariate.intrinsic_mutual_information
 """
 from __future__ import division
 
-from nose.tools import assert_almost_equal, raises
+import pytest
 
 import numpy as np
 
@@ -26,46 +26,51 @@ dist5 = Distribution(['0000', '0011', '0101', '0110', '1001', '1010', '1100', '1
 dist6 = Distribution(['0000', '0011', '0101', '0110', '1001', '1010', '1100', '1111'], [1/8]*8)
 dist6.set_rv_names('WXYZ')
 
+@pytest.mark.flaky(reruns=5)
 def test_itc1():
     """
     Test against standard result.
     """
     itc = intrinsic_total_correlation(dist1, [[0], [1]], [2])
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist1, [[0], [2]], [1])
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist1, [[1], [2]], [0])
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist3, [[0,1], [2]], [3, 4])
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_itc2():
     """
     Test against standard result, with rv names.
     """
     itc = intrinsic_total_correlation(dist2, ['X', 'Y'], 'Z')
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist2, ['X', 'Z'], 'Y')
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist2, ['Y', 'Z'], 'X')
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
     itc = intrinsic_total_correlation(dist4, ['VW', 'X'], 'YZ')
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_itc3():
     """
     Test multivariate
     """
     itc = intrinsic_total_correlation(dist5, [[0], [1], [2]], [3])
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_itc4():
     """
     Test multivariate, with rv names
     """
     itc = intrinsic_total_correlation(dist6, ['W', 'X', 'Y'], 'Z')
-    assert_almost_equal(itc, 0)
+    assert itc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_itc5():
     """
     Test with initial condition.
@@ -75,100 +80,109 @@ def test_itc5():
     d = itc.construct_distribution()
     print(d)
     val = total_correlation(d, [[0], [1]], [3])
-    assert_almost_equal(val, 0)
+    assert val == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_idtc1():
     """
     Test against standard result.
     """
     idtc = intrinsic_dual_total_correlation(dist1, [[0], [1]], [2])
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist1, [[0], [2]], [1])
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist1, [[1], [2]], [0])
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist3, [[0,1], [2]], [3, 4])
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_idtc2():
     """
     Test against standard result, with rv names.
     """
     idtc = intrinsic_dual_total_correlation(dist2, ['X', 'Y'], 'Z')
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist2, ['X', 'Z'], 'Y')
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist2, ['Y', 'Z'], 'X')
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
     idtc = intrinsic_dual_total_correlation(dist4, ['VW', 'X'], 'YZ')
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_idtc3():
     """
     Test multivariate
     """
     idtc = intrinsic_dual_total_correlation(dist5, [[0], [1], [2]], [3])
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_idtc4():
     """
     Test multivariate, with rv names
     """
     idtc = intrinsic_dual_total_correlation(dist6, ['W', 'X', 'Y'], 'Z')
-    assert_almost_equal(idtc, 0)
+    assert idtc == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_icmi1():
     """
     Test against standard result.
     """
     icmi = intrinsic_caekl_mutual_information(dist1, [[0], [1]], [2])
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist1, [[0], [2]], [1])
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist1, [[1], [2]], [0])
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist3, [[0,1], [2]], [3, 4])
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_icmi2():
     """
     Test against standard result, with rv names.
     """
     icmi = intrinsic_caekl_mutual_information(dist2, ['X', 'Y'], 'Z')
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist2, ['X', 'Z'], 'Y')
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist2, ['Y', 'Z'], 'X')
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
     icmi = intrinsic_caekl_mutual_information(dist4, ['VW', 'X'], 'YZ')
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_icmi3():
     """
     Test multivariate
     """
     icmi = intrinsic_caekl_mutual_information(dist5, [[0], [1], [2]], [3])
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_icmi4():
     """
     Test multivariate, with rv names
     """
     icmi = intrinsic_caekl_mutual_information(dist6, ['W', 'X', 'Y'], 'Z')
-    assert_almost_equal(icmi, 0)
+    assert icmi == pytest.approx(0)
 
+@pytest.mark.flaky(reruns=5)
 def test_constructor():
     """
     Test the generic constructor.
     """
     test = intrinsic_mutual_information(total_correlation).functional()
-    itc = intrinsic_total_correlation(dist1, [[0], [1]], [2], nhops=16)
-    itc2 = test(dist1, [[0], [1]], [2], nhops=16)
-    assert_almost_equal(itc, itc2, places=4)
+    itc = intrinsic_total_correlation(dist1, [[0], [1]], [2], nhops=5)
+    itc2 = test(dist1, [[0], [1]], [2], nhops=5)
+    assert itc == pytest.approx(itc2, abs=1e-4)
 
-@raises(ditException)
 def test_imi_fail():
     """
     Test that things fail when not provided with a conditional variable.
     """
-    intrinsic_total_correlation(dist1, [[0], [1], [2]])
+    with pytest.raises(ditException):
+        intrinsic_total_correlation(dist1, [[0], [1], [2]])

--- a/dit/multivariate/tests/test_mss_common_information.py
+++ b/dit/multivariate/tests/test_mss_common_information.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.joint_mss.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import Distribution
 from dit.multivariate import mss_common_information as M
@@ -29,7 +29,7 @@ def test_M1():
                 'b1c',]
     pmf = [1/16]*16
     d = Distribution(outcomes, pmf)
-    assert_almost_equal(M(d), 2.0)
+    assert M(d) == pytest.approx(2.0)
 
 def test_M2():
     """ Test M with rv names """
@@ -52,4 +52,4 @@ def test_M2():
     pmf = [1/16]*16
     d = Distribution(outcomes, pmf)
     d.set_rv_names('XYZ')
-    assert_almost_equal(M(d), 2.0)
+    assert M(d) == pytest.approx(2.0)

--- a/dit/multivariate/tests/test_mutual_informations.py
+++ b/dit/multivariate/tests/test_mutual_informations.py
@@ -2,7 +2,7 @@
 Tests for the various mutual informations.
 """
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import random_distribution
 from dit.multivariate import (coinformation as I,
@@ -12,17 +12,17 @@ from dit.multivariate import (coinformation as I,
                               interaction_information as II,
                              )
 
-def test_mis1():
+@pytest.mark.parametrize('d', [random_distribution(2, 4) for _ in range(10)])
+def test_mis1(d):
     """
     Test that all the mutual informations match for bivariate distributions.
     """
-    for d in [random_distribution(2, 4) for _ in range(10)]:
-        i = I(d)
-        t = T(d)
-        b = B(d)
-        j = J(d)
-        ii = II(d)
-        yield assert_almost_equal, i, t
-        yield assert_almost_equal, t, b
-        yield assert_almost_equal, b, j
-        yield assert_almost_equal, j, ii
+    i = I(d)
+    t = T(d)
+    b = B(d)
+    j = J(d)
+    ii = II(d)
+    assert i == pytest.approx(t)
+    assert t == pytest.approx(b)
+    assert b == pytest.approx(j)
+    assert j == pytest.approx(ii)

--- a/dit/multivariate/tests/test_total_correlation.py
+++ b/dit/multivariate/tests/test_total_correlation.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.total_correlation.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 from dit import Distribution as D, ScalarDistribution as SD
 from dit.exceptions import ditException
@@ -12,57 +12,59 @@ from dit.multivariate import total_correlation as T
 from dit.shannon import mutual_information as I
 from dit.example_dists import n_mod_m
 
-def test_tc1():
+
+@pytest.mark.parametrize('n', range(3, 7))
+def test_tc1(n):
     """ Test T of parity distributions """
-    for n in range(3, 7):
-        d = n_mod_m(n, 2)
-        yield assert_almost_equal, T(d), 1.0
+    d = n_mod_m(n, 2)
+    assert T(d) == pytest.approx(1.0)
 
 def test_tc2():
     """ Test T of subvariables, with names """
     d = n_mod_m(4, 2)
-    assert_almost_equal(T(d, [[0], [1], [2]]), 0.0)
+    assert T(d, [[0], [1], [2]]) == pytest.approx(0.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(T(d, [['X'], ['Y'], ['Z']]), 0.0)
+    assert T(d, [['X'], ['Y'], ['Z']]) == pytest.approx(0.0)
 
 def test_tc3():
     """ Test conditional T """
     d = n_mod_m(4, 2)
-    assert_almost_equal(T(d, [[0], [1], [2]], [3]), 1.0)
+    assert T(d, [[0], [1], [2]], [3]) == pytest.approx(1.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(T(d, [['X'], ['Y'], ['Z']], ['W']), 1.0)
+    assert T(d, [['X'], ['Y'], ['Z']], ['W']) == pytest.approx(1.0)
 
 def test_tc4():
     """ Test conditional T """
     d = n_mod_m(4, 2)
-    assert_almost_equal(T(d, [[0], [1]], [2, 3]), 1.0)
+    assert T(d, [[0], [1]], [2, 3]) == pytest.approx(1.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(T(d, [['X'], ['Y']], ['Z', 'W']), 1.0)
+    assert T(d, [['X'], ['Y']], ['Z', 'W']) == pytest.approx(1.0)
 
 def test_tc5():
     """ Test T with subvariables """
     d = n_mod_m(4, 2)
-    assert_almost_equal(T(d, [[0, 1], [2], [3]]), 1.0)
+    assert T(d, [[0, 1], [2], [3]]) == pytest.approx(1.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(T(d, [['X', 'Y'], ['Z'], ['W']]), 1.0)
+    assert T(d, [['X', 'Y'], ['Z'], ['W']]) == pytest.approx(1.0)
 
 def test_tc6():
     """ Test T with overlapping subvariables """
     d = n_mod_m(4, 2)
-    assert_almost_equal(T(d, [[0, 1, 2], [1, 2, 3]]), 3.0)
+    assert T(d, [[0, 1, 2], [1, 2, 3]]) == pytest.approx(3.0)
     d.set_rv_names("XYZW")
-    assert_almost_equal(T(d, [['X', 'Y', 'Z'], ['Y', 'Z', 'W']]), 3.0)
+    assert T(d, [['X', 'Y', 'Z'], ['Y', 'Z', 'W']]) == pytest.approx(3.0)
 
 def test_tc7():
     """ Test T = I with two variables """
     outcomes = ['00', '01', '11']
     pmf = [1/3] * 3
     d = D(outcomes, pmf)
-    assert_almost_equal(T(d), I(d, [0], [1]))
+    assert T(d) == pytest.approx(I(d, [0], [1]))
     d.set_rv_names("XY")
-    assert_almost_equal(T(d), I(d, ['X'], ['Y']))
+    assert T(d) == pytest.approx(I(d, ['X'], ['Y']))
 
 def test_tc8():
     """ Test that T fails on SDs """
     d = SD([1/3]*3)
-    assert_raises(ditException, T, d)
+    with pytest.raises(ditException):
+        T(d)

--- a/dit/multivariate/tests/test_tse_complexity.py
+++ b/dit/multivariate/tests/test_tse_complexity.py
@@ -4,7 +4,7 @@ Tests for dit.multivariate.tse_complexity.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from iterutils import powerset
 
@@ -13,18 +13,18 @@ from dit.multivariate import binding_information as B, tse_complexity as TSE
 from dit.example_dists import n_mod_m
 from dit.math.misc import combinations as nCk
 
-def test_tse1():
+@pytest.mark.parametrize(('i', 'j'), list(zip(range(3, 6), range(2, 5))))
+def test_tse1(i, j):
     """ Test identity comparing TSE to B from Olbrich's talk """
-    for i, j in zip(range(3, 6), range(2, 5)):
-        d = n_mod_m(i, j)
-        indices = [[k] for k in range(i)]
-        tse = TSE(d)
-        x = 1/2 * sum(B(d, rv)/nCk(i, len(rv)) for rv in powerset(indices))
-        yield assert_almost_equal, tse, x
+    d = n_mod_m(i, j)
+    indices = [[k] for k in range(i)]
+    tse = TSE(d)
+    x = 1/2 * sum(B(d, rv)/nCk(i, len(rv)) for rv in powerset(indices))
+    assert tse == pytest.approx(x)
 
-def test_tse2():
+@pytest.mark.parametrize('n', range(2, 7))
+def test_tse2(n):
     """ Test TSE for giant bit distributions """
-    for n in range(2, 7):
-        d = D(['0'*n, '1'*n], [1/2, 1/2])
-        tse = TSE(d)
-        yield assert_almost_equal, tse, (n-1)/2
+    d = D(['0'*n, '1'*n], [1/2, 1/2])
+    tse = TSE(d)
+    assert tse == pytest.approx((n-1)/2)

--- a/dit/multivariate/tests/test_wyner_common_information.py
+++ b/dit/multivariate/tests/test_wyner_common_information.py
@@ -3,10 +3,7 @@ Tests for dit.multivariate.wyner_common_information
 """
 
 from __future__ import division
-
-from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
-from nose.tools import assert_almost_equal, assert_true
+import pytest
 
 from dit import Distribution as D
 from dit.multivariate import wyner_common_information as C
@@ -20,19 +17,25 @@ xor = D(outcomes, pmf)
 sbec = lambda p: D(['00', '0e', '1e', '11'], [(1-p)/2, p/2, p/2, (1-p)/2])
 C_sbec = lambda p: 1 if p < 1/2 else entropy(p)
 
-@attr('scipy')
-@attr('slow')
-def test_wci1():
+
+pytest.importorskip('scipy')
+
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize(('rvs', 'crvs', 'val'), [
+    (None, None, 2.0),
+    ([[0], [1], [2]], None, 2.0),
+    ([[0], [1]], [2, 3], 1.0),
+    ([[0], [1]], [2], 1.0),
+    ([[0], [1]], None, 0.0),
+])
+def test_wci1(rvs, crvs, val):
     """
     Test against known values.
     """
-    assert_almost_equal(C(xor), 2.0, places=4)
-    assert_almost_equal(C(xor, [[0], [1], [2]]), 2.0, places=4)
-    assert_almost_equal(C(xor, [[0], [1]], [2, 3]), 1.0, places=4)
-    assert_almost_equal(C(xor, [[0], [1]], [2]), 1.0, places=4)
-    assert_almost_equal(C(xor, [[0], [1]]), 0.0, places=4)
+    assert C(xor, rvs, crvs) == pytest.approx(val, abs=1e-4)
 
-@attr('scipy')
+@pytest.mark.flaky(reruns=5)
 def test_wci2():
     """
     Test the golden mean.
@@ -47,32 +50,34 @@ def test_wci2():
     d_opt4 = D([(0,0,1), (0,0,0), (0,1,0), (1,0,1)], [1/6, 1/6, 1/3, 1/3])
     d_opts = [d_opt1, d_opt2, d_opt3, d_opt4]
     equal = lambda d1, d2: d1.is_approx_equal(d2, rtol=1e-4, atol=1e-4)
-    assert_true(any(equal(d, d_opt) for d_opt in d_opts))
-    assert_almost_equal(wci.objective(wci._optima), 2/3, places=5)
+    assert any(equal(d, d_opt) for d_opt in d_opts)
+    assert wci.objective(wci._optima) == pytest.approx(2/3, abs=1e-5)
 
-@attr('scipy')
-@attr('slow')
+@pytest.mark.slow
+@pytest.mark.skip(reason="Jacobian doesn't seem to work well right now.")
 def test_wci3():
     """
     Test with jacobian=True
     """
-    # jacobian doesn't seem to work well right now
-    raise SkipTest
     d = D([(0,0), (1,1)], [2/3, 1/3])
     wci = WynerCommonInformation(d)
     wci.optimize(minimize=True, jacobian=True)
     d_opt = D([(0,0,0), (1,1,1)], [2/3, 1/3])
-    assert_true(d_opt.is_approx_equal(wci.construct_distribution()))
+    assert d_opt.is_approx_equal(wci.construct_distribution())
 
-@attr('scipy')
-@attr('slow')
-def test_wci4():
+@pytest.fixture
+def x0():
+    return {'x0': None}
+
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize('i', range(1, 10))
+def test_wci4(i, x0):
     """
     Test the binary symmetric erasure channel.
     """
-    x0 = None
-    for p in [i/10 for i in range(1, 10)]:
-        wci = WynerCommonInformation(sbec(p))
-        wci.optimize(x0=x0, nhops=10)
-        x0 = wci._optima
-        yield assert_almost_equal, wci.objective(wci._optima), C_sbec(p), 4
+    p = i/10
+    wci = WynerCommonInformation(sbec(p))
+    wci.optimize(x0=x0['x0'], nhops=5)
+    x0['x0'] = wci._optima
+    assert wci.objective(wci._optima) == pytest.approx(C_sbec(p), abs=1e-4)

--- a/dit/other/tests/test_cumulative_residual_entropy.py
+++ b/dit/other/tests/test_cumulative_residual_entropy.py
@@ -4,12 +4,13 @@ Tests for dit.others.cumulative_residual_entropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
-from numpy.testing import assert_array_almost_equal
+import pytest
 
 from six.moves import range # pylint: disable=redefined-builtin
 
 from itertools import combinations, product
+
+import numpy as np
 
 from dit import (ScalarDistribution as SD,
                  Distribution as D)
@@ -39,74 +40,78 @@ def conditional_uniform2():
     d = D(events, probs)
     return d
 
-def test_cre_1():
+@pytest.mark.parametrize(('n', 'val'), zip(range(2, 23, 2),[0.5, 0.81127812, 1.15002242, 1.49799845,
+                                                            1.85028649, 2.20496373, 2.56111354,
+                                                            2.91823997, 3.27604979, 3.6343579,
+                                                            3.99304129]))
+def test_cre_1(n, val):
     """
     Test the CRE against known values for several uniform distributions.
     """
-    dists = [ uniform(-n//2, n//2) for n in range(2, 23, 2) ]
-    results = [0.5, 0.81127812, 1.15002242, 1.49799845, 1.85028649, 2.20496373,
-               2.56111354, 2.91823997, 3.27604979, 3.6343579, 3.99304129]
-    for d, r in zip(dists, results):
-        yield assert_almost_equal, r, CRE(d)
+    dist = uniform(-n//2, n//2)
+    assert CRE(dist) == pytest.approx(val)
 
 def test_cre_2():
     """
     Test the CRE of a multivariate distribution (CRE is of each marginal).
     """
     d = miwin()
-    assert_array_almost_equal(CRE(d), [3.34415526, 3.27909534, 2.56831826])
+    assert np.allclose(CRE(d), [3.34415526, 3.27909534, 2.56831826])
 
 def test_cre_3():
     """
     Test that the CRE fails when the events are not numbers.
     """
     dist = Xor()
-    assert_raises(TypeError, CRE, dist)
+    with pytest.raises(TypeError):
+        CRE(dist)
 
-def test_gcre_1():
+@pytest.mark.parametrize(('n', 'val'), zip(range(2, 23, 2),[0.5, 1.31127812, 2.06831826, 2.80927657,
+                                                            3.54316518, 4.27328199, 5.00113503,
+                                                            5.72751654, 6.45288453, 7.17752308,
+                                                            7.90161817]))
+def test_gcre_1(n, val):
     """
     Test the GCRE against known values for the uniform distribution.
     """
-    dists = [ uniform(-n//2, n//2) for n in range(2, 23, 2) ]
-    results = [0.5, 1.31127812, 2.06831826, 2.80927657, 3.54316518, 4.27328199,
-               5.00113503, 5.72751654, 6.45288453, 7.17752308, 7.90161817]
-    for d, r in zip(dists, results):
-        yield assert_almost_equal, r, GCRE(d)
+    dist = uniform(-n//2, n//2)
+    assert GCRE(dist) == pytest.approx(val)
 
 def test_gcre_32():
     """
     Test the GCRE of a multivariate distribution.
     """
     d = miwin()
-    assert_array_almost_equal(GCRE(d), [3.34415526, 3.27909534, 2.56831826])
+    assert np.allclose(GCRE(d), [3.34415526, 3.27909534, 2.56831826])
 
 def test_gcre_3():
     """
     Test that the GCRE fails on non-numeric events.
     """
     dist = Xor()
-    assert_raises(TypeError, GCRE, dist)
+    with pytest.raises(TypeError):
+        GCRE(dist)
 
-def test_gcre_4():
+@pytest.mark.parametrize('i', range(-5, 1))
+def test_gcre_4(i):
     """
     Test that equal-length uniform distributions all have the same GCRE.
     """
-    gcres = [ GCRE(uniform(i, i+5)) for i in range(-5, 1) ]
-    for gcre in gcres:
-        yield assert_almost_equal, gcre, gcres[0]
+    gcre = GCRE(uniform(i, i+5))
+    assert gcre == pytest.approx(GCRE(uniform(-5, 0)))
 
-def test_ccre_1():
+@pytest.mark.parametrize('crvs', combinations([0, 1, 2], 2))
+def test_ccre_1(crvs):
     """
     Test that independent RVs have CCRE = CRE.
     """
     d = miwin()
-    for crvs in combinations([0, 1, 2], 2):
-        rv = (set([0, 1, 2]) - set(crvs)).pop()
-        ccre1 = CCRE(d, rv, crvs)
-        ccre2 = CCRE(d, rv)
-        yield assert_almost_equal, CRE(d)[rv], mean(ccre1)
-        yield assert_almost_equal, CRE(d)[rv], mean(ccre2)
-        yield assert_almost_equal, standard_deviation(ccre1), 0
+    rv = (set([0, 1, 2]) - set(crvs)).pop()
+    ccre1 = CCRE(d, rv, crvs)
+    ccre2 = CCRE(d, rv)
+    assert CRE(d)[rv] == pytest.approx(mean(ccre1))
+    assert CRE(d)[rv] == pytest.approx(mean(ccre2))
+    assert standard_deviation(ccre1) == pytest.approx(0)
 
 def test_ccre_2():
     """
@@ -115,7 +120,7 @@ def test_ccre_2():
     d = conditional_uniform1()
     ccre = CCRE(d, 1, [0])
     uniforms = [ CRE(uniform(i)) for i in range(1, 6) ]
-    assert_array_almost_equal(ccre.outcomes, uniforms)
+    assert np.allclose(ccre.outcomes, uniforms)
 
 def test_ccre_3():
     """
@@ -124,7 +129,7 @@ def test_ccre_3():
     d = conditional_uniform2()
     ccre = CCRE(d, 1, [0])
     uniforms = sorted([ CRE(uniform(i-2, 3)) for i in range(5) ])
-    assert_array_almost_equal(ccre.outcomes, uniforms)
+    assert np.allclose(ccre.outcomes, uniforms)
 
 def test_cgcre_1():
     """
@@ -133,17 +138,17 @@ def test_cgcre_1():
     d = conditional_uniform2()
     cgcre = CGCRE(d, 1, [0])
     uniforms = [ GCRE(uniform(i)) for i in range(1, 6) ]
-    assert_array_almost_equal(cgcre.outcomes, uniforms)
+    assert np.allclose(cgcre.outcomes, uniforms)
 
-def test_cgcre_2():
+@pytest.mark.parametrize('crvs', combinations([0, 1, 2], 2))
+def test_cgcre_2(crvs):
     """
     Test that independent RVs have CGCRE = GCRE.
     """
     d = miwin()
-    for crvs in combinations([0, 1, 2], 2):
-        rv = (set([0, 1, 2]) - set(crvs)).pop()
-        ccre1 = CGCRE(d, rv, crvs)
-        ccre2 = CGCRE(d, rv)
-        yield assert_almost_equal, GCRE(d)[rv], mean(ccre1)
-        yield assert_almost_equal, GCRE(d)[rv], mean(ccre2)
-        yield assert_almost_equal, standard_deviation(ccre1), 0
+    rv = (set([0, 1, 2]) - set(crvs)).pop()
+    ccre1 = CGCRE(d, rv, crvs)
+    ccre2 = CGCRE(d, rv)
+    assert GCRE(d)[rv] == pytest.approx(mean(ccre1))
+    assert GCRE(d)[rv] == pytest.approx(mean(ccre2))
+    assert standard_deviation(ccre1) == pytest.approx(0)

--- a/dit/other/tests/test_disequilibrium.py
+++ b/dit/other/tests/test_disequilibrium.py
@@ -6,7 +6,7 @@ from __future__ import division
 
 from itertools import combinations
 
-from nose.tools import assert_almost_equal, assert_true, assert_greater
+import pytest
 
 from dit import Distribution, ScalarDistribution
 from dit.example_dists import uniform
@@ -22,52 +22,52 @@ def test_disequilibrium1():
     """
     dis1 = disequilibrium(d1)
     dis2 = disequilibrium(d2)
-    assert_almost_equal(dis1, 0.43418979240387018)
-    assert_almost_equal(dis2, 0.43418979240387018)
-    assert_almost_equal(dis1, dis2)
+    assert dis1 == pytest.approx(0.43418979240387018)
+    assert dis2 == pytest.approx(0.43418979240387018)
+    assert dis1 == pytest.approx(dis2)
 
 def test_disequilibrium2():
     """
     Test that while the XOR distribution has non-zero disequilibrium, all its
     marginals have zero disequilibrium (are uniform).
     """
-    assert_true(disequilibrium(d2) > 0)
+    assert disequilibrium(d2) > 0
     for rvs in combinations(flatten(d2.rvs), 2):
-        assert_almost_equal(disequilibrium(d2, rvs), 0)
+        assert disequilibrium(d2, rvs) == pytest.approx(0)
 
-def test_disequilibrium3():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_disequilibrium3(n):
     """
     Test that uniform ScalarDistributions have zero disequilibrium.
     """
-    for n in range(2, 11):
-        d = uniform(n)
-        yield assert_almost_equal, disequilibrium(d), 0
+    d = uniform(n)
+    assert disequilibrium(d) == pytest.approx(0)
 
-def test_disequilibrium4():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_disequilibrium4(n):
     """
     Test that uniform Distributions have zero disequilibrium.
     """
-    for n in range(2, 11):
-        d = Distribution.from_distribution(uniform(n))
-        yield assert_almost_equal, disequilibrium(d), 0
+    d = Distribution.from_distribution(uniform(n))
+    assert disequilibrium(d) == pytest.approx(0)
 
-def test_disequilibrium5():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_disequilibrium5(n):
     """
     Test that peaked ScalarDistributions have non-zero disequilibrium.
     """
-    for n in range(2, 11):
-        d = ScalarDistribution([1] + [0]*(n-1))
-        yield assert_greater, disequilibrium(d), 0
+    d = ScalarDistribution([1] + [0]*(n-1))
+    assert disequilibrium(d) >= 0
 
-def test_disequilibrium6():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_disequilibrium6(n):
     """
     Test that peaked Distributions have non-zero disequilibrium.
     """
-    for n in range(2, 11):
-        d = ScalarDistribution([1] + [0]*(n-1))
-        d.make_dense()
-        d = Distribution.from_distribution(d)
-        yield assert_greater, disequilibrium(d), 0
+    d = ScalarDistribution([1] + [0]*(n-1))
+    d.make_dense()
+    d = Distribution.from_distribution(d)
+    assert disequilibrium(d) >= 0
 
 def test_LMPR_complexity1():
     """
@@ -75,40 +75,40 @@ def test_LMPR_complexity1():
     """
     c1 = LMPR_complexity(d1)
     c2 = LMPR_complexity(d2)
-    assert_almost_equal(c1, 0.28945986160258008)
-    assert_almost_equal(c2, 0.28945986160258008)
-    assert_almost_equal(c1, c2)
+    assert c1 == pytest.approx(0.28945986160258008)
+    assert c2 == pytest.approx(0.28945986160258008)
+    assert c1 == pytest.approx(c2)
 
-def test_LMPR_complexity2():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_LMPR_complexity2(n):
     """
     Test that uniform ScalarDistirbutions have zero complexity.
     """
-    for n in range(2, 11):
-        d = uniform(n)
-        yield assert_almost_equal, LMPR_complexity(d), 0
+    d = uniform(n)
+    assert LMPR_complexity(d) == pytest.approx(0)
 
-def test_LMPR_complexity3():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_LMPR_complexity3(n):
     """
     Test that uniform Distirbutions have zero complexity.
     """
-    for n in range(2, 11):
-        d = Distribution.from_distribution(uniform(n))
-        yield assert_almost_equal, LMPR_complexity(d), 0
+    d = Distribution.from_distribution(uniform(n))
+    assert LMPR_complexity(d) == pytest.approx(0)
 
-def test_LMPR_complexity4():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_LMPR_complexity4(n):
     """
     Test that peaked ScalarDistributions have zero complexity.
     """
-    for n in range(2, 11):
-        d = ScalarDistribution([1] + [0]*(n-1))
-        yield assert_almost_equal, LMPR_complexity(d), 0
+    d = ScalarDistribution([1] + [0]*(n-1))
+    assert LMPR_complexity(d) == pytest.approx(0)
 
-def test_LMPR_complexity4():
+@pytest.mark.parametrize('n', range(2, 11))
+def test_LMPR_complexity4(n):
     """
     Test that peaked Distributions have zero complexity.
     """
-    for n in range(2, 11):
-        d = ScalarDistribution([1] + [0]*(n-1))
-        d.make_dense()
-        d = Distribution.from_distribution(d)
-        yield assert_almost_equal, LMPR_complexity(d), 0
+    d = ScalarDistribution([1] + [0]*(n-1))
+    d.make_dense()
+    d = Distribution.from_distribution(d)
+    assert LMPR_complexity(d) == pytest.approx(0)

--- a/dit/other/tests/test_extropy.py
+++ b/dit/other/tests/test_extropy.py
@@ -4,7 +4,7 @@ Tests for dit.other.extropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_true
+import pytest
 
 import numpy as np
 
@@ -14,51 +14,51 @@ from dit.other import extropy as J
 
 def test_J1():
     """ Test that H = J for two probabilities """
-    assert_almost_equal(H(0.25), J(0.25))
+    assert H(0.25) == pytest.approx(J(0.25))
 
 def test_J2():
     """ Test a simple base case using ScalarDistribution """
     d = SD([1/2]*2)
-    assert_almost_equal(J(d), 1)
+    assert J(d) == pytest.approx(1)
 
 def test_J3():
     """ Test a simple base case using Distribution """
     d = D(['00', '11'], [1/2, 1/2])
-    assert_almost_equal(J(d), 1)
-    assert_almost_equal(J(d, [0, 1]), 1)
+    assert J(d) == pytest.approx(1)
+    assert J(d, [0, 1]) == pytest.approx(1)
 
-def test_J4():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_J4(i):
     """ Test a property of J from result 2 of the paper """
-    for i in range(2, 10):
-        d = SD([1/i]*i)
-        yield assert_almost_equal, J(d), (i-1)*(np.log2(i) - np.log2(i-1))
+    d = SD([1/i]*i)
+    assert J(d) == pytest.approx((i-1)*(np.log2(i) - np.log2(i-1)))
 
-def test_J5():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_J5(i):
     """ Test a property of J from result 2 of the paper with a log base """
-    for i in range(2, 10):
-        d = SD([1/i]*i)
-        d.set_base('e')
-        yield assert_almost_equal, J(d), (i-1)*(np.log(i)-np.log(i-1))
+    d = SD([1/i]*i)
+    d.set_base('e')
+    assert J(d) == pytest.approx((i-1)*(np.log(i)-np.log(i-1)))
 
-def test_J6():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_J6(i):
     """ Test a property of J from result 2 of the paper with base 10 """
-    for i in range(2, 10):
-        d = SD([1/i]*i)
-        d.set_base(10)
-        yield assert_almost_equal, J(d), (i-1)*(np.log10(i)-np.log10(i-1))
+    d = SD([1/i]*i)
+    d.set_base(10)
+    assert J(d) == pytest.approx((i-1)*(np.log10(i)-np.log10(i-1)))
 
-def test_J7():
+@pytest.mark.parametrize('i', range(3, 10))
+def test_J7(i):
     """ Test a property of J from result 1 of the paper """
-    for i in range(3, 10):
-        d = SD([1/i]*i)
-        yield assert_true, J(d) < H(d)
+    d = SD([1/i]*i)
+    assert J(d) < H(d)
 
-def test_J8():
+@pytest.mark.parametrize('i', range(3, 10))
+def test_J8(i):
     """ Test a property of J from result 1 of the paper using log bases """
-    for i in range(3, 10):
-        d = SD([1/i]*i)
-        d.set_base(i)
-        yield assert_true, J(d) < H(d)
+    d = SD([1/i]*i)
+    d.set_base(i)
+    assert J(d) < H(d)
 
 def test_J9():
     """ Test a property of J from result 4 of the paper """
@@ -66,7 +66,7 @@ def test_J9():
     j = J(d)
     h = H(d)
     s = sum(H(p) for p in d.pmf)
-    assert_almost_equal(j, s-h)
+    assert j == pytest.approx(s-h)
 
 def test_J10():
     """ Test a property of J from result 4 of the paper """
@@ -74,7 +74,7 @@ def test_J10():
     j = J(d)
     h = H(d)
     s = sum(J(p) for p in d.pmf)
-    assert_almost_equal(h, s-j)
+    assert h == pytest.approx(s-j)
 
 def test_J11():
     """ Test a property of J from result 5 of the paper """
@@ -83,4 +83,4 @@ def test_J11():
     d = SD(pmf)
     q = SD(1/(N-1)*(1-pmf))
     j2 = (N-1)*(H(q)-np.log2(N-1))
-    assert_almost_equal(J(d), j2)
+    assert J(d) == pytest.approx(j2)

--- a/dit/other/tests/test_perplexity.py
+++ b/dit/other/tests/test_perplexity.py
@@ -4,7 +4,7 @@ Tests for dit.other.perplexity.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 from dit import (ScalarDistribution as SD,
                  Distribution as D)
@@ -12,43 +12,43 @@ from dit.other import perplexity as P
 from six.moves import range # pylint: disable=redefined-builtin
 
 
-def test_p1():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_p1(i):
     """ Test some simple base cases using SD """
-    for i in range(2, 10):
-        yield assert_almost_equal, P(SD([1/i]*i)), i
+    assert P(SD([1/i]*i)) == pytest.approx(i)
 
-def test_p2():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_p2(i):
     """ Test some simple base cases using SD with varying bases """
-    for i in range(2, 10):
-        d = SD([1/i]*i)
-        d.set_base(i)
-        yield assert_almost_equal, P(d), i
+    d = SD([1/i]*i)
+    d.set_base(i)
+    assert P(d) == pytest.approx(i)
 
-def test_p3():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_p3(i):
     """ Test some simple base cases using D """
-    for i in range(2, 10):
-        d = D([str(_) for _ in range(i)], [1/i]*i)
-        yield assert_almost_equal, P(d), i
+    d = D([str(_) for _ in range(i)], [1/i]*i)
+    assert P(d) == pytest.approx(i)
 
-def test_p4():
+@pytest.mark.parametrize('i', range(2, 10))
+def test_p4(i):
     """ Test some simple base cases using D with varying bases """
-    for i in range(2, 10):
-        d = D([str(_) for _ in range(i)], [1/i]*i)
-        d.set_base(i)
-        yield assert_almost_equal, P(d), i
+    d = D([str(_) for _ in range(i)], [1/i]*i)
+    d.set_base(i)
+    assert P(d) == pytest.approx(i)
 
 def test_p5():
     """ Test some joint, marginal, and conditional perplexities """
     d = D(['00', '01', '10', '11'], [1/4]*4)
-    assert_almost_equal(P(d), 4)
-    assert_almost_equal(P(d, [0]), 2)
-    assert_almost_equal(P(d, [1]), 2)
-    assert_almost_equal(P(d, [0], [1]), 2)
-    assert_almost_equal(P(d, [1], [0]), 2)
+    assert P(d) == pytest.approx(4)
+    assert P(d, [0]) == pytest.approx(2)
+    assert P(d, [1]) == pytest.approx(2)
+    assert P(d, [0], [1]) == pytest.approx(2)
+    assert P(d, [1], [0]) == pytest.approx(2)
 
 def test_p6():
     """ Test some joint and conditional perplexities """
     d = D(['00', '11'], [1/2]*2)
-    assert_almost_equal(P(d), 2)
-    assert_almost_equal(P(d, [0], [1]), 1)
-    assert_almost_equal(P(d, [1], [0]), 1)
+    assert P(d) == pytest.approx(2)
+    assert P(d, [0], [1]) == pytest.approx(1)
+    assert P(d, [1], [0]) == pytest.approx(1)

--- a/dit/other/tests/test_renyi_entropy.py
+++ b/dit/other/tests/test_renyi_entropy.py
@@ -4,7 +4,7 @@ Tests for dit.other.renyi_entropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_raises
+import pytest
 
 import numpy as np
 
@@ -12,29 +12,30 @@ from dit import Distribution
 from dit.example_dists import uniform
 from dit.other import renyi_entropy
 
-def test_renyi_entropy_1():
+@pytest.mark.parametrize('alpha', [0, 1/2, 1, 2, 5, np.inf])
+def test_renyi_entropy_1(alpha):
     """
     Test that the Renyi entropy of a uniform distirbution is indipendent of the
     order.
     """
     d = uniform(8)
-    for alpha in [0, 1/2, 1, 2, 5, np.inf]:
-        yield assert_almost_equal, renyi_entropy(d, alpha), 3
+    assert renyi_entropy(d, alpha) == pytest.approx(3)
 
-def test_renyi_entropy_2():
+@pytest.mark.parametrize('alpha', [0, 1/2, 1, 2, 5, np.inf])
+def test_renyi_entropy_2(alpha):
     """
     Test the Renyi entropy of joint distributions.
     """
     d = Distribution(['00', '11', '22', '33'], [1/4]*4)
-    for alpha in [0, 1/2, 1, 2, 5, np.inf]:
-        yield assert_almost_equal, renyi_entropy(d, alpha), 2
-        yield assert_almost_equal, renyi_entropy(d, alpha, [0]), 2
-        yield assert_almost_equal, renyi_entropy(d, alpha, [1]), 2
+    assert renyi_entropy(d, alpha) == pytest.approx(2)
+    assert renyi_entropy(d, alpha, [0]) == pytest.approx(2)
+    assert renyi_entropy(d, alpha, [1]) == pytest.approx(2)
 
-def test_renyi_entropy_3():
+@pytest.mark.parametrize('alpha', [-np.inf, -5, -1, -1/2, -0.0000001])
+def test_renyi_entropy_3(alpha):
     """
     Test that negative orders raise ValueErrors.
     """
     d = uniform(8)
-    for alpha in [-np.inf, -5, -1, -1/2, -0.0000001]:
-        yield assert_raises, ValueError, renyi_entropy, d, alpha
+    with pytest.raises(ValueError):
+        renyi_entropy(d, alpha)

--- a/dit/other/tests/test_tsallis_entropy.py
+++ b/dit/other/tests/test_tsallis_entropy.py
@@ -4,21 +4,21 @@ Tests for dit.other.tsallis_entropy.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 import numpy as np
 
 from dit import Distribution
 from dit.other import tsallis_entropy
 
-def test_tsallis_entropy_1():
+@pytest.mark.parametrize('q', np.arange(-2, 2.5, 0.5))
+def test_tsallis_entropy_1(q):
     """
     Test the pseudo-additivity property.
     """
     d = Distribution(['00', '01', '02', '10', '11', '12'], [1/6]*6)
-    for q in np.arange(-2, 2.5, 0.5):
-        S_AB = tsallis_entropy(d, q)
-        S_A = tsallis_entropy(d, q, [0])
-        S_B = tsallis_entropy(d, q, [1])
-        pa_prop = S_A + S_B + (1-q)*S_A*S_B
-        yield assert_almost_equal, S_AB, pa_prop
+    S_AB = tsallis_entropy(d, q)
+    S_A = tsallis_entropy(d, q, [0])
+    S_B = tsallis_entropy(d, q, [1])
+    pa_prop = S_A + S_B + (1-q)*S_A*S_B
+    assert S_AB == pytest.approx(pa_prop)

--- a/dit/profiles/tests/test_complexity_profile.py
+++ b/dit/profiles/tests/test_complexity_profile.py
@@ -4,7 +4,7 @@ Tests for dit.profiles.ComplexityProfile. Known examples taken from http://arxiv
 
 from __future__ import division
 
-from nose.tools import assert_dict_equal
+import pytest
 
 from dit import Distribution
 from dit.profiles import ComplexityProfile
@@ -13,17 +13,16 @@ ex1 = Distribution(['000', '001', '010', '011', '100', '101', '110', '111'], [1/
 ex2 = Distribution(['000', '111'], [1/2]*2)
 ex3 = Distribution(['000', '001', '110', '111'], [1/4]*4)
 ex4 = Distribution(['000', '011', '101', '110'], [1/4]*4)
-examples = [ex1, ex2, ex3, ex4]
 
-
-def test_complexity_profile():
+@pytest.mark.parametrize(('ex', 'prof'), [
+    (ex1, {1: 3.0, 2: 0.0, 3: 0.0}),
+    (ex2, {1: 1.0, 2: 1.0, 3: 1.0}),
+    (ex3, {1: 2.0, 2: 1.0, 3: 0.0}),
+    (ex4, {1: 2.0, 2: 2.0, 3: -1.0}),
+])
+def test_complexity_profile(ex, prof):
     """
     Test against known examples.
     """
-    profs = [{1: 3.0, 2: 0.0, 3: 0.0},
-             {1: 1.0, 2: 1.0, 3: 1.0},
-             {1: 2.0, 2: 1.0, 3: 0.0},
-             {1: 2.0, 2: 2.0, 3: -1.0}]
-    for ex, prof in zip(examples, profs):
-        cp = ComplexityProfile(ex)
-        yield assert_dict_equal, cp.profile, prof
+    cp = ComplexityProfile(ex)
+    assert cp.profile == prof

--- a/dit/profiles/tests/test_entropy_triangle.py
+++ b/dit/profiles/tests/test_entropy_triangle.py
@@ -4,7 +4,7 @@ Tests for dit.profiles.entropy_triangle. Known examples taken from http://arxiv.
 
 from __future__ import division
 
-from nose.tools import assert_in, assert_tuple_equal
+import pytest
 
 from dit import Distribution
 from dit.profiles import EntropyTriangle, EntropyTriangle2
@@ -13,55 +13,43 @@ ex1 = Distribution(['000', '001', '010', '011', '100', '101', '110', '111'], [1/
 ex2 = Distribution(['000', '111'], [1/2]*2)
 ex3 = Distribution(['000', '001', '110', '111'], [1/4]*4)
 ex4 = Distribution(['000', '011', '101', '110'], [1/4]*4)
-examples = [ex1, ex2, ex3, ex4]
 
-def test_et_1():
+@pytest.mark.parametrize(('d', 'val'), [
+    (ex1, (0, 0, 1)),
+    (ex2, (0, 1, 0)),
+    (ex3, (0, 2/3, 1/3)),
+    (ex4, (0, 1, 0)),
+])
+def test_et_1(d, val):
     """
     Test EntropyTriangle against known values.
     """
-    vals = [(0, 0, 1),
-            (0, 1, 0),
-            (0, 2/3, 1/3),
-            (0, 1, 0),
-           ]
-    for d, val in zip(examples, vals):
-        yield assert_tuple_equal, EntropyTriangle(d).points[0], val
+    assert EntropyTriangle(d).points[0] == val
 
-def test_et_2():
+@pytest.mark.parametrize('val', [(0, 0, 1), (0, 1, 0), (0, 2/3, 1/3), (0, 1, 0)])
+def test_et_2(val):
     """
     Test EntropyTriangle against known values.
     """
-    vals = [(0, 0, 1),
-            (0, 1, 0),
-            (0, 2/3, 1/3),
-            (0, 1, 0),
-           ]
-    et = EntropyTriangle(examples)
-    for val in vals:
-        yield assert_in, val, et.points
+    et = EntropyTriangle([ex1, ex2, ex3, ex4])
+    assert val in et.points
 
-
-def test_et2_1():
+@pytest.mark.parametrize(('d', 'val'), [
+    (ex1, (1, 0, 0)),
+    (ex2, (0, 2/3, 1/3)),
+    (ex3, (1/3, 1/3, 1/3)),
+    (ex4, (0, 1/3, 2/3)),
+])
+def test_et2_1(d, val):
     """
     Test EntropyTriangle2 against known values.
     """
-    vals = [(1, 0, 0),
-            (0, 2/3, 1/3),
-            (1/3, 1/3, 1/3),
-            (0, 1/3, 2/3),
-           ]
-    for d, val in zip(examples, vals):
-        yield assert_tuple_equal, EntropyTriangle2(d).points[0], val
+    assert EntropyTriangle2(d).points[0] == val
 
-def test_et_2():
+@pytest.mark.parametrize('val', [(1, 0, 0), (0, 2/3, 1/3), (1/3, 1/3, 1/3), (0, 1/3, 2/3)])
+def test_et_2(val):
     """
     Test EntropyTriangle against known values.
     """
-    vals = [(1, 0, 0),
-            (0, 2/3, 1/3),
-            (1/3, 1/3, 1/3),
-            (0, 1/3, 2/3),
-           ]
-    et = EntropyTriangle2(examples)
-    for val in vals:
-        yield assert_in, val, et.points
+    et = EntropyTriangle2([ex1, ex2, ex3, ex4])
+    assert val in et.points

--- a/dit/profiles/tests/test_information_partitions.py
+++ b/dit/profiles/tests/test_information_partitions.py
@@ -1,7 +1,7 @@
 """
 Tests for dit.util.information_partitions.
 """
-from nose.tools import assert_almost_equal, assert_equal
+import pytest
 
 from itertools import islice
 from iterutils import powerset
@@ -20,20 +20,20 @@ def all_info_measures(vars):
             for cond in powerset(others):
                 yield (part , cond)
 
-def test_sp1():
+@pytest.mark.parametrize('meas', all_info_measures(range(4)))
+def test_sp1(meas):
     """ Test all possible info measures """
     d = n_mod_m(4, 2)
     ip = ShannonPartition(d)
-    for meas in all_info_measures(range(4)):
-        yield assert_almost_equal, ip[meas], I(d, meas[0], meas[1])
+    assert ip[meas] == pytest.approx(I(d, meas[0], meas[1]))
 
-def test_sp2():
+@pytest.mark.parametrize('meas', all_info_measures('xyzw'))
+def test_sp2(meas):
     """ Test all possible info measures, with rv_names """
     d = n_mod_m(4, 2)
     d.set_rv_names('xyzw')
     ip = ShannonPartition(d)
-    for meas in all_info_measures('xyzw'):
-        yield assert_almost_equal, ip[meas], I(d, meas[0], meas[1])
+    assert ip[meas] == pytest.approx(I(d, meas[0], meas[1]))
 
 def test_sp3():
     """ Test get_atoms() """
@@ -48,7 +48,7 @@ def test_sp3():
                   'I[1:2|0]'
                  ])
     atoms2 = ip.get_atoms()
-    assert_equal((atoms1 - atoms2) | (atoms2 - atoms1), set())
+    assert (atoms1 - atoms2) | (atoms2 - atoms1) == set()
 
 def test_sp4():
     """ Test printing """
@@ -66,7 +66,7 @@ def test_sp4():
 | I[1:2|0] |  1.000 |
 | I[0:1:2] | -1.000 |
 +----------+--------+"""
-    assert_equal(str(ip), string)
+    assert str(ip) == string
 
 def test_ep1():
     """
@@ -86,4 +86,4 @@ def test_ep1():
 | X[1:2|0] |  0.245 |
 | X[0:1:2] |  0.510 |
 +----------+--------+"""
-    assert_equal(str(ep), string)
+    assert str(ep) == string

--- a/dit/profiles/tests/test_mui.py
+++ b/dit/profiles/tests/test_mui.py
@@ -4,9 +4,9 @@ Tests for dit.profiles.MUIProfile. Known examples taken from http://arxiv.org/ab
 
 from __future__ import division
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_dict_equal
-from numpy.testing import assert_array_almost_equal
+import pytest
+
+import numpy as np
 
 from dit import Distribution
 from dit.profiles import MUIProfile
@@ -17,16 +17,19 @@ ex3 = Distribution(['000', '001', '110', '111'], [1/4]*4)
 ex4 = Distribution(['000', '011', '101', '110'], [1/4]*4)
 examples = [ex1, ex2, ex3, ex4]
 
-@attr("scipy")
-def test_mui_profile():
+
+pytest.importorskip('scipy')
+
+@pytest.mark.parametrize(('d', 'prof', 'width'), [
+    (ex1, {0.0: 1.0}, [3.0]),
+    (ex2, {0.0: 3.0}, [1.0]),
+    (ex3, {0.0: 2.0, 1.0: 1.0}, [1.0, 1.0]),
+    (ex4, {0.0: 3/2}, [2.0]),
+])
+def test_mui_profile(d, prof, width):
     """
     Test against known examples.
     """
-    profs = [({0.0: 1.0}, [3.0]),
-             ({0.0: 3.0}, [1.0]),
-             ({0.0: 2.0, 1.0: 1.0}, [1.0, 1.0]),
-             ({0.0: 3/2}, [2.0])]
-    for ex, (prof, width) in zip(examples, profs):
-        mui = MUIProfile(ex)
-        yield assert_dict_equal, mui.profile, prof
-        yield assert_array_almost_equal, mui.widths, width
+    mui = MUIProfile(d)
+    assert mui.profile == prof
+    assert np.allclose(mui.widths, width)

--- a/dit/profiles/tests/test_schneidman.py
+++ b/dit/profiles/tests/test_schneidman.py
@@ -4,9 +4,9 @@ Tests for dit.profiles.SchneidmanProfile. Known examples taken from http://arxiv
 
 from __future__ import division
 
-from nose.plugins.attrib import attr
-from nose.tools import assert_dict_equal
-from numpy.testing import assert_array_almost_equal
+import pytest
+
+import numpy as np
 
 from dit import Distribution
 from dit.profiles import SchneidmanProfile
@@ -17,15 +17,18 @@ ex3 = Distribution(['000', '001', '110', '111'], [1/4]*4)
 ex4 = Distribution(['000', '011', '101', '110'], [1/4]*4)
 examples = [ex1, ex2, ex3, ex4]
 
-@attr('cvxopt')
-def test_schneidman_profile():
+
+pytest.importorskip('cvxopt')
+
+@pytest.mark.parametrize(('ex', 'prof'), [
+    (ex1, (0.0, 0.0, 0.0)),
+    (ex2, (0.0, 2.0, 0.0)),
+    (ex3, (0.0, 1.0, 0.0)),
+    (ex4, (0.0, 0.0, 1.0)),
+])
+def test_schneidman_profile(ex, prof):
     """
     Test against known examples.
     """
-    profs = [(0.0, 0.0, 0.0),
-             (0.0, 2.0, 0.0),
-             (0.0, 1.0, 0.0),
-             (0.0, 0.0, 1.0)]
-    for ex, prof in zip(examples, profs):
-        sp = SchneidmanProfile(ex)
-        yield assert_array_almost_equal, [sp.profile[i] for i in (1,2,3)], prof
+    sp = SchneidmanProfile(ex)
+    assert np.allclose([sp.profile[i] for i in (1,2,3)], prof, atol=1e-5)

--- a/dit/shannon/tests/test_shannon.py
+++ b/dit/shannon/tests/test_shannon.py
@@ -4,7 +4,7 @@ Tests for dit.shannon.shannon.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal
+import pytest
 
 import numpy as np
 
@@ -17,65 +17,65 @@ from dit.shannon import (entropy as H,
 def test_entropy_pmf1d():
     """ Test the entropy of a fair coin """
     d = [.5, .5]
-    assert_almost_equal(entropy_pmf(d), 1.0)
+    assert entropy_pmf(d) == pytest.approx(1.0)
 
 def test_entropy_pmf2d():
     """ Test the entropy of a fair coin """
     d = np.array([[1,0],[.5, .5]])
     H = np.array([0, 1])
-    np.testing.assert_allclose(entropy_pmf(d), H)
+    assert np.allclose(entropy_pmf(d), H)
 
 def test_H1():
     """ Test the entropy of a fair coin """
     d = SD([1/2, 1/2])
-    assert_almost_equal(H(d), 1.0)
+    assert H(d) == pytest.approx(1.0)
 
 def test_H2():
     """ Test the entropy of a fair coin, float style """
-    assert_almost_equal(H(1/2), 1.0)
+    assert H(1/2) == pytest.approx(1.0)
 
 def test_H3():
     """ Test joint and marginal entropies """
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = D(outcomes, pmf)
-    assert_almost_equal(H(d, [0]), 1.0)
-    assert_almost_equal(H(d, [1]), 1.0)
-    assert_almost_equal(H(d, [0, 1]), 2.0)
-    assert_almost_equal(H(d), 2.0)
+    assert H(d, [0]) == pytest.approx(1.0)
+    assert H(d, [1]) == pytest.approx(1.0)
+    assert H(d, [0, 1]) == pytest.approx(2.0)
+    assert H(d) == pytest.approx(2.0)
 
 def test_H4():
     """ Test entropy in base 10 """
     d = SD([1/10]*10)
     d.set_base(10)
-    assert_almost_equal(H(d), 1.0)
+    assert H(d) == pytest.approx(1.0)
 
 def test_I1():
     """ Test mutual information of independent variables """
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = D(outcomes, pmf)
-    assert_almost_equal(I(d, [0], [1]), 0.0)
+    assert I(d, [0], [1]) == pytest.approx(0.0)
 
 def test_I2():
     """ Test mutual information of dependent variables """
     outcomes = ['00', '11']
     pmf = [1/2]*2
     d = D(outcomes, pmf)
-    assert_almost_equal(I(d, [0], [1]), 1.0)
+    assert I(d, [0], [1]) == pytest.approx(1.0)
 
 def test_I3():
     """ Test mutual information of overlapping variables """
     outcomes = ['000', '011', '101', '110']
     pmf = [1/4]*4
     d = D(outcomes, pmf)
-    assert_almost_equal(I(d, [0, 1], [1, 2]), 2.0)
+    assert I(d, [0, 1], [1, 2]) == pytest.approx(2.0)
 
 def test_CH1():
     """ Test conditional entropies """
     outcomes = ['000', '011', '101', '110']
     pmf = [1/4]*4
     d = D(outcomes, pmf)
-    assert_almost_equal(CH(d, [0], [1, 2]), 0.0)
-    assert_almost_equal(CH(d, [0, 1], [2]), 1.0)
-    assert_almost_equal(CH(d, [0], [0]), 0.0)
+    assert CH(d, [0], [1, 2]) == pytest.approx(0.0)
+    assert CH(d, [0, 1], [2]) == pytest.approx(1.0)
+    assert CH(d, [0], [0]) == pytest.approx(0.0)

--- a/dit/tests/test_cdisthelpers.py
+++ b/dit/tests/test_cdisthelpers.py
@@ -1,5 +1,6 @@
 
-from nose.tools import *
+import pytest
+
 import numpy as np
 import dit
 
@@ -8,7 +9,7 @@ def test_joint_from_factors():
     for i in range(3):
         pX, pYgX = d.condition_on([i])
         pXY = dit.joint_from_factors(pX, pYgX)
-        assert_true(pXY.is_approx_equal(d))
+        assert pXY.is_approx_equal(d)
 
 def test_joint_from_factors_rvname():
     d = dit.example_dists.Xor()
@@ -18,18 +19,18 @@ def test_joint_from_factors_rvname():
 
     # Standard
     pXYZ = dit.joint_from_factors(pY, pXZgY)
-    assert_true(pXYZ.is_approx_equal(d))
+    assert pXYZ.is_approx_equal(d)
 
     # Now we make them have incompatible masks.
     pY._new_mask()
-    assert_raises(dit.exceptions.ditException,
-                  dit.joint_from_factors, pY, pXZgY, strict=True)
+    with pytest.raises(dit.exceptions.ditException):
+        dit.joint_from_factors(pY, pXZgY, strict=True)
 
     # Build out of order now.
     pYXZ = dit.joint_from_factors(pY, pXZgY, strict=False)
     # This is one instance where ['YXZ'] is not treated the same as 'YXZ'
     d2 = d.coalesce(['YXZ'], extract=True)
-    assert_true(pYXZ.is_approx_equal(d2))
+    assert pYXZ.is_approx_equal(d2)
 
 def test_bad_marginal():
     d = dit.example_dists.Xor()
@@ -37,8 +38,8 @@ def test_bad_marginal():
 
     # Incompatible marginal
     pY = dit.Distribution(['0', '1', '2'], [.25, .5, .25])
-    assert_raises(dit.exceptions.ditException,
-                  dit.joint_from_factors, pY, pXZgY, strict=False)
+    with pytest.raises(dit.exceptions.ditException):
+        dit.joint_from_factors(pY, pXZgY, strict=False)
 
     # Compatible marginal that is not trim.
     pY = dit.Distribution(['0', '1', '2'], [.25, .75, 0])
@@ -51,4 +52,3 @@ def test_bad_marginal():
     pY = dit.Distribution(['0', '1', '2'], [.25, 0, .75])
     pY.make_dense()
     pYXZ = dit.joint_from_factors(pY, pXZgY, strict=False)
-

--- a/dit/tests/test_convert.py
+++ b/dit/tests/test_convert.py
@@ -4,7 +4,7 @@ Tests for dit.convert.
 
 from __future__ import division
 
-from nose.tools import assert_equal, assert_raises, assert_true
+import pytest
 
 from dit import Distribution, ScalarDistribution
 from dit.convert import DtoSD, SDtoD
@@ -15,31 +15,32 @@ def test_DtoSD1():
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     sd = DtoSD(d, False)
-    assert_true(type(d) is Distribution)
-    assert_true(type(sd) is ScalarDistribution)
+    assert type(d) is Distribution
+    assert type(sd) is ScalarDistribution
 
 def test_DtoSD2():
     outcomes = [(0,), (2,), (4,)]
     pmf = [1/3]*3
     d = Distribution(outcomes, pmf)
     sd = DtoSD(d, True)
-    assert_true(type(sd) is ScalarDistribution)
-    assert_true(sd.outcomes == (0, 2, 4))
+    assert type(sd) is ScalarDistribution
+    assert sd.outcomes == (0, 2, 4)
 
 def test_SDtoD1():
     sd = ScalarDistribution([1/4]*4)
     d = SDtoD(sd)
-    assert_true(type(sd) is ScalarDistribution)
-    assert_true(type(d) is Distribution)
+    assert type(sd) is ScalarDistribution
+    assert type(d) is Distribution
 
 def test_SDtoD2():
     sd = ScalarDistribution([1])
     sd[0] = 0
     sd.make_sparse()
-    assert_raises(InvalidDistribution, SDtoD, sd)
+    with pytest.raises(InvalidDistribution):
+        SDtoD(sd)
 
 def test_SDtoD3():
     sd = ScalarDistribution([(0, 1), (2, 3), (4, 5)], [1/3]*3)
     d = SDtoD(sd)
-    assert_true(type(d) is Distribution)
-    assert_equal(d.outcome_length(), 2)
+    assert type(d) is Distribution
+    assert d.outcome_length() == 2

--- a/dit/tests/test_distconst.py
+++ b/dit/tests/test_distconst.py
@@ -4,14 +4,13 @@ Tests for dit.distconst.
 
 from __future__ import division
 
-from nose.tools import assert_equal, assert_false, assert_raises, assert_true
+import pytest
 
 import itertools
 
 from six.moves import range
 
 import numpy as np
-import numpy.testing as npt
 
 from dit.exceptions import ditException, InvalidOutcome
 import dit
@@ -20,8 +19,10 @@ def test_mixture_distribution_weights():
     d = dit.Distribution(['A', 'B'], [0.5, 0.5])
     d2 = dit.Distribution(['A', 'B'], [1, 0])
 
-    assert_raises(ditException, dit.mixture_distribution, [d, d2], [1])
-    assert_raises(ditException, dit.mixture_distribution2, [d, d2], [1])
+    with pytest.raises(ditException):
+        dit.mixture_distribution([d, d2], [1])
+    with pytest.raises(ditException):
+        dit.mixture_distribution2([d, d2], [1])
 
 def test_mixture_distribution():
     d = dit.Distribution(['A', 'B'], [0.5, 0.5])
@@ -29,7 +30,7 @@ def test_mixture_distribution():
     pmf = np.array([0.75, 0.25])
 
     d3 = dit.mixture_distribution([d, d2], [0.5, 0.5])
-    npt.assert_allclose(pmf, d3.pmf)
+    assert np.allclose(pmf, d3.pmf)
 
 def test_mixture_distribution_log():
     d = dit.Distribution(['A', 'B'], [0.5, 0.5])
@@ -40,7 +41,7 @@ def test_mixture_distribution_log():
     pmf = np.log2(np.array([0.75, 0.25]))
 
     d3 = dit.mixture_distribution([d, d2], weights)
-    npt.assert_allclose(pmf, d3.pmf)
+    assert np.allclose(pmf, d3.pmf)
 
 def test_mixture_distribution2():
     # Test when pmfs are different lengths.
@@ -48,7 +49,8 @@ def test_mixture_distribution2():
     d2 = dit.Distribution(['A', 'B'], [1, 0], sort=True, trim=True)
 
     # Fails when it checks that all pmfs have the same length.
-    assert_raises(ValueError, dit.mixture_distribution2, [d, d2], [0.5, 0.5])
+    with pytest.raises(ValueError):
+        dit.mixture_distribution2([d, d2], [0.5, 0.5])
 
 def test_mixture_distribution3():
     # Sample spaces are compatible.
@@ -58,9 +60,9 @@ def test_mixture_distribution3():
     pmf = np.array([0.25, 0.75])
 
     d3 = dit.mixture_distribution([d, d2], [0.5, 0.5])
-    assert_true(np.allclose(pmf, d3.pmf))
+    assert np.allclose(pmf, d3.pmf)
     d3 = dit.mixture_distribution2([d, d2], [0.5, 0.5])
-    assert_false(np.allclose(pmf, d3.pmf))
+    assert not np.allclose(pmf, d3.pmf)
 
 def test_mixture_distribution4():
     # Sample spaces are compatible.
@@ -71,8 +73,9 @@ def test_mixture_distribution4():
     pmf = np.array([0.25, 0.75])
 
     d3 = dit.mixture_distribution([d, d2], [0.5, 0.5])
-    assert_true(np.allclose(pmf, d3.pmf))
-    assert_raises(ValueError, dit.mixture_distribution2, [d, d2], [0.5, 0.5])
+    assert np.allclose(pmf, d3.pmf)
+    with pytest.raises(ValueError):
+        dit.mixture_distribution2([d, d2], [0.5, 0.5])
 
 def test_mixture_distribution5():
     # Incompatible sample spaces.
@@ -80,7 +83,7 @@ def test_mixture_distribution5():
     d2 = dit.Distribution(['B', 'C'], [0.5, 0.5])
     d3 = dit.mixture_distribution([d1, d2], [0.5, 0.5], merge=True)
     pmf = np.array([0.25, 0.5, 0.25])
-    assert_true(np.allclose(pmf, d3.pmf))
+    assert np.allclose(pmf, d3.pmf)
 
 def test_random_scalar_distribution():
     # Test with no alpha and only an integer
@@ -88,22 +91,23 @@ def test_random_scalar_distribution():
     for prng in [None, dit.math.prng]:
         dit.math.prng.seed(1)
         d = dit.random_scalar_distribution(3, prng=prng)
-        assert_equal(d.outcomes, (0, 1, 2))
-        np.testing.assert_allclose(d.pmf, pmf)
+        assert d.outcomes == (0, 1, 2)
+        assert np.allclose(d.pmf, pmf)
 
     # Test with outcomes specified
     dit.math.prng.seed(1)
     d = dit.random_scalar_distribution([0, 1, 2])
-    assert_equal(d.outcomes, (0, 1, 2))
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == (0, 1, 2)
+    assert np.allclose(d.pmf, pmf)
 
     # Test with concentration parameters
     pmf = np.array([0.34228708, 0.52696865, 0.13074428])
     dit.math.prng.seed(1)
     d = dit.random_scalar_distribution(3, alpha=[1, 2, 1])
-    assert_equal(d.outcomes, (0, 1, 2))
-    np.testing.assert_allclose(d.pmf, pmf)
-    assert_raises(ditException, dit.random_scalar_distribution, 3, alpha=[1])
+    assert d.outcomes == (0, 1, 2)
+    assert np.allclose(d.pmf, pmf)
+    with pytest.raises(ditException):
+        dit.random_scalar_distribution(3, alpha=[1])
 
 def test_random_distribution():
     # Test with no alpha
@@ -112,46 +116,49 @@ def test_random_distribution():
     for prng in [None, dit.math.prng]:
         dit.math.prng.seed(1)
         d = dit.random_distribution(2, 2, prng=prng)
-        assert_equal(d.outcomes, outcomes)
-        np.testing.assert_allclose(d.pmf, pmf)
+        assert d.outcomes == outcomes
+        assert np.allclose(d.pmf, pmf)
 
     # Test with a single alphabet specified
     dit.math.prng.seed(1)
     d = dit.random_distribution(2, [[0, 1]])
-    assert_equal(d.outcomes, outcomes)
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == outcomes
+    assert np.allclose(d.pmf, pmf)
 
     # Test with two alphabets specified
     dit.math.prng.seed(1)
     d = dit.random_distribution(2, [[0, 1], [0, 1]])
-    assert_equal(d.outcomes, outcomes)
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == outcomes
+    assert np.allclose(d.pmf, pmf)
 
     # Test with invalid number of alphabets
-    assert_raises(TypeError, dit.random_distribution, 3, [3, 2])
-    assert_raises(TypeError, dit.random_distribution, 3, [3, 2, 3])
+    with pytest.raises(TypeError):
+        dit.random_distribution(3, [3, 2])
+    with pytest.raises(TypeError):
+        dit.random_distribution(3, [3, 2, 3])
 
     # Test with concentration parameters
     pmf = np.array([0.15092872, 0.23236257, 0.05765063, 0.55905808])
     dit.math.prng.seed(1)
     d = dit.random_distribution(2, 2, alpha=[1, 2, 1, 3])
-    assert_equal(d.outcomes, outcomes)
-    np.testing.assert_allclose(d.pmf, pmf)
-    assert_raises(ditException, dit.random_distribution, 2, 2, alpha=[1])
+    assert d.outcomes == outcomes
+    assert np.allclose(d.pmf, pmf)
+    with pytest.raises(ditException):
+        dit.random_distribution(2, 2, alpha=[1])
 
 def test_simplex_grid1():
     # Test with tuple
     dists = np.asarray(list(dit.simplex_grid(2, 2**2, using=tuple)))
     dists_ = np.asarray([(0.0, 1.0), (0.25, 0.75), (0.5, 0.5),
                          (0.75, 0.25), (1.0, 0.0)])
-    np.testing.assert_allclose(dists, dists_)
+    assert np.allclose(dists, dists_)
 
 def test_simplex_grid2():
     # Test with ScalarDistribution
     dists = np.asarray([d.pmf for d in dit.simplex_grid(2, 2**2)])
     dists_ = np.asarray([(0.0, 1.0), (0.25, 0.75), (0.5, 0.5),
                          (0.75, 0.25), (1.0, 0.0)])
-    np.testing.assert_allclose(dists, dists_)
+    assert np.allclose(dists, dists_)
 
 def test_simplex_grid3():
     # Test with Distribution
@@ -159,20 +166,21 @@ def test_simplex_grid3():
     dists = np.asarray([x.pmf for x in dit.simplex_grid(2, 2**2, using=d)])
     dists_ = np.asarray([(0.0, 1.0), (0.25, 0.75), (0.5, 0.5),
                          (0.75, 0.25), (1.0, 0.0)])
-    np.testing.assert_allclose(dists, dists_)
+    assert np.allclose(dists, dists_)
 
 def test_simplex_grid4():
     # Test with Distribution but with wrong length specified.
     d = dit.random_distribution(2, 2)
     g = dit.simplex_grid(5, 2**2, using=d)
-    np.testing.assert_raises(Exception, next, g)
+    with pytest.raises(Exception):
+        next(g)
 
 def test_simplex_grid5():
     # Test with ScalarDistribution with inplace=True
     # All final dists should be the same.
     dists = np.asarray([d.pmf for d in dit.simplex_grid(2, 2**2, inplace=True)])
     dists_ = np.asarray([(1.0, 0.0)]*5)
-    np.testing.assert_allclose(dists, dists_)
+    assert np.allclose(dists, dists_)
 
 def test_simplex_grid6():
     # Test using NumPy arrays and a base of 3.
@@ -189,15 +197,17 @@ def test_simplex_grid6():
         [ 1.        ,  0.        ,  0.        ]
     ])
     d = np.array(list(dit.simplex_grid(3, 3, using=np.array)))
-    np.testing.assert_allclose(d, d_)
+    assert np.allclose(d, d_)
 
 def test_simplex_grid_bad_n():
     x = dit.simplex_grid(0, 3)
-    assert_raises(ditException, list, x)
+    with pytest.raises(ditException):
+        list(x)
 
 def test_simplex_grid_bad_subdivisions():
     x = dit.simplex_grid(3, 0)
-    assert_raises(ditException, list, x)
+    with pytest.raises(ditException):
+        list(x)
 
 # These can be simple smoke test, since the random* tests hit all the branches.
 
@@ -206,20 +216,20 @@ def test_uniform_scalar_distribution():
     outcomes = (0, 1, 2)
     dit.math.prng.seed(1)
     d = dit.uniform_scalar_distribution(len(outcomes))
-    assert_equal(d.outcomes, outcomes)
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == outcomes
+    assert np.allclose(d.pmf, pmf)
 
     dit.math.prng.seed(1)
     d = dit.uniform_scalar_distribution(outcomes)
-    assert_equal(d.outcomes, outcomes)
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == outcomes
+    assert np.allclose(d.pmf, pmf)
 
 def test_uniform_distribution():
     pmf = np.array([1/4] * 4)
     dit.math.prng.seed(1)
     d = dit.uniform_distribution(2, 2)
-    assert_equal(d.outcomes, ((0, 0), (0, 1), (1, 0), (1, 1)))
-    np.testing.assert_allclose(d.pmf, pmf)
+    assert d.outcomes == ((0, 0), (0, 1), (1, 0), (1, 1))
+    assert np.allclose(d.pmf, pmf)
 
 def test_rvfunctions1():
     # Smoke test with strings
@@ -227,7 +237,7 @@ def test_rvfunctions1():
     bf = dit.RVFunctions(d)
     d = dit.insert_rvf(d, bf.xor([0,1]))
     d = dit.insert_rvf(d, bf.xor([1,2]))
-    assert_equal(d.outcomes, ('0000', '0110', '1011', '1101'))
+    assert d.outcomes == ('0000', '0110', '1011', '1101')
 
 def test_rvfunctions2():
     # Smoke test with int tuples
@@ -235,7 +245,7 @@ def test_rvfunctions2():
     bf = dit.RVFunctions(d)
     d = dit.insert_rvf(d, bf.xor([0,1]))
     d = dit.insert_rvf(d, bf.xor([1,2]))
-    assert_equal(d.outcomes, ((0,0,0,0), (0,1,1,0), (1,0,1,1), (1,1,0,1)))
+    assert d.outcomes == ((0,0,0,0), (0,1,1,0), (1,0,1,1), (1,1,0,1))
 
 def test_rvfunctions3():
     # Smoke test strings with from_hexes
@@ -245,7 +255,7 @@ def test_rvfunctions3():
     bf = dit.RVFunctions(d)
     d = dit.insert_rvf(d, bf.from_hexes('27'))
     outcomes = ('0000', '0010', '0101', '0110', '1000', '1010', '1100', '1111')
-    assert_equal(d.outcomes, outcomes)
+    assert d.outcomes == outcomes
 
 def test_rvfunctions4():
     # Smoke test int tuples from_hexes
@@ -257,11 +267,12 @@ def test_rvfunctions4():
     d = dit.insert_rvf(d, bf.from_hexes('27'))
     outcomes = ('0000', '0010', '0101', '0110', '1000', '1010', '1100', '1111')
     outcomes = tuple(tuple(map(int, o)) for o in outcomes)
-    assert_equal(d.outcomes, outcomes)
+    assert d.outcomes == outcomes
 
 def test_rvfunctions_scalardist():
     d = dit.ScalarDistribution(range(5), [1/5] * 5)
-    assert_raises(ditException, dit.RVFunctions, d)
+    with pytest.raises(ditException):
+        dit.RVFunctions(d)
 
 def test_rvfunctions_ints():
     d = dit.uniform_distribution(2, 2)
@@ -270,7 +281,7 @@ def test_rvfunctions_ints():
     mapping = rvf.from_partition(partition)
     d2 = dit.insert_rvf(d, mapping)
     outcomes = ((0,0,0), (0,1,1), (1,0,2), (1,1,3))
-    assert_equal(d2.outcomes, outcomes)
+    assert d2.outcomes == outcomes
 
 def test_rvfunctions_toolarge():
     letters = 'abcd'
@@ -279,7 +290,8 @@ def test_rvfunctions_toolarge():
     d = dit.Distribution(outcomes, [1/64]*64, validate=False)
     rvf = dit.RVFunctions(d)
     partition = [(d.outcomes[i],) for i in range(len(d))]
-    assert_raises(NotImplementedError, rvf.from_partition, partition)
+    with pytest.raises(NotImplementedError):
+        rvf.from_partition(partition)
 
 def test_insert_rvf1():
     # Test multiple insertion.
@@ -296,7 +308,7 @@ def test_insert_rvf1():
         (1, 0, 1, 1, 1, 1),
         (1, 1, 0, 0, 0, 0)
     )
-    assert_equal(d2.outcomes, outcomes)
+    assert d2.outcomes == outcomes
 
 def test_insert_rvf2():
     # Test multiple insertion.
@@ -309,7 +321,7 @@ def test_insert_rvf2():
     # We are also inserting two times simultaneously.
     d2 = dit.insert_rvf(d, [xor, xor])
     outcomes = ('000000', '011111', '101111', '110000')
-    assert_equal(d2.outcomes, outcomes)
+    assert d2.outcomes == outcomes
 
 def test_RVFunctions_from_mapping1():
     d = dit.Distribution(['00', '01', '10', '11'], [1/4]*4)
@@ -317,7 +329,7 @@ def test_RVFunctions_from_mapping1():
     mapping = {'00': '0', '01': '1', '10': '1', '11': '0'}
     d = dit.insert_rvf(d, bf.from_mapping(mapping))
     outcomes = ('000', '011', '101', '110')
-    assert_equal(d.outcomes, outcomes)
+    assert d.outcomes == outcomes
 
 def test_RVFunctions_from_mapping2():
     d = dit.Distribution([(0,0), (0,1), (1,0), (1,1)], [1/4]*4)
@@ -325,7 +337,7 @@ def test_RVFunctions_from_mapping2():
     mapping = {(0,0): 0, (0,1): 1, (1,0): 1, (1,1): 0}
     d = dit.insert_rvf(d, bf.from_mapping(mapping, force=True))
     outcomes = ((0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 0))
-    assert_equal(d.outcomes, outcomes)
+    assert d.outcomes == outcomes
 
 def test_RVFunctions_from_partition():
     d = dit.Distribution(['00', '01', '10', '11'], [1/4]*4)
@@ -333,7 +345,7 @@ def test_RVFunctions_from_partition():
     partition = (('00','11'), ('01', '10'))
     d = dit.insert_rvf(d, bf.from_partition(partition))
     outcomes = ('000', '011', '101', '110')
-    assert_equal(d.outcomes, outcomes)
+    assert d.outcomes == outcomes
 
 def test_product():
     """
@@ -344,7 +356,7 @@ def test_product():
     d_iid = dit.product_distribution(d)
     d_truth = dit.uniform_distribution(3, ['01'])
     d_truth = dit.modify_outcomes(d_truth, lambda x: ''.join(x))
-    assert_true(d_truth.is_approx_equal(d_iid))
+    assert d_truth.is_approx_equal(d_iid)
 
 def test_product_nonjoint():
     """
@@ -352,7 +364,8 @@ def test_product_nonjoint():
 
     """
     d = dit.ScalarDistribution([.5, .5])
-    assert_raises(Exception, dit.product_distribution, d)
+    with pytest.raises(Exception):
+        dit.product_distribution(d)
 
 def test_product_with_rvs1():
     """
@@ -363,7 +376,7 @@ def test_product_with_rvs1():
     d_iid = dit.product_distribution(d, [[0,1], [2]])
     d_truth = dit.uniform_distribution(3, ['01'])
     d_truth = dit.modify_outcomes(d_truth, lambda x: ''.join(x))
-    assert_true(d_truth.is_approx_equal(d_iid))
+    assert d_truth.is_approx_equal(d_iid)
 
 def test_product_with_rvs2():
     """
@@ -374,7 +387,7 @@ def test_product_with_rvs2():
     d_iid = dit.product_distribution(d, [[0,1]])
     d_truth = dit.uniform_distribution(2, ['01'])
     d_truth = dit.modify_outcomes(d_truth, lambda x: ''.join(x))
-    assert_true(d_truth.is_approx_equal(d_iid))
+    assert d_truth.is_approx_equal(d_iid)
 
 def test_product_with_badrvs():
     """
@@ -382,31 +395,31 @@ def test_product_with_badrvs():
 
     """
     d = dit.example_dists.Xor()
-    assert_raises(Exception, dit.product_distribution, d, [[0,1], [0]])
+    with pytest.raises(Exception):
+        dit.product_distribution(d, [[0,1], [0]])
 
-def test_all_dist_structures():
+@pytest.mark.parametrize(('n', 'k'), [(2, 2), (2, 3), (3, 2)])
+def test_all_dist_structures(n, k):
     """
     Test all_dist_structures().
 
     """
-    for n, k in [(2, 2), (2, 3), (3, 2)]:
-        num_dists = len(list(dit.all_dist_structures(n, k)))
-        yield assert_equal, num_dists, 2**(k**n)-1
+    num_dists = len(list(dit.all_dist_structures(n, k)))
+    assert num_dists == 2**(k**n)-1
 
-def test_random_dist_structure():
+@pytest.mark.parametrize('d', [ dit.random_dist_structure(3, 3) for _ in range(10) ])
+def test_random_dist_structure(d):
     """
     Test random_dist_structure()
 
     """
     words = {''.join(word) for word in itertools.product('012', repeat=3)}
-    for i in range(10):
-        d = dit.random_dist_structure(3, 3)
-        diff = set(d.outcomes) - words
-        yield assert_equal, diff, set()
-        yield assert_true, 0 < len(d.outcomes) <= 3**3
+    diff = set(d.outcomes) - words
+    assert diff == set()
+    assert 0 < len(d.outcomes) <= 3**3
 
 def test_coarsegrain():
     d = dit.example_dists.Xor()
     d2 = dit.modify_outcomes(d, lambda x: '1' if '1' in x else '0')
-    assert_equal(d2.outcomes, ('0', '1'))
-    np.testing.assert_allclose(d2.pmf, [.25, .75])
+    assert d2.outcomes == ('0', '1')
+    assert np.allclose(d2.pmf, [.25, .75])

--- a/dit/tests/test_distribution.py
+++ b/dit/tests/test_distribution.py
@@ -1,8 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 
-from nose.tools import assert_almost_equal, assert_equal, assert_raises, \
-                       assert_true
+import pytest
 
 from dit import Distribution, ScalarDistribution
 from dit.distribution import BaseDistribution
@@ -13,9 +12,9 @@ def test_dist_iter1():
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     for o in d:
-        assert_true(o in outcomes)
+        assert o in outcomes
     for o1, o2 in zip(d, outcomes):
-        assert_equal(o1, o2)
+        assert o1 == o2
 
 
 def test_dist_iter2():
@@ -23,24 +22,24 @@ def test_dist_iter2():
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     for o in reversed(d):
-        assert_true(o in outcomes)
+        assert o in outcomes
     for o1, o2 in zip(reversed(d), reversed(outcomes)):
-        assert_equal(o1, o2)
+        assert o1 == o2
 
 
 def test_numerical():
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
-    assert_true(d.is_numerical())
+    assert d.is_numerical()
 
 
-def test_rand():
+@pytest.mark.parametrize('i', range(10))
+def test_rand(i):
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
-    for _ in range(10):
-        yield assert_true, d.rand() in outcomes
+    assert d.rand() in outcomes
 
 
 def test_to_dict():
@@ -49,29 +48,32 @@ def test_to_dict():
     d = Distribution(outcomes, pmf)
     dd = d.to_dict()
     for o, p in dd.items():
-        yield assert_almost_equal, d[o], p
+        assert d[o] == pytest.approx(p)
 
 def test_validate1():
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
-    assert_true(d.validate())
-    assert_true(BaseDistribution.validate(d))
+    assert d.validate()
+    assert BaseDistribution.validate(d)
 
 def test_validate2():
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     d['00'] = 0
-    assert_raises(InvalidNormalization, d.validate)
-    assert_raises(InvalidNormalization, BaseDistribution.validate, d)
+    with pytest.raises(InvalidNormalization):
+        d.validate()
+    with pytest.raises(InvalidNormalization):
+        BaseDistribution.validate(d)
 
 def test_zipped1():
     outcomes = ['00', '01', '10', '11']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     zipped = d.zipped(mode='pants')
-    assert_raises(ditException, list, zipped)
+    with pytest.raises(ditException):
+        list(zipped)
 
 
 def test_to_string1():
@@ -92,7 +94,7 @@ x    p(x)
 01   0.25
 10   0.25
 11   0.25"""
-    assert_equal(s, s_)
+    assert s == s_
 
 
 def test_to_string2():
@@ -113,7 +115,7 @@ x    p(x)
 01   1/4
 10   1/4
 11   1/4"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string3():
     # Test printing
@@ -145,7 +147,7 @@ x    p(x)
         sys.stdout = old
     sio.seek(0)
     s = sio.read()
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string4():
     # Basic with marginal
@@ -164,7 +166,7 @@ RV Names:       None
 x   p(x)
 0   0.5
 1   0.5"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string5():
     # Basic with marginal and mask
@@ -183,7 +185,7 @@ RV Names:       None
 x    p(x)
 0*   0.5
 1*   0.5"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string6():
     # Basic
@@ -203,7 +205,7 @@ x    p(x)
 01   0.2
 10   0.2
 11   0.2"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string7():
     # Basic
@@ -220,7 +222,7 @@ x    p(x)
 01   0.25
 10   0.25
 11   0.25"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string8():
     outcomes = ['00', '01', '10', '11']
@@ -238,7 +240,7 @@ RV Names:       None
 x    p(x)
 0!   0.5
 1!   0.5"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string9():
     # Basic
@@ -259,7 +261,7 @@ x    log p(x)
 01   -2.0
 10   -2.0
 11   -2.0"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_to_string10():
     # Basic
@@ -270,7 +272,7 @@ Alphabet: (0, 1)
 Base:     2
 
 x   log p(x)"""
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_prepare_string1():
     # Basic
@@ -278,7 +280,8 @@ def test_prepare_string1():
     pmf = [1/4]*4
     d = ScalarDistribution(outcomes, pmf)
     from dit.distribution import prepare_string
-    assert_raises(ditException, prepare_string, d, show_mask=True)
+    with pytest.raises(ditException):
+        prepare_string(d, show_mask=True)
 
 def test_prepare_string2():
     # Basic
@@ -286,7 +289,8 @@ def test_prepare_string2():
     pmf = [1/4]*4
     d = ScalarDistribution(outcomes, pmf)
     from dit.distribution import prepare_string
-    assert_raises(ditException, prepare_string, d, str_outcomes=True)
+    with pytest.raises(ditException):
+        prepare_string(d, str_outcomes=True)
 
 def test_prepare_string3():
     outcomes = [(0, 0), (0, 1), (1, 0), (1, 1)]
@@ -305,7 +309,7 @@ x    p(x)
 10   0.25
 11   0.25"""
     s = d.to_string(str_outcomes=True)
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_prepare_string4():
     class WeirdInt(int):
@@ -328,7 +332,7 @@ x        p(x)
 (1, 0)   0.25
 (1, 1)   0.25"""
     s = d.to_string(str_outcomes=True)
-    assert_equal(s, s_)
+    assert s == s_
 
 def test_really_big_words():
     """
@@ -339,4 +343,4 @@ def test_really_big_words():
     d = Distribution(outcomes, pmf)
     d = d.coalesce([range(30), range(30, 60), range(60, 90)])
     new_outcomes = (('10'*15,)*3, ('01'*15,)*3)
-    assert_equal(d.outcomes, new_outcomes)
+    assert d.outcomes == new_outcomes

--- a/dit/tests/test_helpers.py
+++ b/dit/tests/test_helpers.py
@@ -4,7 +4,7 @@ Tests for dit.helpers.
 
 from __future__ import division
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 from dit import Distribution
 from dit.exceptions import ditException, InvalidDistribution, InvalidOutcome
@@ -14,48 +14,55 @@ from dit.helpers import construct_alphabets, get_product_func, parse_rvs, \
 def test_construct_alphabets1():
     outcomes = ['00', '01', '10', '11']
     alphas = construct_alphabets(outcomes)
-    assert_equal(alphas, (('0', '1'), ('0', '1')))
+    assert alphas == (('0', '1'), ('0', '1'))
 
 def test_construct_alphabets2():
     outcomes = 3
-    assert_raises(TypeError, construct_alphabets, outcomes)
+    with pytest.raises(TypeError):
+        construct_alphabets(outcomes)
 
 def test_construct_alphabets3():
     outcomes = [0, 1, 2]
-    assert_raises(ditException, construct_alphabets, outcomes)
+    with pytest.raises(ditException):
+        construct_alphabets(outcomes)
 
 def test_construct_alphabets4():
     outcomes = ['0', '1', '01']
-    assert_raises(ditException, construct_alphabets, outcomes)
+    with pytest.raises(ditException):
+        construct_alphabets(outcomes)
 
 def test_parse_rvs1():
     outcomes = ['00', '11']
     pmf = [1/2]*2
     d = Distribution(outcomes, pmf)
-    assert_raises(ditException, parse_rvs, d, [0, 0, 1])
+    with pytest.raises(ditException):
+        parse_rvs(d, [0, 0, 1])
 
 def test_parse_rvs2():
     outcomes = ['00', '11']
     pmf = [1/2]*2
     d = Distribution(outcomes, pmf)
     d.set_rv_names('XY')
-    assert_raises(ditException, parse_rvs, d, ['X', 'Y', 'Z'])
+    with pytest.raises(ditException):
+        parse_rvs(d, ['X', 'Y', 'Z'])
 
 def test_parse_rvs3():
     outcomes = ['00', '11']
     pmf = [1/2]*2
     d = Distribution(outcomes, pmf)
-    assert_raises(ditException, parse_rvs, d, [0, 1, 2])
+    with pytest.raises(ditException):
+        parse_rvs(d, [0, 1, 2])
 
 def test_reorder1():
     outcomes = ['00', '11', '01']
     pmf = [1/3]*3
     sample_space = ('00', '01', '10', '11')
     new = reorder(outcomes, pmf, sample_space)
-    assert_equal(new[0], ['00', '01', '11'])
+    assert new[0] == ['00', '01', '11']
 
 def test_reorder2():
     outcomes = ['00', '11', '22']
     pmf = [1/3]*3
     sample_space = ('00', '01', '10', '11')
-    assert_raises(InvalidOutcome, reorder, outcomes, pmf, sample_space)
+    with pytest.raises(InvalidOutcome):
+        reorder(outcomes, pmf, sample_space)

--- a/dit/tests/test_npdist.py
+++ b/dit/tests/test_npdist.py
@@ -7,23 +7,24 @@ Tests for dit.npdist.
 
 from __future__ import division
 
-from nose.tools import (assert_almost_equal, assert_equal, assert_false,
-                        assert_raises, assert_true)
-from numpy.testing import assert_array_almost_equal
+import pytest
 
 from six.moves import map, zip # pylint: disable=redefined-builtin
+
+import numpy as np
 
 from dit.npdist import Distribution, ScalarDistribution, _make_distribution
 from dit.exceptions import ditException, InvalidDistribution, InvalidOutcome
 from dit.samplespace import CartesianProduct
 
-import numpy as np
 from itertools import product
 
 def test_init1():
     # Invalid initializations.
-    assert_raises(InvalidDistribution, Distribution, [])
-    assert_raises(InvalidDistribution, Distribution, [], [])
+    with pytest.raises(InvalidDistribution):
+        Distribution([])
+    with pytest.raises(InvalidDistribution):
+        Distribution([], [])
     Distribution([], [], sample_space=[(0, 1)], validate=False)
 
 def test_init2():
@@ -31,35 +32,39 @@ def test_init2():
     # Must pass in a sequence for outcomes.
     outcomes = map(int, ['0', '1', '2', '3', '4'])
     pmf = [1/5] * 5
-    assert_raises(TypeError, Distribution, outcomes, pmf)
+    with pytest.raises(TypeError):
+        Distribution(outcomes, pmf)
 
 def test_init3():
     dist = {'0': 1/2, '1': 1/2}
     d = Distribution(dist)
-    assert_equal(d.outcomes, ('0', '1'))
-    assert_array_almost_equal(d.pmf, [1/2, 1/2])
+    assert d.outcomes == ('0', '1')
+    assert np.allclose(d.pmf, [1/2, 1/2])
 
 def test_init4():
     dist = {'0': 1/2, '1': 1/2}
     pmf = [1/2, 1/2]
-    assert_raises(InvalidDistribution, Distribution, dist, pmf)
+    with pytest.raises(InvalidDistribution):
+        Distribution(dist, pmf)
 
 def test_init5():
     outcomes = ['0', '1', '2']
     pmf = [1/2, 1/2]
-    assert_raises(InvalidDistribution, Distribution, outcomes, pmf)
+    with pytest.raises(InvalidDistribution):
+        Distribution(outcomes, pmf)
 
 def test_init6():
     outcomes = set(['0', '1', '2'])
     pmf = [1/3]*3
-    assert_raises(ditException, Distribution, outcomes, pmf)
+    with pytest.raises(ditException):
+        Distribution(outcomes, pmf)
 
 def test_init7():
     outcomes = ['0', '1']
     pmf = [1/2, 1/2]
     d1 = Distribution(outcomes, pmf)
     d2 = Distribution.from_distribution(d1)
-    assert_true(d1.is_approx_equal(d2))
+    assert d1.is_approx_equal(d2)
 
 def test_init8():
     outcomes = [(0,), (1,)]
@@ -67,7 +72,7 @@ def test_init8():
     d1 = ScalarDistribution(pmf)
     d2 = Distribution.from_distribution(d1)
     d3 = Distribution(outcomes, pmf)
-    assert_true(d2.is_approx_equal(d3))
+    assert d2.is_approx_equal(d3)
 
 def test_init9():
     outcomes = [(0,), (1,)]
@@ -76,7 +81,7 @@ def test_init9():
     d2 = Distribution.from_distribution(d1, base=10)
     d3 = Distribution(outcomes, pmf)
     d3.set_base(10)
-    assert_true(d2.is_approx_equal(d3))
+    assert d2.is_approx_equal(d3)
 
 def test_atoms():
     pmf = [.125, .125, .125, .125, .25, 0, .25]
@@ -84,15 +89,15 @@ def test_atoms():
     d = Distribution(outcomes, pmf)
 
     atoms = d._product(['0','1','2', '3'], repeat=3)
-    assert_equal(list(d.atoms()), list(atoms))
+    assert list(d.atoms()) == list(atoms)
 
     patoms = ['000', '011', '101', '110', '222', '333']
-    assert_equal(list(d.atoms(patoms=True)), patoms)
+    assert list(d.atoms(patoms=True)) == patoms
 
     ss = CartesianProduct.from_outcomes(outcomes + ['444'])
     d = Distribution(outcomes, pmf, sample_space=ss)
     atoms = d._product(['0','1','2', '3', '4'], repeat=3)
-    assert_equal(list(d.atoms()), list(atoms))
+    assert list(d.atoms()) == list(atoms)
 
 def test_zipped():
     pmf = [.125, .125, .125, .125, .25, 0, .25]
@@ -101,42 +106,43 @@ def test_zipped():
 
     outcomes_, pmf_ = list(zip(*d.zipped()))
     d2 = Distribution(outcomes_, pmf_)
-    assert_true(d.is_approx_equal(d2))
+    assert d.is_approx_equal(d2)
 
     outcomes_, pmf_ = list(zip(*d.zipped(mode='atoms')))
     d3 = Distribution(outcomes_, pmf_)
-    assert_true(d.is_approx_equal(d3))
+    assert d.is_approx_equal(d3)
 
     outcomes_, pmf_ = list(zip(*d.zipped(mode='patoms')))
     d4 = Distribution(outcomes_, pmf_)
     d.make_sparse()
-    np.testing.assert_allclose(d.pmf, d4.pmf)
+    assert np.allclose(d.pmf, d4.pmf)
 
 def test_make_distribution():
     outcomes = ['0', '1']
     pmf = [1/2, 1/2]
     d = _make_distribution(outcomes, pmf, None)
-    assert_true(type(d) is Distribution)
-    assert_equal(d.outcomes, ('0', '1'))
+    assert type(d) is Distribution
+    assert d.outcomes == ('0', '1')
 
 def test_setitem1():
     d = Distribution(['0', '1'], [1/2, 1/2])
-    assert_raises(InvalidOutcome, d.__setitem__, '2', 0)
+    with pytest.raises(InvalidOutcome):
+        d.__setitem__('2', 0)
 
 def test_setitem2():
     d = Distribution(['00', '11'], [1, 0])
     d.make_sparse()
     d['11'] = 1/2
     d.normalize()
-    assert_true('11' in d)
-    assert_almost_equal(d['11'], 1/3)
+    assert '11' in d
+    assert d['11'] == pytest.approx(1/3)
 
 def test_coalesce():
     outcomes = ['000', '011', '101', '110']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     d = d.coalesce([[0, 1], [2]])
-    assert_equal(d.outcome_length(), 2)
+    assert d.outcome_length() == 2
 
 def test_copy():
     outcomes = ['0', '1']
@@ -145,36 +151,36 @@ def test_copy():
     d2 = d1.copy(base=10)
     d3 = Distribution(outcomes, pmf)
     d3.set_base(10)
-    assert_true(d2.is_approx_equal(d3))
+    assert d2.is_approx_equal(d3)
 
 def test_outcome_length():
     outcomes = ['000', '011', '101', '110']
     pmf = [1/4]*4
     d = Distribution(outcomes, pmf)
     d = d.marginal([0, 2])
-    assert_equal(d.outcome_length(), 2)
-    assert_equal(d.outcome_length(masked=True), 3)
+    assert d.outcome_length() == 2
+    assert d.outcome_length(masked=True) == 3
 
 def test_has_outcome1():
     d = Distribution(['0', '1'], [1, 0])
     d.make_sparse()
-    assert_false(d.has_outcome('1', null=False))
+    assert not d.has_outcome('1', null=False)
 
 def test_has_outcome2():
     d = Distribution(['0', '1'], [1, 0])
-    assert_false(d.has_outcome('1', null=False))
+    assert not d.has_outcome('1', null=False)
 
 def test_is_homogeneous1():
     outcomes = ['00', '11']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_true(d.is_homogeneous())
+    assert d.is_homogeneous()
 
 def test_is_homogeneous2():
     outcomes = ['00', '01']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_false(d.is_homogeneous())
+    assert not d.is_homogeneous()
 
 def test_marginalize():
     outcomes = ['000', '011', '101', '110']
@@ -182,16 +188,18 @@ def test_marginalize():
     d = Distribution(outcomes, pmf)
     d1 = d.marginal([0, 2])
     d2 = d.marginalize([1])
-    assert_true(d1.is_approx_equal(d2))
+    assert d1.is_approx_equal(d2)
 
 def test_set_rv_names1():
     outcomes = ['00', '11']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_raises(ditException, d.set_rv_names, 'X')
+    with pytest.raises(ditException):
+        d.set_rv_names('X')
 
 def test_set_rv_names2():
     outcomes = ['00', '11']
     pmf = [1/2, 1/2]
     d = Distribution(outcomes, pmf)
-    assert_raises(ditException, d.set_rv_names, 'XYZ')
+    with pytest.raises(ditException):
+        d.set_rv_names('XYZ')

--- a/dit/tests/test_npscalardist.py
+++ b/dit/tests/test_npscalardist.py
@@ -4,9 +4,9 @@ Tests for dit.npscalardist.
 
 from __future__ import division
 
-from nose.tools import assert_almost_equal, assert_equal, assert_raises, \
-                       assert_true, assert_false
-from numpy.testing import assert_array_almost_equal
+import pytest
+
+import numpy as np
 
 from itertools import product
 
@@ -17,45 +17,50 @@ from dit.exceptions import ditException, InvalidDistribution, InvalidOutcome
 def test_init1():
     dist = {0: 1/2, 1: 1/2}
     d = ScalarDistribution(dist)
-    assert_equal(d.outcomes, (0, 1))
-    assert_array_almost_equal(d.pmf, [1/2, 1/2])
+    assert d.outcomes == (0, 1)
+    assert np.allclose(d.pmf, [1/2, 1/2])
 
 def test_init2():
     dist = {0: 1/2, 1: 1/2}
     pmf = [1/2, 1/2]
-    assert_raises(ditException, ScalarDistribution, dist, pmf)
+    with pytest.raises(ditException):
+        ScalarDistribution(dist, pmf)
 
 def test_init3():
     pmf = ['a', 'b', 'c']
-    assert_raises(ditException, ScalarDistribution, pmf)
+    with pytest.raises(ditException):
+        ScalarDistribution(pmf)
 
 def test_init4():
     outcomes = float
     pmf = int
-    assert_raises(TypeError, ScalarDistribution, outcomes, pmf)
+    with pytest.raises(TypeError):
+        ScalarDistribution(outcomes, pmf)
 
 def test_init5():
     outcomes = [0, 1, 2]
     pmf = [1/2, 1/2]
-    assert_raises(InvalidDistribution, ScalarDistribution, outcomes, pmf)
+    with pytest.raises(InvalidDistribution):
+        ScalarDistribution(outcomes, pmf)
 
 def test_init6():
     outcomes = set([0, 1])
     pmf = [1/2, 1/2]
-    assert_raises(ditException, ScalarDistribution, outcomes, pmf)
+    with pytest.raises(ditException):
+        ScalarDistribution(outcomes, pmf)
 
 def test_init7():
     outcomes = [0, 1, 2]
     pmf = [1/2, 1/2, 0]
     d = ScalarDistribution(outcomes, pmf, trim=True)
-    assert_equal(len(d.outcomes), 2)
+    assert len(d.outcomes) == 2
 
 def test_init8():
     outcomes = [0, 1, 2]
     pmf = [1/3]*3
     d1 = ScalarDistribution(outcomes, pmf)
     d2 = ScalarDistribution.from_distribution(d1)
-    assert_true(d1.is_approx_equal(d2))
+    assert d1.is_approx_equal(d2)
 
 def test_init9():
     outcomes = [0, 1, 2]
@@ -63,12 +68,13 @@ def test_init9():
     d1 = ScalarDistribution(outcomes, pmf)
     d2 = ScalarDistribution.from_distribution(d1, base=10)
     d1.set_base(10)
-    assert_true(d1.is_approx_equal(d2))
+    assert d1.is_approx_equal(d2)
 
 def test_init10():
     outcomes = []
     pmf = []
-    assert_raises(InvalidDistribution, ScalarDistribution, outcomes, pmf)
+    with pytest.raises(InvalidDistribution):
+        ScalarDistribution(outcomes, pmf)
 
 def test_init11():
     outcomes = ['0', '1']
@@ -76,7 +82,7 @@ def test_init11():
     d = Distribution(outcomes, pmf)
     sd = ScalarDistribution.from_distribution(d)
     # Different sample space representations
-    assert_false(d.is_approx_equal(sd))
+    assert not d.is_approx_equal(sd)
 
 def test_init12():
     outcomes = ['0', '1']
@@ -85,24 +91,25 @@ def test_init12():
     sd = ScalarDistribution.from_distribution(d, base=10)
     d.set_base(10)
     # Different sample space representations
-    assert_false(d.is_approx_equal(sd))
+    assert not d.is_approx_equal(sd)
 
 def test_del1():
     d = ScalarDistribution([1/2, 1/2])
     del d[1]
     d.normalize()
-    assert_almost_equal(d[0], 1)
+    assert d[0] == pytest.approx(1)
 
 def test_del2():
     d = ScalarDistribution([1/2, 1/2])
     d.make_dense()
     del d[1]
     d.normalize()
-    assert_almost_equal(d[0], 1)
+    assert d[0] == pytest.approx(1)
 
 def test_del3():
     d = ScalarDistribution([1/2, 1/2])
-    assert_raises(InvalidOutcome, d.__delitem__, 2)
+    with pytest.raises(InvalidOutcome):
+        d.__delitem__(2)
 
 def test_setitem1():
     pmf = [1/2, 1/2]
@@ -110,12 +117,13 @@ def test_setitem1():
     d[0] = 1
     d[1] = 0
     d.make_sparse()
-    assert_equal(d.outcomes, (0,))
+    assert d.outcomes == (0,)
 
 def test_setitem2():
     pmf = [1/2, 1/2]
     d = ScalarDistribution(pmf)
-    assert_raises(InvalidOutcome, d.__setitem__, 2, 1/2)
+    with pytest.raises(InvalidOutcome):
+        d.__setitem__(2, 1/2)
 
 def test_setitem3():
     outcomes = (0, 1)
@@ -123,66 +131,66 @@ def test_setitem3():
     d = ScalarDistribution(outcomes, pmf, sample_space=(0, 1, 2))
     d[2] = 1/2
     d.normalize()
-    assert_array_almost_equal(d.pmf, [1/3]*3)
+    assert np.allclose(d.pmf, [1/3]*3)
 
 def test_has_outcome1():
     d = ScalarDistribution([1, 0])
-    assert_true(d.has_outcome(1))
+    assert d.has_outcome(1)
 
 def test_has_outcome2():
     d = ScalarDistribution([1, 0])
-    assert_false(d.has_outcome(1, null=False))
+    assert not d.has_outcome(1, null=False)
 
 def test_has_outcome3():
     d = ScalarDistribution([1, 0])
-    assert_false(d.has_outcome(2, null=False))
+    assert not d.has_outcome(2, null=False)
 
 def test_is_approx_equal1():
     d1 = ScalarDistribution([1/2, 1/2, 0])
     d1.make_dense()
     d2 = ScalarDistribution([1/2, 1/2, 0])
     d2.make_dense()
-    assert_true(d1.is_approx_equal(d2))
+    assert d1.is_approx_equal(d2)
 
 def test_is_approx_equal2():
     d1 = ScalarDistribution([1/2, 1/2, 0])
     d1.make_dense()
     d2 = ScalarDistribution([1/2, 0, 1/2])
     d2.make_dense()
-    assert_false(d1.is_approx_equal(d2))
+    assert not d1.is_approx_equal(d2)
 
 def test_is_approx_equal3():
     d1 = ScalarDistribution([1/2, 1/2], sample_space=(0, 1, 2))
     d2 = ScalarDistribution([1/2, 1/2])
-    assert_false(d1.is_approx_equal(d2))
+    assert not d1.is_approx_equal(d2)
 
 def test_add():
     d1 = uniform_scalar_distribution(range(3))
     d2 = uniform_scalar_distribution(range(1, 4))
     d3 = ScalarDistribution([0, 1, 2, 3, 4], [1/9, 2/9, 3/9, 2/9, 1/9])
-    assert_true((d1+1).is_approx_equal(d2))
-    assert_true((1+d1).is_approx_equal(d2))
-    assert_true((d2).is_approx_equal(d1+1))
-    assert_true((d2).is_approx_equal(1+d1))
-    assert_true((d1+d1).is_approx_equal(d3))
+    assert (d1+1).is_approx_equal(d2)
+    assert (1+d1).is_approx_equal(d2)
+    assert (d2).is_approx_equal(d1+1)
+    assert (d2).is_approx_equal(1+d1)
+    assert (d1+d1).is_approx_equal(d3)
 
 def test_sub():
     d1 = uniform_scalar_distribution(range(3))
     d2 = uniform_scalar_distribution(range(1, 4))
     d3 = ScalarDistribution([-2, -1, 0, 1, 2], [1/9, 2/9, 3/9, 2/9, 1/9])
-    assert_true((d2-1).is_approx_equal(d1))
-    assert_true((3-d2).is_approx_equal(d1))
-    assert_true((d1).is_approx_equal(d2-1))
-    assert_true((d1).is_approx_equal(3-d2))
-    assert_true((d1-d1).is_approx_equal(d3))
+    assert (d2-1).is_approx_equal(d1)
+    assert (3-d2).is_approx_equal(d1)
+    assert (d1).is_approx_equal(d2-1)
+    assert (d1).is_approx_equal(3-d2)
+    assert (d1-d1).is_approx_equal(d3)
 
 def test_mul():
     d1 = uniform_scalar_distribution(range(1, 3))
     d2 = ScalarDistribution([1, 2, 4], [0.25, 0.5, 0.25])
     d3 = ScalarDistribution([2, 4], [0.5, 0.5])
-    assert_true((d1*d1).is_approx_equal(d2))
-    assert_true((d1*2).is_approx_equal(d3))
-    assert_true((2*d1).is_approx_equal(d3))
+    assert (d1*d1).is_approx_equal(d2)
+    assert (d1*2).is_approx_equal(d3)
+    assert (2*d1).is_approx_equal(d3)
 
 def test_div():
     d1 = uniform_scalar_distribution([2,4,6])
@@ -191,9 +199,9 @@ def test_div():
     d4 = uniform_scalar_distribution([12,6,4,3,2])
     d5 = uniform_scalar_distribution([1,2])
     d6 = ScalarDistribution([1,2,3,4,6], [1/6,1/3,1/6,1/6,1/6])
-    assert_true((d1/2).is_approx_equal(d3))
-    assert_true((12/d2).is_approx_equal(d4))
-    assert_true((d1/d5).is_approx_equal(d6))
+    assert (d1/2).is_approx_equal(d3)
+    assert (12/d2).is_approx_equal(d4)
+    assert (d1/d5).is_approx_equal(d6)
 
 def test_floordiv():
     d1 = uniform_scalar_distribution(range(1, 7))
@@ -201,68 +209,70 @@ def test_floordiv():
     d3 = ScalarDistribution([1,2,3,6], [1/2,1/6,1/6,1/6])
     d4 = uniform_scalar_distribution(range(1, 3))
     d5 = ScalarDistribution([0,1,2,3,4,5,6],[1/12,1/4,1/4,1/6,1/12,1/12,1/12])
-    assert_true((d1//2).is_approx_equal(d2))
-    assert_true((6//d1).is_approx_equal(d3))
-    assert_true((d1//d4).is_approx_equal(d5))
+    assert (d1//2).is_approx_equal(d2)
+    assert (6//d1).is_approx_equal(d3)
+    assert (d1//d4).is_approx_equal(d5)
 
 def test_mod():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = uniform_scalar_distribution(range(2))
     d3 = uniform_scalar_distribution(range(1,3))
     d4 = ScalarDistribution([0,1],[3/4,1/4])
-    assert_true((d1%2).is_approx_equal(d2))
-    assert_true((5%d3).is_approx_equal(d2))
-    assert_true((d1%d3).is_approx_equal(d4))
+    assert (d1%2).is_approx_equal(d2)
+    assert (5%d3).is_approx_equal(d2)
+    assert (d1%d3).is_approx_equal(d4)
 
 def test_lt():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = uniform_scalar_distribution(range(2))
     d3 = ScalarDistribution([True, False], [11/12, 1/12])
-    assert_true((d1 < 4).is_approx_equal(d2))
-    assert_true((d2 < d1).is_approx_equal(d3))
+    assert (d1 < 4).is_approx_equal(d2)
+    assert (d2 < d1).is_approx_equal(d3)
 
 def test_le():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = uniform_scalar_distribution(range(2))
     d3 = ScalarDistribution([True], [1])
-    assert_true((d1 <= 3).is_approx_equal(d2))
-    assert_true((d2 <= d1).is_approx_equal(d3))
+    assert (d1 <= 3).is_approx_equal(d2)
+    assert (d2 <= d1).is_approx_equal(d3)
 
 def test_eq():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = ScalarDistribution([True, False], [1/6, 5/6])
-    assert_true((d1 == 6).is_approx_equal(d2))
-    assert_true((d1 == d1).is_approx_equal(d2))
+    assert (d1 == 6).is_approx_equal(d2)
+    assert (d1 == d1).is_approx_equal(d2)
 
 def test_ne():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = ScalarDistribution([True, False], [5/6, 1/6])
-    assert_true((d1 != 6).is_approx_equal(d2))
-    assert_true((d1 != d1).is_approx_equal(d2))
+    assert (d1 != 6).is_approx_equal(d2)
+    assert (d1 != d1).is_approx_equal(d2)
 
 def test_gt():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = uniform_scalar_distribution(range(2))
     d3 = ScalarDistribution([True, False], [11/12, 1/12])
-    assert_true((d1 > 3).is_approx_equal(d2))
-    assert_true((d1 > d2).is_approx_equal(d3))
+    assert (d1 > 3).is_approx_equal(d2)
+    assert (d1 > d2).is_approx_equal(d3)
 
 def test_ge():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = uniform_scalar_distribution(range(2))
     d3 = ScalarDistribution([True], [1])
-    assert_true((d1 >= 4).is_approx_equal(d2))
-    assert_true((d1 >= d2).is_approx_equal(d3))
+    assert (d1 >= 4).is_approx_equal(d2)
+    assert (d1 >= d2).is_approx_equal(d3)
 
 def test_matmul():
     d1 = uniform_scalar_distribution(range(1,7))
     d2 = Distribution(list(product(d1.outcomes, repeat=2)), [1/36]*36)
-    assert_true((d1.__matmul__(d1)).is_approx_equal(d2))
+    assert (d1.__matmul__(d1)).is_approx_equal(d2)
 
 def test_cmp_fail():
     d1 = uniform_scalar_distribution(range(1,7))
-    assert_raises(NotImplementedError, lambda x: x + '0', d1)
+    with pytest.raises(NotImplementedError):
+        (lambda x: x + '0')(d1)
 
 def test_matmul_fail():
     d1 = uniform_scalar_distribution(range(1,7))
-    assert_raises(NotImplementedError, lambda x: x.__matmul__('0'), d1)
+    with pytest.raises(NotImplementedError):
+        (lambda x: x.__matmul__('0'))(d1)

--- a/dit/tests/test_params.py
+++ b/dit/tests/test_params.py
@@ -2,8 +2,7 @@
 Tests for dit.params.
 """
 
-from nose.tools import (assert_almost_equal, assert_equal, assert_false,
-                        assert_true, assert_raises)
+import pytest
 
 from numpy import inf, nan
 
@@ -15,18 +14,19 @@ def test_validate_boolean1():
     good = ['t', 'T', 'y', 'Y', 'yes', 'Yes', 'YES', 'on', 'On', 'ON', 'true',
             'True', 'TRUE', '1', 1, True]
     for value in good:
-        assert_true(validate_boolean(value))
+        assert validate_boolean(value)
 
 def test_validate_boolean2():
     bad = ['f', 'F', 'n', 'N', 'no', 'No', 'NO', 'off', 'Off', 'OFF', 'false',
            'False', 'FALSE', '0', 0, False]
     for value in bad:
-        assert_false(validate_boolean(value))
+        assert not validate_boolean(value)
 
 def test_validate_boolean3():
     not_valid = ['maybe', 2, 0.5]
     for value in not_valid:
-        assert_raises(ValueError, validate_boolean, value)
+        with pytest.raises(ValueError):
+            validate_boolean(value)
 
 def test_validate_float1():
     good = [0.5, 0, '0.123', 2, inf, nan]
@@ -34,38 +34,42 @@ def test_validate_float1():
         val1 = validate_float(value)
         val2 = float(value)
         if not val1 is val2:
-            assert_almost_equal(val1, val2)
+            assert val1 == pytest.approx(val2)
 
 def test_validate_float2():
     bad = ['pants', float, []]
     for value in bad:
-        assert_raises(ValueError, validate_float, value)
+        with pytest.raises(ValueError):
+            validate_float(value)
 
 def test_validate_base1():
     good = ['e', 'linear', 0.5, 1.5, 2, 10]
     for value in good:
-        assert_equal(validate_base(value), value)
+        assert validate_base(value) == value
 
 def test_validate_base2():
     bad = ['nope', -0.5, 0, 1]
     for value in bad:
-        assert_raises(InvalidBase, validate_base, value)
+        with pytest.raises(InvalidBase):
+            validate_base(value)
 
 def test_validate_choice1():
     choices = [0, 1, '2', 3, 'four']
     for choice in choices:
-        assert_equal(validate_choice(choice, choices), choice)
+        assert validate_choice(choice, choices) == choice
 
 def test_validate_choice2():
     choices = [0, 1, 2]
     bads = ['0', '1', '2']
     for choice in bads:
-        assert_raises(ValueError, validate_choice, choice, choices)
+        with pytest.raises(ValueError):
+            validate_choice(choice, choices)
 
 def test_validate_text1():
     for s in ['ascii', 'linechar']:
-        assert_equal(validate_text(s), s)
+        assert validate_text(s) == s
 
 def test_validate_text2():
     for s in ['no', 3]:
-        assert_raises(ValueError, validate_text, s)
+        with pytest.raises(ValueError):
+            validate_text(s)

--- a/dit/tests/test_samplespace.py
+++ b/dit/tests/test_samplespace.py
@@ -1,11 +1,12 @@
-from nose.tools import *
+
+import pytest
 
 from dit.samplespace import SampleSpace, CartesianProduct
 
 import dit
 
 class TestSampleSpace(object):
-    def setUp(self):
+    def setup_class(self):
         product = dit.helpers.get_product_func(str)
         self.samplespace = ['00', '01', '10', '12']
         self.ss = SampleSpace(self.samplespace, product)
@@ -13,43 +14,43 @@ class TestSampleSpace(object):
     def test_samplespace_auto(self):
         samplespace = ['00', '01', '10', '12']
         ss = SampleSpace(samplespace)
-        assert_equal(list(ss), list(self.ss))
+        assert list(ss) == list(self.ss)
 
     def test_samplespace(self):
-        assert_equal(list(self.ss), self.samplespace)
-        assert_equal(len(self.ss), 4)
-        assert_equal(self.ss.outcome_length(), 2)
-        assert_true('00' in self.ss)
-        assert_false('22' in self.ss)
+        assert list(self.ss) == self.samplespace
+        assert len(self.ss) == 4
+        assert self.ss.outcome_length() == 2
+        assert '00' in self.ss
+        assert not '22' in self.ss
 
     def test_marginalize(self):
         ss0 = self.ss.marginalize([1])
-        assert_equal(list(ss0), ['0', '1'])
+        assert list(ss0) == ['0', '1']
 
     def test_marginal(self):
         ss1 = self.ss.marginal([1])
-        assert_equal(list(ss1), ['0', '1', '2'])
+        assert list(ss1) == ['0', '1', '2']
 
     def test_coalesce(self):
         ss2 = self.ss.coalesce([[0,1,1],[1,0]])
         ss2_ = [('000', '00'), ('011', '10'), ('100', '01'), ('122', '21')]
-        assert_equal(list(ss2), ss2_)
+        assert list(ss2) == ss2_
 
     def test_sort(self):
         product = dit.helpers.get_product_func(str)
         samplespace = ['00', '01', '12', '10']
         ss = SampleSpace(samplespace, product)
-        assert_equal(list(ss), samplespace)
+        assert list(ss) == samplespace
         indexes = [ss.index(i) for i in samplespace]
-        assert_equal(indexes, list(range(len(samplespace))))
+        assert indexes == list(range(len(samplespace)))
 
         ss.sort()
-        assert_equal(list(ss), sorted(samplespace))
+        assert list(ss) == sorted(samplespace)
         indexes = [ss.index(i) for i in samplespace]
-        assert_equal(indexes, [0, 1, 3, 2])
+        assert indexes == [0, 1, 3, 2]
 
 class TestCartesianProduct(object):
-    def setUp(self):
+    def setup_class(self):
         product = dit.helpers.get_product_func(str)
         alphabets = [['0', '1'], ['0', '1', '2']]
         self.ss = CartesianProduct(alphabets, product)
@@ -57,22 +58,22 @@ class TestCartesianProduct(object):
     def test_stralphabets(self):
         # Test that str product is inferred.
         x = CartesianProduct([['0', '1']]*2)
-        assert_equal(list(x), ['00', '01', '10', '11'])
+        assert list(x) == ['00', '01', '10', '11']
 
     def test_samplespace(self):
-        assert_equal(list(self.ss), ['00', '01', '02', '10', '11', '12'])
-        assert_equal(len(self.ss), 6)
-        assert_equal(self.ss.outcome_length(), 2)
-        assert_true('00' in self.ss)
-        assert_false('22' in self.ss)
+        assert list(self.ss) == ['00', '01', '02', '10', '11', '12']
+        assert len(self.ss) == 6
+        assert self.ss.outcome_length() == 2
+        assert '00' in self.ss
+        assert not '22' in self.ss
 
     def test_marginalize(self):
         ss0 = self.ss.marginalize([1])
-        assert_equal(list(ss0), ['0', '1'])
+        assert list(ss0) == ['0', '1']
 
     def test_marginal(self):
         ss1 = self.ss.marginal([1])
-        assert_equal(list(ss1), ['0', '1', '2'])
+        assert list(ss1) == ['0', '1', '2']
 
     def test_coalesce(self):
         ss2 = self.ss.coalesce([[1,0],[1]])
@@ -82,29 +83,30 @@ class TestCartesianProduct(object):
                  ('11', '0'), ('11', '1'), ('11', '2'),
                  ('20', '0'), ('20', '1'), ('20', '2'),
                  ('21', '0'), ('21', '1'), ('21', '2')]
-        assert_equal(list(ss2), ss2_)
+        assert list(ss2) == ss2_
 
     def test_sort(self):
         alphabets = [[0,1], [2,1]]
         ss = CartesianProduct(alphabets)
         indexes = [ss.index(i) for i in list(ss)]
-        assert_equal(indexes, list(range(len(ss))))
+        assert indexes == list(range(len(ss)))
 
         samplespace = list(ss)
         ss.sort()
         indexes = [ss.index(i) for i in samplespace]
-        assert_equal(indexes, [1, 0, 3, 2])
+        assert indexes == [1, 0, 3, 2]
 
     def test_from_outcomes(self):
         outcomes = ['00', '11']
         ss = CartesianProduct.from_outcomes(outcomes)
-        assert_equal(list(ss), ['00', '01', '10', '11'])
-        assert_raises(ValueError, ss.index, '22')
+        assert list(ss) == ['00', '01', '10', '11']
+        with pytest.raises(ValueError):
+            ss.index('22')
 
 def test_nested():
     outcomes = ['11', '00']
     ss = CartesianProduct.from_outcomes(outcomes)
     ss2 = CartesianProduct([[0], ss])
-    assert_equal(list(ss2), [(0,'11'), (0,'10'), (0,'01'), (0,'00')])
+    assert list(ss2) == [(0,'11'), (0,'10'), (0,'01'), (0,'00')]
     ss2.sort()
-    assert_equal(list(ss2), [(0,'00'), (0,'01'), (0,'10'), (0,'11')])
+    assert list(ss2) == [(0,'00'), (0,'01'), (0,'10'), (0,'11')]

--- a/dit/tests/test_validate.py
+++ b/dit/tests/test_validate.py
@@ -2,7 +2,7 @@
 Tests for dit.validate.
 """
 
-from nose.tools import assert_false, assert_raises, assert_true
+import pytest
 
 import numpy as np
 
@@ -14,73 +14,81 @@ def test_is_pmf():
     ops = LinearOperations()
 
     pmf = np.asarray([0.5, 0.5])
-    assert_true(v.is_pmf(pmf, ops))
+    assert v.is_pmf(pmf, ops)
 
     pmf = np.array([0.6, 0.7])
-    assert_false(v.is_pmf(pmf, ops))
+    assert not v.is_pmf(pmf, ops)
 
     pmf = np.array([1.6, -0.6])
-    assert_false(v.is_pmf(pmf, ops))
+    assert not v.is_pmf(pmf, ops)
 
 def test_validate_normalization():
     ops = LinearOperations()
 
     pmf = np.asarray([0.6, 0.4])
-    assert_true(v.validate_normalization(pmf, ops))
+    assert v.validate_normalization(pmf, ops)
 
     pmf = np.asarray([0.6, 0.6])
-    assert_raises(v.InvalidNormalization, v.validate_normalization, pmf, ops)
+    with pytest.raises(v.InvalidNormalization):
+        v.validate_normalization(pmf, ops)
 
 def test_validate_outcomes():
     outcomes = [1, 2, 3]
     sample_space = [1, 2, 3, 4]
-    assert_true(v.validate_outcomes(outcomes, sample_space))
+    assert v.validate_outcomes(outcomes, sample_space)
 
     # One bad outcome
     outcomes = [1, 2, 3]
     sample_space = [1, 2, 4]
-    assert_raises(v.InvalidOutcome, v.validate_outcomes, outcomes, sample_space)
+    with pytest.raises(v.InvalidOutcome):
+        v.validate_outcomes(outcomes, sample_space)
 
     # Multiple bad outcomes
     outcomes = [1, 2, 3]
     sample_space = [1]
-    assert_raises(v.InvalidOutcome, v.validate_outcomes, outcomes, sample_space)
+    with pytest.raises(v.InvalidOutcome):
+        v.validate_outcomes(outcomes, sample_space)
 
 def test_validate_pmf():
     # Already covered by other tests
     ops = LinearOperations()
     pmf = np.asarray([0.5, 0.5])
-    assert_true(v.is_pmf(pmf, ops))
+    assert v.is_pmf(pmf, ops)
 
 def test_validate_probabilities():
     # Already covered by other tests
     ops = LinearOperations()
     pmf = np.asarray([0.5, 0.5])
-    assert_true(v.validate_probabilities(pmf, ops))
+    assert v.validate_probabilities(pmf, ops)
 
     ops = LogOperations(2)
     pmf = np.array([0.1, 0.23, -0.523])
-    assert_raises(v.InvalidProbability, v.validate_probabilities, pmf, ops)
+    with pytest.raises(v.InvalidProbability):
+        v.validate_probabilities(pmf, ops)
 
 def test_validate_sequence():
     x = '101'
-    assert_true(v.validate_sequence(x))
+    assert v.validate_sequence(x)
     x = 3
-    assert_raises(dit.exceptions.ditException, v.validate_sequence, x)
+    with pytest.raises(dit.exceptions.ditException):
+        v.validate_sequence(x)
 
 def test_validate_outcome_class():
     x = [1, 2, 3]
-    assert_true(v.validate_outcome_class(x))
+    assert v.validate_outcome_class(x)
     x = [1, 2, '3']
-    assert_raises(dit.exceptions.ditException, v.validate_outcome_class, x)
+    with pytest.raises(dit.exceptions.ditException):
+        v.validate_outcome_class(x)
 
 def test_validate_outcome_length():
     # Is a sequence
     x = ['1', '2', '3']
-    assert_true(v.validate_outcome_length(x))
+    assert v.validate_outcome_length(x)
     # Not a sequence
     x = ['1', '2', 3]
-    assert_raises(dit.exceptions.ditException, v.validate_outcome_length, x)
+    with pytest.raises(dit.exceptions.ditException):
+        v.validate_outcome_length(x)
     # Unequal lengths
     x = ['1', '2', '33']
-    assert_raises(dit.exceptions.ditException, v.validate_outcome_length, x)
+    with pytest.raises(dit.exceptions.ditException):
+        v.validate_outcome_length(x)

--- a/dit/utils/tests/test_bindargs.py
+++ b/dit/utils/tests/test_bindargs.py
@@ -4,8 +4,6 @@ Tests for dit.utils.bindargs.
 
 from dit.utils.bindargs import bindcallargs
 
-from nose.tools import assert_equal
-
 def F0(a, b=3, *args, **kwargs): # pylint: disable=unused-argument
     pass
 
@@ -18,15 +16,14 @@ def F2(a, b=3): # pylint: disable=unused-argument
 def test_bindcallargs0():
     out = bindcallargs(F0, 5, 4, 3, 2, 1, hello='there')
     out_ = (5, 4, 3, 2, 1), {'hello': 'there'}
-    assert_equal(out, out_)
+    assert out == out_
 
 def test_bindcallargs1():
     out = bindcallargs(F1, 0, 1, 3, 4, 5, extra='hello')
     out_ = ((0, 1, 3, 4, 5), {'extra': 'hello'})
-    assert_equal(out, out_)
+    assert out == out_
 
 def test_bindcallargs2():
     out = bindcallargs(F2, 0)
     out_ = ((0, 3), {})
-    assert_equal(out, out_)
-
+    assert out == out_

--- a/dit/utils/tests/test_bindargs3.py
+++ b/dit/utils/tests/test_bindargs3.py
@@ -1,6 +1,6 @@
 from dit.utils.bindargs import bindcallargs
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 def F1(a, b, c=2, *, d, e, f=5, **kwargs):
     pass
@@ -14,18 +14,19 @@ def F3(a, b, *args, c, d=7, e=8):
 def test_bindcallargs1():
     out = bindcallargs(F1, 0, 1, d=3, e=4, extra='hello')
     out_ = ((0, 1, 2), {'d':3, 'e':4, 'f':5, 'extra': 'hello'})
-    assert_equal(out, out_)
+    assert out == out_
 
 def test_bindcallargs2():
     out = bindcallargs(F2, d=0, e=1, f=2)
     out_ = ((), {'d':0, 'e':1, 'f':2})
-    assert_equal(out, out_)
+    assert out == out_
     out = bindcallargs(F2, d=0, e=1)
     out_ = ((), {'d':0, 'e':1, 'f':5})
-    assert_equal(out, out_)
-    assert_raises(TypeError, bindcallargs, F2, d=0, f=2)
+    assert out == out_
+    with pytest.raises(TypeError):
+        bindcallargs(F2, d=0, f=2)
 
 def test_bindcallargs3():
     out = bindcallargs(F3, 0, 1, 2, 3, 4, 5, c=6, e=-8)
     out_ = ((0, 1, 2, 3, 4, 5), {'c':6, 'd':7, 'e':-8})
-    assert_equal(out, out_)
+    assert out == out_

--- a/dit/utils/tests/test_context.py
+++ b/dit/utils/tests/test_context.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import sys
 
-from nose.tools import assert_equal, assert_false, assert_true
 import os
 from dit.utils import cd, named_tempfile, tempdir
 
@@ -16,41 +15,41 @@ root = 'C:\\' if sys.platform in ('win32', 'cygwin') else '/'
 
 def test_cd():
     with cd(root):
-        assert_equal(os.getcwd(), root)
+        assert os.getcwd() == root
 
 def test_cd_bad_oldcwd():
     # Test attempting to go back to a directory that no longer exists.
     name = tempfile.mkdtemp()
     with cd(name):
-        assert_equal(os.getcwd(), os.path.realpath(name))
+        assert os.getcwd() == os.path.realpath(name)
         with cd(root):
-            assert_equal(os.getcwd(), root)
+            assert os.getcwd() == root
             os.rmdir(name)
-        assert_equal(os.getcwd(), root)
+        assert os.getcwd() == root
 
 def test_named_tempfile1():
     name = None
     with named_tempfile() as tempfile:
         name = tempfile.name
-        assert_true(os.path.isfile(name))
+        assert os.path.isfile(name)
         tempfile.write('hello'.encode('utf8'))
         tempfile.close()
-        assert_true(os.path.isfile(name))
-    assert_false(os.path.isfile(name))
+        assert os.path.isfile(name)
+    assert not os.path.isfile(name)
 
 def test_named_tempfile2():
     name = None
     # The specification of delete=True should be ignored.
     with named_tempfile(delete=True) as tempfile:
         name = tempfile.name
-        assert_true(os.path.isfile(name))
+        assert os.path.isfile(name)
         tempfile.write('hello'.encode('utf8'))
         tempfile.close()
-        assert_true(os.path.isfile(name))
-    assert_false(os.path.isfile(name))
+        assert os.path.isfile(name)
+    assert not os.path.isfile(name)
 
 
 def test_tempdir():
     with tempdir() as tmpdir:
-        assert_true(os.path.isdir(tmpdir))
-    assert_false(os.path.isdir(tmpdir))
+        assert os.path.isdir(tmpdir)
+    assert not os.path.isdir(tmpdir)

--- a/dit/utils/tests/test_latexarray.py
+++ b/dit/utils/tests/test_latexarray.py
@@ -2,8 +2,8 @@
 Tests for dit.utils.latexarray.
 """
 
-from nose.tools import assert_equal
-from nose import SkipTest
+import pytest
+
 import os
 
 import numpy as np
@@ -13,56 +13,55 @@ def test_to_latex1():
     x = np.array([1, 2, 3, 10])
     y = la.to_latex(x)
     y_ = '\\newcolumntype{X}{D{.}{.}{2,0}}\n\\begin{array}{*{4}{X}}\n  1 & 2 & 3 & 10\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex2():
     x = np.array([1, 2, -3, 100])
     y = la.to_latex(x)
     y_ = '\\newcolumntype{X}{D{.}{.}{4,0}}\n\\begin{array}{*{4}{X}}\n  1 & 2 & -3 & 100\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex3():
     x = x = np.array([0.078, 0.480, 0.413, 0.830, 0.776, 0.102, 0.513, 0.462, 0.335, 0.712])
     y = la.to_latex(x)
     y_ = '\\newcolumntype{X}{D{.}{.}{1,3}}\n\\begin{array}{*{10}{X}}\n  0.078 & 0.480 & 0.413 & 0.830 & 0.776 & 0.102 & 0.513 & 0.462 & 0.335 & 0.712\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex4():
     x = x = np.array([-0.078, 0.480, 0.413, 0.830, 0.776, 0.102, 0.513, 0.462, 0.335, 0.712])
     y = la.to_latex(x)
     y_ = '\\newcolumntype{X}{D{.}{.}{2,3}}\n\\begin{array}{*{10}{X}}\n  -0.078 & 0.480 & 0.413 & 0.830 & 0.776 & 0.102 & 0.513 & 0.462 & 0.335 & 0.712\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex5():
     np.random.seed(0)
     x = np.random.rand(12).reshape(4, 3) - 0.5
     y = la.to_latex(x, decimals=2)
     y_ = '\\newcolumntype{X}{D{.}{.}{2,2}}\n\\begin{array}{*{3}{X}}\n  0.05 & 0.22 & 0.10 \\\\\n  0.04 & -0.08 & 0.15 \\\\\n  -0.06 & 0.39 & 0.46 \\\\\n  -0.12 & 0.29 & 0.03\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex_exact1():
     x = np.array([1, 2, 3, 10, .1])
     y = la.to_latex(x, exact=True)
     y_ = '\\begin{array}{*{5}{c}}\n  1 & 2 & 3 & 10 & \\frac{1}{10}\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
 def test_to_latex_exact2():
     x = 0.12345
     y = la.to_latex(x, exact=.01)
     y_ = '\\begin{array}{*{1}{c}}\n  \\frac{1}{8}\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
     y = la.to_latex(x, exact=.001)
     y_ = '\\begin{array}{*{1}{c}}\n  \\frac{7}{57}\n\\end{array}'
-    assert_equal(y, y_)
+    assert y == y_
 
+@pytest.mark.xfail
 def test_to_pdf():
     import subprocess
     with open(os.devnull, 'w') as fp:
         error = subprocess.call('pdflatex --help', shell=True, stdout=fp, stderr=fp)
         error |= subprocess.call('pdfcrop --help', shell=True, stdout=fp, stderr=fp)
-        if error:
-            raise SkipTest()
 
     x = 0.1
     # This generates a temporary file...

--- a/dit/utils/tests/test_misc.py
+++ b/dit/utils/tests/test_misc.py
@@ -2,7 +2,7 @@
 Tests for dit.utils.misc.
 """
 
-from nose.tools import assert_equal, assert_false, assert_raises, assert_true
+import pytest
 
 from dit.utils.misc import flatten, is_string_like, partitions, partitions2, \
                            ordered_partitions, require_keys, partition_set, \
@@ -13,98 +13,103 @@ def test_flatten1():
     x = [[[0], 1, 2], 3, [4]]
     fx = list(flatten(x))
     y = [0, 1, 2, 3, 4]
-    assert_equal(len(fx), len(y))
+    assert len(fx) == len(y)
     for i, j in zip(fx, y):
-        assert_equal(i, j)
+        assert i == j
 
 def test_is_string_like1():
     ys = ['', 'hi', "pants", '"test"', u('pants'), r'pants']
     ns = [1, [], int, {}, ()]
     for y in ys:
-        assert_true(is_string_like(y))
+        assert is_string_like(y)
     for n in ns:
-        assert_false(is_string_like(n))
+        assert not is_string_like(n)
 
 def test_partitions1():
     bells = [1, 1, 2, 5, 15, 52]
     for i, b in enumerate(bells):
         parts = list(partitions(range(i)))
-        assert_equal(len(parts), b)
+        assert len(parts) == b
 
 def test_partitions2():
     bells = [1, 1, 2, 5, 15, 52]
     for i, b in enumerate(bells):
         parts = list(partitions(range(i), tuples=True))
-        assert_equal(len(parts), b)
+        assert len(parts) == b
 
 def test_partitions3():
     bells = [1, 1, 2, 5, 15, 52]
     for i, b in enumerate(bells):
         parts = list(partitions2(i))
-        assert_equal(len(parts), b)
+        assert len(parts) == b
 
 def test_ordered_partitions1():
     obells = [1, 1, 3, 13, 75]
     for i, b in enumerate(obells):
         oparts = list(ordered_partitions(range(i)))
-        assert_equal(len(oparts), b)
+        assert len(oparts) == b
 
 
 def test_ordered_partitions2():
     obells = [1, 1, 3, 13, 75]
     for i, b in enumerate(obells):
         oparts = list(ordered_partitions(range(i), tuples=True))
-        assert_equal(len(oparts), b)
+        assert len(oparts) == b
 
 def test_require_keys1():
     d = {0: '', '0': '', 'pants': ''}
     required = [0, '0']
-    assert_true(require_keys(required, d) is None)
+    assert require_keys(required, d) is None
 
 def test_require_keys2():
     d = {0: '', '0': '', 'pants': ''}
     required = [0, '0', 'jeans']
-    assert_raises(Exception, require_keys, required, d)
+    with pytest.raises(Exception):
+        require_keys(required, d)
 
 def test_partition_set1():
     stuff = ['0', '1', '00', '11', '000', '111', [0, 1, 2]]
     fn = lambda a, b: len(a) == len(b)
     _, lookup = partition_set(stuff, fn)
-    assert_equal(lookup, [0, 0, 1, 1, 2, 2, 2])
+    assert lookup == [0, 0, 1, 1, 2, 2, 2]
 
 def test_partition_set2():
     stuff = ['0', '1', '00', '11', '000', '111', [0, 1, 2]]
     fn = lambda a, b: len(a) == len(b)
     _, lookup = partition_set(stuff, fn, reflexive=True, transitive=True)
-    assert_equal(lookup, [0, 0, 1, 1, 2, 2, 2])
+    assert lookup == [0, 0, 1, 1, 2, 2, 2]
 
 def test_abstract_method():
     @abstract_method
     def an_abstract_method():
         pass
-    assert_raises(NotImplementedError, an_abstract_method)
+    with pytest.raises(NotImplementedError):
+        an_abstract_method()
 
 class TestDigits():
     def test_bad_base(self):
-        assert_raises(ValueError, digits, 3, 1)
+        with pytest.raises(ValueError):
+            digits(3, 1)
 
     def test_nonint_base(self):
-        assert_raises(ValueError, digits, 3, 3.2)
+        with pytest.raises(ValueError):
+            digits(3, 3.2)
 
     def test_bad_alphabet(self):
-        assert_raises(ValueError, digits, 3, 2, alphabet=[1,2,3])
+        with pytest.raises(ValueError):
+            digits(3, 2, alphabet=[1,2,3])
 
     def test_with_alphabet(self):
         x = digits(3, 2, alphabet=[0, 1])
-        assert_equal(x, [1, 1])
+        assert x == [1, 1]
 
     def test_with_pad(self):
         x = digits(3, 2, pad=4, alphabet=[0, 1])
-        assert_equal(x, [0, 0, 1, 1])
+        assert x == [0, 0, 1, 1]
 
     def test_little_endian(self):
         x = digits(2, 2)
-        assert_equal(x, [1, 0])
+        assert x == [1, 0]
 
         x = digits(2, 2, big_endian=False)
-        assert_equal(x, [0, 1])
+        assert x == [0, 1]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+python_files = test_*[!3].py
+
+addopts = --cov=dit
+          --cov-report=term-missing
+
+markers = slow: mark that the test may take several minutes to complete.

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,0 +1,6 @@
+coverage
+coveralls
+codecov
+git+https://github.com/pytest-dev/pytest/#egg=pytest
+pytest-cov
+pytest-rerunfailures


### PR DESCRIPTION
Switch the testing framework from nose to pytest. this has many advantages:
- pytest is actively developed
- pytest's plugins, like rerunfailures, are very useful
- parametrize is more clear than yield
- fixtures are nicer than test classes
- plays well with [hypothesis](https://github.com/HypothesisWorks/hypothesis-python)
- more?