### PR TITLE
Dependency Decomposition

### DIFF
--- a/dit/algorithms/__init__.py
+++ b/dit/algorithms/__init__.py
@@ -9,6 +9,7 @@ from .maxentropy import *
 from .maxentropyfw import *
 from .minimal_sufficient_statistic import *
 from .prune_expand import pruned_samplespace, expanded_samplespace
+from .scipy_maxent import *
 from .stats import mean, median, mode, standard_deviation, central_moment, \
                    standard_moment
 

--- a/dit/algorithms/maxentropy.py
+++ b/dit/algorithms/maxentropy.py
@@ -31,7 +31,7 @@ import dit
 
 from dit.abstractdist import AbstractDenseDistribution, get_abstract_dist
 
-from ..helpers import parse_rvs
+from ..helpers import RV_MODES, parse_rvs
 from .optutil import as_full_rank, CVXOPT_Template, prepare_dist, Bunch
 from ..utils import flatten
 
@@ -224,8 +224,13 @@ def marginal_constraints(dist, m, with_normalization=True):
         msg = msg.format(m, n_variables)
         raise ValueError(msg)
 
-    rvs = list(itertools.combinations(range(n_variables), m))
-    rv_mode = 'indices'
+    rv_mode = dist._rv_mode
+
+    if rv_mode in [RV_MODES.NAMES, 'names']:
+        vars = dist.get_rv_names()
+        rvs = list(itertools.combinations(vars, m))
+    else:
+        rvs = list(itertools.combinations(range(n_variables), m))
 
     A, b = marginal_constraints_generic(dist, rvs, rv_mode,
                                         with_normalization=with_normalization)

--- a/dit/algorithms/maxentropy.py
+++ b/dit/algorithms/maxentropy.py
@@ -33,6 +33,7 @@ from dit.abstractdist import AbstractDenseDistribution, get_abstract_dist
 
 from ..helpers import parse_rvs
 from .optutil import as_full_rank, CVXOPT_Template, prepare_dist, Bunch
