### PR TITLE
MAINT: better error message in construct_alphabets

### DIFF
--- a/dit/helpers.py
+++ b/dit/helpers.py
@@ -131,7 +131,9 @@ def construct_alphabets(outcomes):
     try:
         lengths = list(map(len, outcomes))
     except TypeError:
-        raise ditException('At least one element in `outcomes` does not implement __len__.')
+        raise ditException('At least one element in `outcomes` does not implement __len__. '
+                           'Distribution.from_ndarray or ScalarDistribution may help '
+                           'resolve this.')
     else:
         outcome_length = lengths[0]
 

--- a/dit/helpers.py
+++ b/dit/helpers.py
@@ -131,7 +131,7 @@ def construct_alphabets(outcomes):
     try:
         lengths = list(map(len, outcomes))
     except TypeError:
-        raise ditException('One or more outcomes is not sized. len() fails.')
+        raise ditException('At least one element in `outcomes` does not implement __len__.')
     else:
         outcome_length = lengths[0]
 


### PR DESCRIPTION
Run into when trying

``` python
>>> import dit
>>> x = {i: 1/4 for i in range(4)}
>>> x
{0: 0.25, 1: 0.25, 2: 0.25, 3: 0.25}
>>> d = dit.Distribution(x)
```