### PR TITLE
validate_outcome_class corrected

### DIFF
--- a/dit/validate.py
+++ b/dit/validate.py
@@ -233,9 +233,9 @@ def validate_outcome_class(outcomes):
 
     """
     # Make sure the class is the same for all outcomes.
-    classattr = lambda x: getattr(x, '__class__')
-    classes = list(map(classattr, outcomes))
-    equal_classes = np.alltrue(np.equal(classes, outcomes[0].__class__))
+    equal_classes = all(outcomes[0].__class__ == outcome.__class__
+                        for outcome in outcomes)
+
     if not equal_classes:
         raise ditException('Not all outcomes have the same class.')
     else:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16278369/35581011-afe08568-05fb-11e8-8a00-24d37b8ca2a0.png)
Exception is raised as np.equal takes 2 array_like as params and you pass array_like and some object. I don't know, what's the point here to use numpy at all, it doesn't give you any performance advantage.

There is also a problem with Distribution.from_rv_discrete, but it's a bit harder to fix without code knowledge.
![image](https://user-images.githubusercontent.com/16278369/35581277-5f4ed1bc-05fc-11e8-988a-75de8b2ad9f0.png)