+from ..utils import flatten
 
 __all__ = [
     'MarginalMaximumEntropy',
@@ -54,6 +55,9 @@ def isolate_zeros_generic(dist, rvs):
     """
     assert dist.is_dense()
     assert dist.get_base() == 'linear'
+
+    rvs_, indexes = parse_rvs(dist, set(flatten(rvs)), unique=True, sort=True)
+    rvs = [[indexes[rvs_.index(rv)] for rv in subrv] for subrv in rvs]
 
     d = get_abstract_dist(dist)
     n_variables = d.n_variables

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -23,6 +23,7 @@ from .maxentropy import (
 )
 
 __all__ = [
+    'maxent_dist',
     'marginal_maxent_dists',
 ]
 

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -13,6 +13,7 @@ import logging
 import numpy as np
 
 import dit
+from dit.helpers import RV_MODES
 from dit.utils import basic_logger
 
 from .optutil import (
@@ -168,7 +169,7 @@ def marginal_maxent_generic(dist, rvs, **kwargs):
 
     rv_mode = kwargs.pop('rv_mode', None)
 
-    A, b = marginal_constraints_generic(dist, rvs)
+    A, b = marginal_constraints_generic(dist, rvs, rv_mode)
 
     # Reduce the size of A so that only nonzero elements are searched.
     # Also make it full rank.
@@ -229,8 +230,18 @@ def marginal_maxent(dist, k, **kwargs):
         msg = msg.format(m, n_variables)
         raise ValueError(msg)
 
-    rvs = list(itertools.combinations(range(n_variables), k))
-    kwargs['rv_mode'] = 'indices'
+    rv_mode = kwargs.pop('rv_mode', None)
+
+    if rv_mode is None:
+        rv_mode = dist._rv_mode
+
+    if rv_mode in [RV_MODES.NAMES, 'names']:
+        vars = dist.get_rv_names()
+        rvs = list(itertools.combinations(vars, k))
+    else:
+        rvs = list(itertools.combinations(range(n_variables), k))
+
+    kwargs['rv_mode'] = rv_mode
 
     return marginal_maxent_generic(dist, rvs, **kwargs)
 

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -237,6 +237,22 @@ def marginal_maxent(dist, k, **kwargs):
 
 def maxent_dist(dist, rvs, maxiters=1000, tol=1e-3, verbose=False):
     """
+    Return the maximum entropy distribution consistant with the marginals from
+    `dist` specified in `rvs`.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The distributions whose marginals should be matched.
+    rvs : list of lists
+        The marginals from `dist` to constrain.
+    maxiters : int
+        The maximum number of iterations for the optimizer to use. Defaults to
+        1000.
+    tol : float
+        The tolerance for the optimizer. Defaults to 1e-3.
+    verbose : bool
+        Verbosity of the optimizer. Defaults to False.
     """
     dist = prepare_dist(dist.copy())
     outcomes = list(dist._sample_space)

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -26,8 +26,7 @@ from .maxentropy import (
 )
 
 __all__ = [
-    'maxent_dist',
-    'marginal_maxent_dists',
+    # 'marginal_maxent_dists',
 ]
 
 
@@ -246,36 +245,6 @@ def marginal_maxent(dist, k, **kwargs):
     kwargs['rv_mode'] = rv_mode
 
     return marginal_maxent_generic(dist, rvs, **kwargs)
-
-
-def maxent_dist(dist, rvs, maxiters=1000, tol=1e-3, verbose=False):
-    """
-    Return the maximum entropy distribution consistant with the marginals from
-    `dist` specified in `rvs`.
-
-    Parameters
-    ----------
-    dist : Distribution
-        The distributions whose marginals should be matched.
-    rvs : list of lists
-        The marginals from `dist` to constrain.
-    maxiters : int
-        The maximum number of iterations for the optimizer to use. Defaults to
-        1000.
-    tol : float
-        The tolerance for the optimizer. Defaults to 1e-3.
-    verbose : bool
-        Verbosity of the optimizer. Defaults to False.
-    """
-    dist = prepare_dist(dist.copy())
-    outcomes = list(dist._sample_space)
-
-    kwargs = {'maxiters': maxiters, 'tol': tol, 'verbose': verbose}
-    pmf_opt, opt = marginal_maxent_generic(dist, rvs, **kwargs)
-    d = dit.Distribution(outcomes, pmf_opt)
-    d.make_sparse()
-    return d
-
 
 def marginal_maxent_dists(dist, k_max=None, maxiters=1000, tol=1e-3, verbose=False):
     """

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -8,6 +8,8 @@ This uses the Frank-Wolfe algorithm:
 """
 from __future__ import print_function
 
+from itertools import combinations
+
 import logging
 
 import numpy as np
@@ -114,7 +116,7 @@ def initial_point(dist, k, A=None, b=None, isolated=None, **kwargs):
         msg = msg.format(m, n_variables)
         raise ValueError(msg)
 
-    rvs = list(itertools.combinations(range(n_variables), m))
+    rvs = list(combinations(range(n_variables), m))
     kwargs['rv_mode'] = 'indices'
 
     return initial_point_generic(dist, rvs, A, b, isolated, **kwargs)

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -239,9 +239,9 @@ def marginal_maxent(dist, k, **kwargs):
 
     if rv_mode in [RV_MODES.NAMES, 'names']:
         vars = dist.get_rv_names()
-        rvs = list(itertools.combinations(vars, k))
+        rvs = list(combinations(vars, k))
     else:
-        rvs = list(itertools.combinations(range(n_variables), k))
+        rvs = list(combinations(range(n_variables), k))
 
     kwargs['rv_mode'] = rv_mode
 

--- a/dit/algorithms/maxentropyfw.py
+++ b/dit/algorithms/maxentropyfw.py
@@ -165,6 +165,8 @@ def marginal_maxent_generic(dist, rvs, **kwargs):
     verbose = kwargs.get('verbose', False)
     logger = basic_logger('dit.maxentropy', verbose)
 
+    rv_mode = kwargs.pop('rv_mode', None)
+
     A, b = marginal_constraints_generic(dist, rvs)
 
     # Reduce the size of A so that only nonzero elements are searched.
@@ -220,13 +222,13 @@ def marginal_maxent_generic(dist, rvs, **kwargs):
 def marginal_maxent(dist, k, **kwargs):
     n_variables = dist.outcome_length()
 
-    if m > n_variables:
+    if k > n_variables:
         msg = "Cannot constrain {0}-way marginals"
         msg += " with only {1} random variables."
         msg = msg.format(m, n_variables)
         raise ValueError(msg)
 
-    rvs = list(itertools.combinations(range(n_variables), m))
+    rvs = list(itertools.combinations(range(n_variables), k))
     kwargs['rv_mode'] = 'indices'
 
     return marginal_maxent_generic(dist, rvs, **kwargs)
@@ -235,7 +237,7 @@ def marginal_maxent(dist, k, **kwargs):
 def maxent_dist(dist, rvs, maxiters=1000, tol=1e-3, verbose=False):
     """
     """
-    dist = prepare_dist(dist)
+    dist = prepare_dist(dist.copy())
     outcomes = list(dist._sample_space)
 
     kwargs = {'maxiters': maxiters, 'tol': tol, 'verbose': verbose}

--- a/dit/algorithms/scipy_maxent.py
+++ b/dit/algorithms/scipy_maxent.py
@@ -1,0 +1,225 @@
+"""
+"""
+
+from itertools import combinations
+
+import numpy as np
+
+from scipy.optimize import minimize
+
+from .. import Distribution, product_distribution
+from ..helpers import RV_MODES
+from .maxentropy import marginal_constraints_generic
+from .optutil import prepare_dist
+
+__all__ = [
+    'MaxEntOptimizer',
+    'maxent_dist',
+    'marginal_maxent_dists',
+]
+
+class MaxEntOptimizer(object):
+    """
+    Calculate maximum entropy distributions consistant with the given marginal constraints.
+    """
+
+    def __init__(self, dist, rvs, rv_mode=None):
+        """
+        Initialize the optimizer.
+
+        Parameters
+        ----------
+        dist : Distribution
+            The distribution from which the corresponding maximum entropy
+            distribution will be calculated.
+        rvs : list, None
+            The list of sets of variables whose marginals will be constrained to
+            match the given distribution.
+        rv_mode : str, None
+            Specifies how to interpret `rvs` and `crvs`. Valid options are:
+            {'indices', 'names'}. If equal to 'indices', then the elements of
+            `crvs` and `rvs` are interpreted as random variable indices. If
+            equal to 'names', the the elements are interpreted as random
+            variable names. If `None`, then the value of `dist._rv_mode` is
+            consulted, which defaults to 'indices'.
+        """
+        self.dist = prepare_dist(dist)
+        self._A, self._b = marginal_constraints_generic(self.dist, rvs, rv_mode)
+
+    def constraint_match_marginals(self, x):
+        """
+        Ensure that the joint distribution represented by the optimization
+        vector matches that of the distribution.
+
+        Parameters
+        ----------
+        x : ndarray
+            An optimization vector.
+
+        Returns
+        -------
+        d : float
+            The deviation from the constraint.
+        """
+        return sum((np.dot(self._A, x) - self._b)**2)
+
+    def objective(self, x):
+        """
+        The entropy of optimization vector `x`.
+
+        Parameters
+        ----------
+        x : ndarray
+            An optimization vector.
+
+        Returns
+        -------
+        H : float
+            The (neg)entropy of `x`.
+        """
+        return np.nansum(x * np.log2(x))
+
+    def optimize(self):
+        """
+        Perform the optimization.
+
+        Notes
+        -----
+        This is a convex optimization, and so we use scipy's minimize optimizer
+        frontend and the SLSQP algorithm because it is one of the few generic
+        optimizers which can work with both bounds and constraints.
+        """
+        x0 = np.ones_like(self.dist.pmf)/len(self.dist.pmf)
+
+        constraints = [{'type': 'eq',
+                        'fun': self.constraint_match_marginals,
+                       },
+                      ]
+
+        kwargs = {'method': 'SLSQP',
+                  'bounds': [(0, 1)]*len(x0),
+                  'constraints': constraints,
+                  'tol': None,
+                  'callback': None,
+                  'options': {'maxiter': 1000,
+                              'ftol': 15e-11,
+                              'eps': 1.4901161193847656e-12,
+                             },
+                 }
+
+        res = minimize(fun=self.objective,
+                       x0=x0,
+                       **kwargs
+                      )
+
+        self._optima = res.x
+
+    def construct_dist(self, x=None):
+        """
+        Construct the maximum entropy distribution.
+
+        Parameters
+        ----------
+        x : ndarray
+            An optimization vector.
+
+        Returns
+        -------
+        d : distribution
+            The maximum entropy distribution.
+        """
+        if x is None:
+            x = self._optima
+
+        new_dist = self.dist.copy()
+        new_dist.pmf = x
+        new_dist.make_sparse()
+
+        new_dist.set_rv_names(self.dist.get_rv_names())
+
+        return new_dist
+
+
+
+
+def maxent_dist(dist, rvs, rv_mode=None):
+    """
+    Return the maximum entropy distribution consistant with the marginals from
+    `dist` specified in `rvs`.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The distributions whose marginals should be matched.
+    rvs : list of lists
+        The marginals from `dist` to constrain.
+    rv_mode : str, None
+        Specifies how to interpret `rvs` and `crvs`. Valid options are:
+        {'indices', 'names'}. If equal to 'indices', then the elements of
+        `crvs` and `rvs` are interpreted as random variable indices. If
+        equal to 'names', the the elements are interpreted as random
+        variable names. If `None`, then the value of `dist._rv_mode` is
+        consulted, which defaults to 'indices'.
+    """
+    meo = MaxEntOptimizer(dist, rvs, rv_mode)
+    meo.optimize()
+    return meo.construct_dist()
+
+
+
+def marginal_maxent_dists(dist, k_max=None, verbose=False):
+    """
+    Return the marginal-constrained maximum entropy distributions.
+
+    Parameters
+    ----------
+    dist : distribution
+        The distribution used to constrain the maxent distributions.
+    k_max : int
+        The maximum order to calculate.
+
+
+    """
+    dist = prepare_dist(dist)
+
+    n_variables = dist.outcome_length()
+    symbols = dist.alphabet[0]
+
+    if k_max is None:
+        k_max = n_variables
+
+    outcomes = list(dist._sample_space)
+
+    # Optimization for the k=0 and k=1 cases are slow since you have to optimize
+    # the full space. We also know the answer in these cases.
+
+    # This is safe since the distribution must be dense.
+    k0 = Distribution(outcomes, [1]*len(outcomes), base='linear', validate=False)
+    k0.normalize()
+
+    k1 = product_distribution(dist)
+
+    dists = [k0, k1]
+    for k in range(k_max + 1):
+        if verbose:
+            print("Constraining maxent dist to match {0}-way marginals.".format(k))
+
+        if k in [0, 1, n_variables]:
+            continue
+
+        rv_mode = dist._rv_mode
+
+        if rv_mode in [RV_MODES.NAMES, 'names']:
+            vars = dist.get_rv_names()
+            rvs = list(combinations(vars, k))
+        else:
+            rvs = list(combinations(range(n_variables), k))
+
+        dists.append(maxent_dist(dist, rvs, rv_mode))
+
+    # To match the all-way marginal is to match itself. Again, this is a time
+    # savings decision, even though the optimization should be fast.
+    if k_max == n_variables:
+        dists.append(dist)
+
+    return dists

--- a/dit/algorithms/scipy_maxent.py
+++ b/dit/algorithms/scipy_maxent.py
@@ -114,7 +114,7 @@ class MaxEntOptimizer(object):
 
         self._optima = res.x
 
-    def construct_dist(self, x=None):
+    def construct_dist(self, x=None, cutoff=1e-6):
         """
         Construct the maximum entropy distribution.
 
@@ -133,6 +133,7 @@ class MaxEntOptimizer(object):
 
         new_dist = self.dist.copy()
         new_dist.pmf = x
+        new_dist.pmf[new_dist.pmf < cutoff] = 0
         new_dist.make_sparse()
 
         new_dist.set_rv_names(self.dist.get_rv_names())

--- a/dit/algorithms/scipy_maxent.py
+++ b/dit/algorithms/scipy_maxent.py
@@ -129,11 +129,13 @@ class MaxEntOptimizer(object):
             The maximum entropy distribution.
         """
         if x is None:
-            x = self._optima
+            x = self._optima.copy()
 
+        x[x < cutoff] = 0
+        x /= x.sum()
+        
         new_dist = self.dist.copy()
         new_dist.pmf = x
-        new_dist.pmf[new_dist.pmf < cutoff] = 0
         new_dist.make_sparse()
 
         new_dist.set_rv_names(self.dist.get_rv_names())

--- a/dit/algorithms/tests/test_maxent_dist.py
+++ b/dit/algorithms/tests/test_maxent_dist.py
@@ -4,20 +4,31 @@ Tests for dit.algorithms.matextropyfw.maxent_dist.
 
 from __future__ import division
 
-from nose.tools import assert_true
+import pytest
 
 from dit import Distribution
 from dit.distconst import uniform
 from dit.algorithms import maxent_dist
 
-def test_maxent_1():
+
+@pytest.mark.parametrize('vars', [
+    [[0], [1], [2]],
+    [[0, 1], [2]],
+    [[0, 2], [1]],
+    [[0], [1, 2]],
+    [[0, 1], [1, 2]],
+    [[0, 1], [0, 2]],
+    [[0, 2], [1, 2]],
+    [[0, 1], [0, 2], [1, 2]]
+])
+def test_maxent_1(vars):
     """
     Test xor only fixing individual marginals.
     """
     d1 = uniform(['000', '011', '101', '110'])
     d2 = uniform(['000', '001', '010', '011', '100', '101', '110', '111'])
-    d1_maxent = maxent_dist(d1, [[0], [1], [2]], tol=1e-6)
-    assert_true(d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3))
+    d1_maxent = maxent_dist(d1, vars, tol=1e-6)
+    assert d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3)
 
 
 def test_maxent_2():
@@ -27,4 +38,4 @@ def test_maxent_2():
     d1 = uniform(['00', '10', '21', '31'])
     d2 = uniform(['00', '01', '10', '11', '20', '21', '30', '31'])
     d1_maxent = maxent_dist(d1, [[0], [1]], tol=1e-6)
-    assert_true(d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3))
+    assert d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3)

--- a/dit/algorithms/tests/test_maxent_dist.py
+++ b/dit/algorithms/tests/test_maxent_dist.py
@@ -29,7 +29,7 @@ def test_maxent_1(vars):
     """
     d1 = uniform(['000', '011', '101', '110'])
     d2 = uniform(['000', '001', '010', '011', '100', '101', '110', '111'])
-    d1_maxent = maxent_dist(d1, vars, tol=1e-6)
+    d1_maxent = maxent_dist(d1, vars)
     assert d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3)
 
 
