### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/dit/dit.png?label=ready&title=Ready 
+ :target: https://waffle.io/dit/dit?utm_source=badge
+ :alt: 'Stories in Ready'
 ``dit`` is a Python package for information theory.
 
 |build| |build_windows| |codecov| |health| |docs| |deps| |zenodo| |gitter| |saythanks|

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://badge.waffle.io/dit/dit.png?label=ready&title=Ready 
- :target: https://waffle.io/dit/dit?utm_source=badge
- :alt: 'Stories in Ready'
 ``dit`` is a Python package for information theory.
 
 |build| |build_windows| |codecov| |health| |docs| |deps| |zenodo| |gitter| |saythanks|
@@ -219,3 +216,7 @@ Enjoy!
 .. |depsy| image:: http://depsy.org/api/package/pypi/dit/badge.svg
    :target: http://depsy.org/package/python/dit
    :alt: Research software impact
+
+.. |waffle| image:: https://badge.waffle.io/dit/dit.png?label=ready&title=Ready 
+   :target: https://waffle.io/dit/dit?utm_source=badge
+   :alt: Stories in Ready


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/dit/dit

This was requested by a real person (user Autoplectic) on waffle.io, we're not trying to spam you.