### PR TITLE
MathJax doesn't like \scalebox, use \large instead

### DIFF
--- a/docs/_static/dit_mathjax.js
+++ b/docs/_static/dit_mathjax.js
@@ -80,7 +80,7 @@ MathJax.Hub.Config({
             mss: "\\searrow",
             meetop: "\\DeclareMathOperator*{\\meetop}{\\scalerel*{\\meet}{\\textstyle\\sum}}",
             joinop: "\\DeclareMathOperator*{\\joinop}{\\scalerel*{\\join}{\\textstyle\\sum}}",
-            ind: "\\mathrel{\\text{\\scalebox{1.07}{$\\perp\\mkern-10mu\\perp$}}}"
+            ind: "\\mathrel{\\large\\text{$\\perp\\mkern-10mu\\perp$}}"
         }
     }
 });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,7 +272,7 @@ macros = r'''
 \DeclareMathOperator*{\meetop}{\scalerel*{\meet}{\textstyle\sum}}
 \DeclareMathOperator*{\joinop}{\scalerel*{\join}{\textstyle\sum}}
 
-\newcommand{\ind}{\mathrel{\text{\scalebox{1.07}{$\perp\mkern-10mu\perp$}}}}
+\newcommand{\ind}{\mathrel{\large\text{$\perp\mkern-10mu\perp$}}}
 '''
 
 latex_elements = {

--- a/site/src/MathJax/local/dit.js
+++ b/site/src/MathJax/local/dit.js
@@ -74,7 +74,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
   TEX.Macro("meetop", "\\DeclareMathOperator*{\\meetop}{\\scalerel*{\\meet}{\\textstyle\\sum}}")
   TEX.Macro("joinop", "\\DeclareMathOperator*{\\joinop}{\]scalerel*{\]join}{\]textstyle\]sum}}")
 
-  TEX.Macro("ind", "\\mathrel{\\text{\\scalebox{1.07}{$\\perp\\mkern-10mu\\perp$}}}")
+  TEX.Macro("ind", "\\mathrel{\\large\\text{$\\perp\\mkern-10mu\\perp$}}")
 
 
   // don't use stix, it's pretty ugly


### PR DESCRIPTION
MathJax doesn't know how to handle the `\scalebox{1.07}` used for independent variable notation, see [the third paragraph of this section](http://docs.dit.io/en/latest/notation.html#basic-notation).

I've replaced it with `\large`, which I think is a little bit bigger, but does work in MathJax. I couldn't find an easy compatible way to do exactly 7% scaling.

I've also changed the TeX version of this macro, just to keep things consistent.