@@ -39,5 +39,5 @@ def test_maxent_2():
     """
     d1 = uniform(['00', '10', '21', '31'])
     d2 = uniform(['00', '01', '10', '11', '20', '21', '30', '31'])
-    d1_maxent = maxent_dist(d1, [[0], [1]], tol=1e-6)
+    d1_maxent = maxent_dist(d1, [[0], [1]])
     assert d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3)

--- a/dit/algorithms/tests/test_maxent_dist.py
+++ b/dit/algorithms/tests/test_maxent_dist.py
@@ -11,6 +11,8 @@ from dit.distconst import uniform
 from dit.algorithms import maxent_dist
 
 
+pytest.importorskip('cvxopt')
+
 @pytest.mark.parametrize('vars', [
     [[0], [1], [2]],
     [[0, 1], [2]],

--- a/dit/algorithms/tests/test_maxent_dist.py
+++ b/dit/algorithms/tests/test_maxent_dist.py
@@ -1,0 +1,30 @@
+"""
+Tests for dit.algorithms.matextropyfw.maxent_dist.
+"""
+
+from __future__ import division
+
+from nose.tools import assert_true
+
+from dit import Distribution
+from dit.distconst import uniform
+from dit.algorithms import maxent_dist
+
+def test_maxent_1():
+    """
+    Test xor only fixing individual marginals.
+    """
+    d1 = uniform(['000', '011', '101', '110'])
+    d2 = uniform(['000', '001', '010', '011', '100', '101', '110', '111'])
+    d1_maxent = maxent_dist(d1, [[0], [1], [2]], tol=1e-6)
+    assert_true(d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3))
+
+
+def test_maxent_2():
+    """
+    Text a distribution with differing alphabets.
+    """
+    d1 = uniform(['00', '10', '21', '31'])
+    d2 = uniform(['00', '01', '10', '11', '20', '21', '30', '31'])
+    d1_maxent = maxent_dist(d1, [[0], [1]], tol=1e-6)
+    assert_true(d2.is_approx_equal(d1_maxent, rtol=1e-3, atol=1e-3))

--- a/dit/multivariate/intrinsic_mutual_information.py
+++ b/dit/multivariate/intrinsic_mutual_information.py
@@ -83,6 +83,8 @@ class BaseIntrinsicMutualInformation(object):
         keepers = set(flatten(self._rvs)) | {self._crv+1}
         self._others = tuple(all_vars - keepers)
 
+        self._mask = np.ones((self._crv_size, self._crv_size)) / self._crv_size
+
     def construct_random_initial(self):
         """
         Construct a random optimization vector.
@@ -114,9 +116,7 @@ class BaseIntrinsicMutualInformation(object):
         n = self._crv_size
         channel = x.reshape((n, n))
         channel /= channel.sum(axis=1, keepdims=True)
-        mask = np.ones_like(channel)
-        mask /= mask.sum(axis=1, keepdims=True)
-        channel[np.isnan(channel)] = mask[np.isnan(channel)]
+        channel[np.isnan(channel)] = self._mask[np.isnan(channel)]
         slc = (len(self._pmf.shape) - 1)*[np.newaxis] + 2*[slice(None, None)]
         joint = self._pmf[..., np.newaxis] * channel[slc]
 

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -58,6 +58,8 @@ def constraint_lattice(elements):
     def less_than(sss1, sss2):
         return all(any(ss1 <= ss2 for ss2 in sss2) for ss1 in sss1)
 
+    elements = set(elements)
+
     ps = (frozenset(ss) for ss in powerset(elements) if len(ss) > 0)
 
     pps = [c for c in powerset(ps) if is_antichain(c) and is_cover(elements, c)]
@@ -255,3 +257,144 @@ class ExtropyPartition(BaseInformationPartition):
         Returns X for all atoms.
         """
         return 'X'
+
+
+class KrippendorfPartition(object):
+    """
+    Construct a decomposition of all the dependencies in a given joint
+    distribution.
+    """
+
+    def __init__(self, dist, tol=1e-3):
+        """
+        Construct a Krippendorff-type partition of the information contained in
+        `dist`.
+
+        Parameters
+        ----------
+        dist : distribution
+            The distribution to partition.
+        """
+        self.dist = dist
+        self._tol = tol
+        self._partition()
+
+    @staticmethod
+    def _stringify(rvs, crvs):
+        """
+        Construct a string representation of a measure, e.g. I[X:Y|Z]
+
+        Parameters
+        ----------
+        rvs : list
+            The random variable(s) for the measure.
+        crvs : list
+            The random variable(s) that the measure is conditioned on.
+        """
+        rvs = [','.join(str(_) for _ in rv) for rv in rvs]
+        crvs = [str(_) for _ in crvs]
+        a = ':'.join(rvs)
+        b = ','.join(crvs)
+        symbol = 'H' if len(rvs) == 1 else 'I'
+        sep = '|' if len(crvs) > 0 else ''
+        s = "{0}[{1}{2}{3}]".format(symbol, a, sep, b)
+        return s
+
+    def _partition(self):
+        """
+        Return all the atoms of the I-diagram for `dist`.
+
+        Parameters
+        ----------
+        dist : distribution
+            The distribution to compute the I-diagram of.
+        """
+        from .maxentropyfw import maxent_dist
+
+        rvs = self.dist.get_rv_names()
+        if not rvs:
+            rvs = tuple(range(self.dist.outcome_length()))
+
+        lattice = constraint_lattice(rvs)
+        rlattice = lattice.reverse()
+        Hs = {}
+        Is = {}
+        atoms = {}
+        new_atoms = {}
+
+        # Entropies
+        for node in lattice:
+            Hs[node] = H(maxent_dist(self.dist, node, tol=self._tol))
+
+        # Subset-sum type thing, basically co-information calculations.
+        for node in lattice:
+            Is[node] = sum((-1)**(len(rv)+1)*Hs[rv] for rv in children(lattice, node))
+
+        # Mobius inversion of the above, resulting in the Shannon atoms.
+        for node in topological_sort(lattice)[:-1]:
+            kids = islice(children(rlattice, node), 1, None)
+            atoms[node] = Is[node] - sum(atoms[child] for child in kids)
+
+        # get the atom indices in proper format
+        for atom, value in atoms.items():
+            a_rvs = tuple((_,) for _ in atom)
+            a_crvs = tuple(sorted(set(rvs) - set(atom)))
+            new_atoms[(a_rvs, a_crvs)] = value
+
+        self.atoms = new_atoms
+
+    def __getitem__(self, item):
+        """
+        Return the value of any information measure.
+
+        Parameters
+        ----------
+        item : tuple
+            A pair (rvs, crvs).
+        """
+        def is_part(atom, rvs, crvs):
+            lhs = all(any(((_,) in atom[0]) for _ in rv) for rv in rvs)
+            rhs = set(crvs).issubset(atom[1])
+            return lhs and rhs
+
+        return sum(value for atom, value in self.atoms.items() if is_part(atom, *item))
+
+
+    def __str__(self):
+        """
+        Use PrettyTable to create a nice table.
+        """
+        return self.to_string()
+
+    def to_string(self, digits=3):
+        """
+        Use PrettyTable to create a nice table.
+        """
+        table = PrettyTable(['measure', 'bits'])
+        ### TODO: add some logic for the format string, so things look nice
+        # with arbitrary values
+        table.float_format['bits'] = ' 5.{0}'.format(digits)
+        key_function = lambda row: (len(row[0][0]), row[0][0], row[0][1])
+        items = self.atoms.items()
+        for (rvs, crvs), value in sorted(items, key=key_function):
+            # gets rid of pesky -0.0 display values
+            if close(value, 0.0):
+                value = 0.0
+            table.add_row([self._stringify(rvs, crvs), value])
+        return table.get_string()
+
+    def get_atoms(self, string=True):
+        """
+        Return all the atoms for the distribution.
+
+        Parameters
+        ----------
+        string : bool
+            If True, return atoms as strings. Otherwise, as a pair of tuples.
+        """
+        if string:
+            f = self._stringify
+        else:
+            f = lambda a, b: (a, b)
+
+        return set([f(rvs, crvs) for rvs, crvs in self.atoms.keys()])

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -316,6 +316,11 @@ class DependencyDecomposition(object):
 
         self.atoms = atoms
 
+    def __repr__(self):
+        """
+        Represent using the str().
+        """
+        return str(self)
 
     def __str__(self):
         """

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -58,6 +58,10 @@ def constraint_lattice(elements):
     def less_than(sss1, sss2):
         return all(any(ss1 <= ss2 for ss2 in sss2) for ss1 in sss1)
 
+    def normalize(sss):
+        return tuple(sorted(tuple( tuple(sorted(ss)) for ss in sss ),
+                            key=lambda s: (-len(s), s)))
+
     elements = set(elements)
 
     ps = (frozenset(ss) for ss in powerset(elements) if len(ss) > 0)
@@ -70,7 +74,8 @@ def constraint_lattice(elements):
 
     for a, b in order:
         if not any(((a, c) in order) and ((c, b) in order) for c in pps):
-            lattice.add_edge(tuple(map(tuple, b)), tuple(map(tuple, a)))
+
+            lattice.add_edge(normalize(b), normalize(a))
 
     return lattice
 
@@ -259,13 +264,13 @@ class ExtropyPartition(BaseInformationPartition):
         return 'X'
 
 
-class KrippendorfPartition(object):
+class KrippendorffPartition(object):
     """
     Construct a decomposition of all the dependencies in a given joint
     distribution.
     """
 
-    def __init__(self, dist, tol=1e-3):
+    def __init__(self, dist, tol=1e-4):
         """
         Construct a Krippendorff-type partition of the information contained in
         `dist`.
@@ -280,24 +285,15 @@ class KrippendorfPartition(object):
         self._partition()
 
     @staticmethod
-    def _stringify(rvs, crvs):
+    def _stringify(dependency):
         """
-        Construct a string representation of a measure, e.g. I[X:Y|Z]
+        Construct a string representation of a dependency, e.g. ABC:AD:BD
 
         Parameters
         ----------
-        rvs : list
-            The random variable(s) for the measure.
-        crvs : list
-            The random variable(s) that the measure is conditioned on.
+        dependency : tuple of tuples
         """
-        rvs = [','.join(str(_) for _ in rv) for rv in rvs]
-        crvs = [str(_) for _ in crvs]
-        a = ':'.join(rvs)
-        b = ','.join(crvs)
-        symbol = 'H' if len(rvs) == 1 else 'I'
-        sep = '|' if len(crvs) > 0 else ''
-        s = "{0}[{1}{2}{3}]".format(symbol, a, sep, b)
+        s = ':'.join(''.join(map(str, d)) for d in dependency if len(d) > 1)
         return s
 
     def _partition(self):
@@ -315,49 +311,49 @@ class KrippendorfPartition(object):
         if not rvs:
             rvs = tuple(range(self.dist.outcome_length()))
 
-        lattice = constraint_lattice(rvs)
-        rlattice = lattice.reverse()
-        Hs = {}
-        Is = {}
+        self._lattice = constraint_lattice(rvs)
+        # rlattice = lattice.reverse()
+        # Hs = {}
+        # Is = {}
         atoms = {}
-        new_atoms = {}
+        # new_atoms = {}
 
         # Entropies
-        for node in lattice:
-            Hs[node] = H(maxent_dist(self.dist, node, tol=self._tol))
+        for node in self._lattice:
+            atoms[node] = H(maxent_dist(self.dist, node, tol=self._tol))
 
-        # Subset-sum type thing, basically co-information calculations.
-        for node in lattice:
-            Is[node] = sum((-1)**(len(rv)+1)*Hs[rv] for rv in children(lattice, node))
+        # # Subset-sum type thing, basically co-information calculations.
+        # for node in lattice:
+        #     Is[node] = sum((-1)**(len(rv)+1)*Hs[rv] for rv in children(lattice, node))
+        #
+        # # Mobius inversion of the above, resulting in the Shannon atoms.
+        # for node in topological_sort(lattice)[:-1]:
+        #     kids = islice(children(rlattice, node), 1, None)
+        #     atoms[node] = Is[node] - sum(atoms[child] for child in kids)
+        #
+        # # get the atom indices in proper format
+        # for atom, value in atoms.items():
+        #     a_rvs = tuple((_,) for _ in atom)
+        #     a_crvs = tuple(sorted(set(rvs) - set(atom)))
+        #     new_atoms[(a_rvs, a_crvs)] = value
+        #
+        self.atoms = atoms
 
-        # Mobius inversion of the above, resulting in the Shannon atoms.
-        for node in topological_sort(lattice)[:-1]:
-            kids = islice(children(rlattice, node), 1, None)
-            atoms[node] = Is[node] - sum(atoms[child] for child in kids)
-
-        # get the atom indices in proper format
-        for atom, value in atoms.items():
-            a_rvs = tuple((_,) for _ in atom)
-            a_crvs = tuple(sorted(set(rvs) - set(atom)))
-            new_atoms[(a_rvs, a_crvs)] = value
-
-        self.atoms = new_atoms
-
-    def __getitem__(self, item):
-        """
-        Return the value of any information measure.
-
-        Parameters
-        ----------
-        item : tuple
-            A pair (rvs, crvs).
-        """
-        def is_part(atom, rvs, crvs):
-            lhs = all(any(((_,) in atom[0]) for _ in rv) for rv in rvs)
-            rhs = set(crvs).issubset(atom[1])
-            return lhs and rhs
-
-        return sum(value for atom, value in self.atoms.items() if is_part(atom, *item))
+    # def __getitem__(self, item):
+    #     """
+    #     Return the value of any information measure.
+    #
+    #     Parameters
+    #     ----------
+    #     item : tuple
+    #         A pair (rvs, crvs).
+    #     """
+    #     def is_part(atom, rvs, crvs):
+    #         lhs = all(any(((_,) in atom[0]) for _ in rv) for rv in rvs)
+    #         rhs = set(crvs).issubset(atom[1])
+    #         return lhs and rhs
+    #
+    #     return sum(value for atom, value in self.atoms.items() if is_part(atom, *item))
 
 
     def __str__(self):
@@ -370,31 +366,31 @@ class KrippendorfPartition(object):
         """
         Use PrettyTable to create a nice table.
         """
-        table = PrettyTable(['measure', 'bits'])
+        table = PrettyTable(['dependency', 'bits'])
         ### TODO: add some logic for the format string, so things look nice
         # with arbitrary values
         table.float_format['bits'] = ' 5.{0}'.format(digits)
-        key_function = lambda row: (len(row[0][0]), row[0][0], row[0][1])
+        key_function = lambda row: ([len(d) for d in row[0]], row[0])
         items = self.atoms.items()
-        for (rvs, crvs), value in sorted(items, key=key_function):
+        for dependency, value in reversed(sorted(items, key=key_function)):
             # gets rid of pesky -0.0 display values
             if close(value, 0.0):
                 value = 0.0
-            table.add_row([self._stringify(rvs, crvs), value])
+            table.add_row([self._stringify(dependency), value])
         return table.get_string()
 
-    def get_atoms(self, string=True):
-        """
-        Return all the atoms for the distribution.
-
-        Parameters
-        ----------
-        string : bool
-            If True, return atoms as strings. Otherwise, as a pair of tuples.
-        """
-        if string:
-            f = self._stringify
-        else:
-            f = lambda a, b: (a, b)
-
-        return set([f(rvs, crvs) for rvs, crvs in self.atoms.keys()])
+    # def get_atoms(self, string=True):
+    #     """
+    #     Return all the atoms for the distribution.
+    #
+    #     Parameters
+    #     ----------
+    #     string : bool
+    #         If True, return atoms as strings. Otherwise, as a pair of tuples.
+    #     """
+    #     if string:
+    #         f = self._stringify
+    #     else:
+    #         f = lambda a, b: (a, b)
+    #
+    #     return set([f(rvs, crvs) for rvs, crvs in self.atoms.keys()])

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -14,9 +14,9 @@ from prettytable import PrettyTable
 
 from networkx import DiGraph, dfs_preorder_nodes as children, topological_sort
 
-from ..shannon import entropy
-from ..other import extropy
 from ..math import close
+from ..other import extropy
+from ..shannon import entropy
 
 __all__ = ['ShannonPartition',
            'ExtropyPartition',
@@ -299,14 +299,9 @@ class DependencyDecomposition(object):
 
     def _partition(self):
         """
-        Return all the atoms of the I-diagram for `dist`.
-
-        Parameters
-        ----------
-        dist : distribution
-            The distribution to compute the I-diagram of.
+        Computes all the dependencies of `dist`.
         """
-        from .maxentropyfw import maxent_dist
+        from ..algorithms.maxentropyfw import maxent_dist
 
         rvs = self.dist.get_rv_names()
         if not rvs:
@@ -352,12 +347,12 @@ class DependencyDecomposition(object):
         Parameters
         ----------
         string : bool
-            If True, return dependencies as strings. Otherwise, as a pair of
+            If True, return dependencies as strings. Otherwise, as a tuple of
             tuples.
         """
         if string:
             f = self._stringify
         else:
-            f = lambda a, b: (a, b)
+            f = lambda d: d
 
         return set(map(f, self.atoms.keys()))

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -14,6 +14,7 @@ from prettytable import PrettyTable
 
 from networkx import DiGraph, dfs_preorder_nodes as children, topological_sort
 
+from ..algorithms import maxent_dist
 from ..math import close
 from ..other import extropy
 from ..shannon import entropy
@@ -270,7 +271,7 @@ class DependencyDecomposition(object):
     distribution.
     """
 
-    def __init__(self, dist, measure=entropy, tol=1e-4):
+    def __init__(self, dist, measure=entropy):
         """
         Construct a Krippendorff-type partition of the information contained in
         `dist`.
@@ -281,7 +282,6 @@ class DependencyDecomposition(object):
             The distribution to partition.
         """
         self.dist = dist
-        self._tol = tol
         self.measure = measure
         self._partition()
 
@@ -301,8 +301,6 @@ class DependencyDecomposition(object):
         """
         Computes all the dependencies of `dist`.
         """
-        from ..algorithms.maxentropyfw import maxent_dist
-
         rvs = self.dist.get_rv_names()
         if not rvs:
             rvs = tuple(range(self.dist.outcome_length()))
@@ -312,7 +310,7 @@ class DependencyDecomposition(object):
 
         # Entropies
         for node in self._lattice:
-            atoms[node] = self.measure(maxent_dist(self.dist, node, tol=self._tol))
+            atoms[node] = self.measure(maxent_dist(self.dist, node))
 
         self.atoms = atoms
 

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -264,7 +264,7 @@ class ExtropyPartition(BaseInformationPartition):
         return 'X'
 
 
-class KrippendorffPartition(object):
+class DependencyPartition(object):
     """
     Construct a decomposition of all the dependencies in a given joint
     distribution.

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -264,7 +264,7 @@ class ExtropyPartition(BaseInformationPartition):
         return 'X'
 
 
-class DependencyPartition(object):
+class DependencyDecomposition(object):
     """
     Construct a decomposition of all the dependencies in a given joint
     distribution.

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -270,7 +270,7 @@ class DependencyDecomposition(object):
     distribution.
     """
 
-    def __init__(self, dist, tol=1e-4):
+    def __init__(self, dist, measure=H, tol=1e-4):
         """
         Construct a Krippendorff-type partition of the information contained in
         `dist`.
@@ -282,6 +282,7 @@ class DependencyDecomposition(object):
         """
         self.dist = dist
         self._tol = tol
+        self.measure = measure
         self._partition()
 
     @staticmethod
@@ -316,7 +317,7 @@ class DependencyDecomposition(object):
 
         # Entropies
         for node in self._lattice:
-            atoms[node] = H(maxent_dist(self.dist, node, tol=self._tol))
+            atoms[node] = self.measure(maxent_dist(self.dist, node, tol=self._tol))
 
         self.atoms = atoms
 

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -20,7 +20,7 @@ from ..math import close
 
 __all__ = ['ShannonPartition',
            'ExtropyPartition',
-           'DependencyPartition',
+           'DependencyDecomposition',
           ]
 
 
@@ -270,7 +270,7 @@ class DependencyDecomposition(object):
     distribution.
     """
 
-    def __init__(self, dist, measure=H, tol=1e-4):
+    def __init__(self, dist, measure=entropy, tol=1e-4):
         """
         Construct a Krippendorff-type partition of the information contained in
         `dist`.

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -20,6 +20,7 @@ from ..math import close
 
 __all__ = ['ShannonPartition',
            'ExtropyPartition',
+           'DependencyPartition',
           ]
 
 
@@ -74,7 +75,6 @@ def constraint_lattice(elements):
 
     for a, b in order:
         if not any(((a, c) in order) and ((c, b) in order) for c in pps):
-
             lattice.add_edge(normalize(b), normalize(a))
 
     return lattice
@@ -293,7 +293,7 @@ class DependencyPartition(object):
         ----------
         dependency : tuple of tuples
         """
-        s = ':'.join(''.join(map(str, d)) for d in dependency if len(d) > 1)
+        s = ':'.join(''.join(map(str, d)) for d in dependency)
         return s
 
     def _partition(self):

--- a/dit/profiles/tests/test_information_partitions.py
+++ b/dit/profiles/tests/test_information_partitions.py
@@ -6,7 +6,7 @@ import pytest
 from itertools import islice
 from iterutils import powerset
 
-from dit.multivariate import coinformation as I
+from dit.multivariate import coinformation as I, dual_total_correlation as B
 from dit.utils import partitions
 from dit.profiles.information_partitions import *
 from dit.example_dists import n_mod_m
@@ -86,4 +86,26 @@ def test_ep1():
 | X[1:2|0] |  0.245 |
 | X[0:1:2] |  0.510 |
 +----------+--------+"""
+    assert str(ep) == string
+
+def test_dd1():
+    """
+    Test against known values.
+    """
+    d = n_mod_m(3, 2)
+    ep = DependencyDecomposition(d, measure=B)
+    string = """\
++------------+--------+
+| dependency |  bits  |
++------------+--------+
+|    012     |  2.000 |
+|  01:02:12  |  0.000 |
+|   02:12    |  0.000 |
+|   01:12    |  0.000 |
+|   01:02    |  0.000 |
+|    12:0    |  0.000 |
+|    02:1    |  0.000 |
+|    01:2    |  0.000 |
+|   0:1:2    |  0.000 |
++------------+--------+"""
     assert str(ep) == string

--- a/dit/utils/misc.py
+++ b/dit/utils/misc.py
@@ -166,7 +166,7 @@ def flatten(l):
         The non-iterable items in `l`.
     """
     for el in l:
-        if isinstance(el, Iterable) and not isinstance(el, six.string_types):
+        if isinstance(el, Iterable) and not (isinstance(el, six.string_types) and len(el) == 1):
             for sub in flatten(el):
                 yield sub
         else:

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -307,7 +307,7 @@ We can plot these same distributions on a slightly different entropy triangle as
 Dependency Decomposition
 ========================
 
-Using :class:`DependencyDecomposition`, one can discover how an arbitrary information measure varies as marginals of the distribution are fixed:
+Using :class:`DependencyDecomposition`, one can discover how an arbitrary information measure varies as marginals of the distribution are fixed. In our first example, each variable is independent of the others, and so constraining marginals makes no difference:
 
 .. ipython::
    :doctest:
@@ -327,6 +327,8 @@ Using :class:`DependencyDecomposition`, one can discover how an arbitrary inform
    |   0:1:2    |  3.000 |
    +------------+--------+
 
+In the second example, we see that fixing any one of the pairwise marginals reduces the entropy by one bit, and by fixing a second we reduce the entropy down to one bit:
+
 .. ipython::
    :doctest:
 
@@ -345,6 +347,7 @@ Using :class:`DependencyDecomposition`, one can discover how an arbitrary inform
    |   0:1:2    |  3.000 |
    +------------+--------+
 
+In the third example, only constraining the 01 marginal reduces the entropy, and it reduces it by one bit:
 
 .. ipython::
    :doctest:
@@ -364,6 +367,7 @@ Using :class:`DependencyDecomposition`, one can discover how an arbitrary inform
    |   0:1:2    |  3.000 |
    +------------+--------+
 
+And finally in the case of the exclusive or, only constraining the 012 marginal reduces the entropy.
 
 .. ipython::
    :doctest:

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -21,10 +21,10 @@ There are several ways to decompose the information contained in a joint distrib
 
 .. py:module:: dit.profiles.information_partitions
 
-:class:`ShannonPartition` and :class:`ExtropyPartition`
-=======================================================
+Shannon Partition and Extropy Partition
+=======================================
 
-The I-diagrams for these four examples can be computed thusly:
+The I-diagrams, or :class:`ShannonPartition`, for these four examples can be computed thusly:
 
 .. ipython::
    :doctest:
@@ -81,7 +81,7 @@ The I-diagrams for these four examples can be computed thusly:
    | I[0:1:2] |  0.510 |
    +----------+--------+
 
-And their X-diagrams can be computed like so:
+And their X-diagrams, or :class:`ExtropyDiagram`, can be computed like so:
 
 .. ipython::
    :doctest:
@@ -140,10 +140,10 @@ And their X-diagrams can be computed like so:
 
 .. py:module:: dit.profiles.complexity_profile
 
-:class:`ComplexityProfile`
-==========================
+Complexity Profile
+==================
 
-The complexity profile is simply the amount of information at scale :math:`\geq k` of each "layer" of the I-diagram :cite:`Baryam2004`.
+The complexity profile, implimented by :class:`ComplexityProfile` is simply the amount of information at scale :math:`\geq k` of each "layer" of the I-diagram :cite:`Baryam2004`.
 
 Consider example 1, which contains three independent bits. Each of these bits are in the outermost "layer" of the i-diagram, and so the information in the complexity profile is all at layer 1:
 
@@ -175,10 +175,10 @@ Finally, example 4 (where each variable is the ``exclusive or`` of the other two
 
 .. py:module:: dit.profiles.marginal_utility_of_information
 
-:class:`MUIProfile`
-===================
+Marginal Utility of Information
+===============================
 
-The marginal utility of information (MUI) :cite:`Allen2014` takes a different approach. It asks, given an amount of information :math:`\I[d : \{X\}] = y`, what is the maximum amount of information one can extract using an auxilliary variable :math:`d` as measured by the sum of the pairwise mutual informations, :math:`\sum \I[d : X_i]`. The MUI is then the rate of this maximum as a function of :math:`y`.
+The marginal utility of information (MUI) :cite:`Allen2014`, implimented by :class:`MUIProfile` takes a different approach. It asks, given an amount of information :math:`\I[d : \{X\}] = y`, what is the maximum amount of information one can extract using an auxilliary variable :math:`d` as measured by the sum of the pairwise mutual informations, :math:`\sum \I[d : X_i]`. The MUI is then the rate of this maximum as a function of :math:`y`.
 
 For the first example, each bit is independent and so basically must be extracted independently. Thus, as one increases :math:`y` the maximum amount extracted grows equally:
 
@@ -210,10 +210,10 @@ Lastly, the ``xor`` example:
 
 .. py:module:: dit.profiles.schneidman
 
-:class:`SchneidmanProfile`
-==========================
+Schneidman Profile
+==================
 
-Also known as the *connected information* or *network informations*, the Schneidman profile exposes how much information is learned about the distribution when considering :math:`k`-way dependencies :cite:`Amari2001,Schneidman2003`. In all the following examples, each individual marginal is already uniformly distributed, and so the connected information at scale 1 is 0.
+Also known as the *connected information* or *network informations*, the Schneidman profile (:class:`SchneidmanProfile`) exposes how much information is learned about the distribution when considering :math:`k`-way dependencies :cite:`Amari2001,Schneidman2003`. In all the following examples, each individual marginal is already uniformly distributed, and so the connected information at scale 1 is 0.
 
 In the first example, all the random variables are independent already, so fixing marginals above :math:`k=1` does not result in any change to the inferred distribution:
 
@@ -248,10 +248,10 @@ And for the ``xor``, all bits appear independent until fixing the three-way marg
 
 .. py:module:: dit.profiles.entropy_triangle
 
-:class:`EntropyTriangle` and :class:`EntropyTriangle2`
-======================================================
+Entropy Triangle and Entropy Triangle2
+======================================
 
-The entropy triangle :cite:`valverde2016multivariate` is a method of visualizing how the information in the distribution is distributed among deviation from uniformity, independence, and dependence. The deviation from independence is measured by considering the difference in entropy between a independent variables with uniform distributions, and independent variables with the same marginal distributions as the distribution in question. Independence is measured via the :doc:`measures/multivariate/residual_entropy`, and dependence is measured by the sum of the :doc:`measures/multivariate/total_correlation` and :doc:`measures/multivariate/dual_total_correlation`.
+The entropy triangle, :class:`EntropyTriangle`, :cite:`valverde2016multivariate` is a method of visualizing how the information in the distribution is distributed among deviation from uniformity, independence, and dependence. The deviation from independence is measured by considering the difference in entropy between a independent variables with uniform distributions, and independent variables with the same marginal distributions as the distribution in question. Independence is measured via the :doc:`measures/multivariate/residual_entropy`, and dependence is measured by the sum of the :doc:`measures/multivariate/total_correlation` and :doc:`measures/multivariate/dual_total_correlation`.
 
 All four examples lay along the left axis because their distributions are uniform over the events that have non-zero probability.
 
@@ -297,9 +297,88 @@ We can also plot all four on the same entropy triangle:
    @savefig entropy_triangle_example.png width=500 align=center
    In [32]: EntropyTriangle(dists).draw();
 
-We can plot these same distributions on a slightly different entropy triangle as well, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/dual_total_correlation`:
+We can plot these same distributions on a slightly different entropy triangle as well, :class:`EntropyTriangle2`, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/dual_total_correlation`:
 
 .. ipython::
 
    @savefig entropy_triangle2_example.png width=500 align=center
    In [33]: EntropyTriangle2(dists).draw();
+
+Dependency Decomposition
+========================
+
+Using :class:`DependencyDecomposition`, one can discover how an arbitrary information measure varies as marginals of the distribution are fixed:
+
+.. ipython::
+   :doctest:
+
+   In [34]: DependencyDecomposition(ex1)
+   +------------+--------+
+   | dependency |  bits  |
+   +------------+--------+
+   |    012     |  3.000 |
+   |  01:02:12  |  3.000 |
+   |   02:12    |  3.000 |
+   |   01:12    |  3.000 |
+   |   01:02    |  3.000 |
+   |    12:0    |  3.000 |
+   |    02:1    |  3.000 |
+   |    01:2    |  3.000 |
+   |   0:1:2    |  3.000 |
+   +------------+--------+
+
+.. ipython::
+   :doctest:
+
+   In [35]: DependencyDecomposition(ex2)
+   +------------+--------+
+   | dependency |  bits  |
+   +------------+--------+
+   |    012     |  1.000 |
+   |  01:02:12  |  1.000 |
+   |   02:12    |  1.000 |
+   |   01:12    |  1.000 |
+   |   01:02    |  1.000 |
+   |    12:0    |  2.000 |
+   |    02:1    |  2.000 |
+   |    01:2    |  2.000 |
+   |   0:1:2    |  3.000 |
+   +------------+--------+
+
+
+.. ipython::
+   :doctest:
+
+   In [36]: DependencyDecomposition(ex3)
+   +------------+--------+
+   | dependency |  bits  |
+   +------------+--------+
+   |    012     |  2.000 |
+   |  01:02:12  |  2.000 |
+   |   02:12    |  3.000 |
+   |   01:12    |  2.000 |
+   |   01:02    |  2.000 |
+   |    12:0    |  3.000 |
+   |    02:1    |  3.000 |
+   |    01:2    |  2.000 |
+   |   0:1:2    |  3.000 |
+   +------------+--------+
+
+
+.. ipython::
+   :doctest:
+
+   In [37]: DependencyDecomposition(ex4)
+   +------------+--------+
+   | dependency |  bits  |
+   +------------+--------+
+   |    012     |  2.000 |
+   |  01:02:12  |  3.000 |
+   |   02:12    |  3.000 |
+   |   01:12    |  3.000 |
+   |   01:02    |  3.000 |
+   |    12:0    |  3.000 |
+   |    02:1    |  3.000 |
+   |    01:2    |  3.000 |
+   |   0:1:2    |  3.000 |
+   +------------+--------+


### PR DESCRIPTION
This refactors some of the maxent code, providing the maxent_dist function which takes a distribution and a set of marginals which should be constrained, and otherwise finds the maxent distribution.

this is used to create the DependencyDecomposition, which considers all possible coverings of the variables for which no element is a subset of any others. Those elements (marginals) are constrained, and maxent is taken. for example, one could constrain p(x,y,z), p(w,x), and p(w,z) and otherwise maxent over p(w,x,y,z). by ordering these according to which coverings subsume others, we can see how each marginal contributes to the overall entropy, total correlation, dual total correlation, or any other measure.

don't merge yet, i still need to add docs and tests.

closes #99 