### PR TITLE
Add conda installation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 |build| |build_windows| |codecov| |health| |deps|
 
-|docs| |slack| |saythanks|
+|docs| |slack| |saythanks| |conda|
 
 |joss| |zenodo|
 
@@ -54,6 +54,8 @@ Downloads
 
 https://pypi.org/project/dit/
 
+https://anaconda.org/conda-forge/dit
+
 +-------------------------------------------------------------------+
 | Dependencies                                                      |
 +===================================================================+
@@ -86,6 +88,12 @@ The easiest way to install is:
 .. code-block:: bash
 
   pip install dit
+  
+If you want to install `dit` within a conda environment, you can simply do:
+
+.. code-block:: bash
+
+  conda install -c conda-forge dit
 
 Alternatively, you can clone this repository, move into the newly created
 ``dit`` directory, and then install the package:
@@ -315,6 +323,10 @@ If you'd like to get in contact about anything, you can reach us through our `sl
 .. |deps| image:: https://requires.io/github/dit/dit/requirements.svg?branch=master
    :target: https://requires.io/github/dit/dit/requirements/?branch=master
    :alt: Requirements Status
+   
+.. |conda| image:: https://anaconda.org/conda-forge/dit/badges/installer/conda.svg
+   :target: https://anaconda.org/conda-forge/dit
+   :alt: Conda installation
 
 .. |zenodo| image:: https://zenodo.org/badge/13201610.svg
    :target: https://zenodo.org/badge/latestdoi/13201610

--- a/docs/basicinfo.rst.txt
+++ b/docs/basicinfo.rst.txt
@@ -3,6 +3,8 @@ Documentation:
 
 Downloads:
    https://pypi.org/project/dit/
+   
+   https://anaconda.org/conda-forge/dit
 
 Dependencies:
    * Python 2.7, 3.3, 3.4, 3.5, or 3.6


### PR DESCRIPTION
Hi, @Autoplectic and dit's devs!

Thanks for the interesting package! For sure it's an amazing work!

I took the initiative to add `dit` to [conda-forge](https://conda-forge.org/) channel. Now, it's possible to install `dit` within a conda env simply doing:

```console
conda install -c conda-forge dit
```

This PR modifies proper places to include this installation option instructions. Please check if there is other places that this could be added. I think providing `dit` from conda increases the access to this package for a wider range of users. I hope you all appreciate it. Otherwise, sorry for my intrusive contribution!

By the way, I would like to invite anyone who contributes here to join me as one of the dit's conda feedstock repo maintainers. Actually, I'm the only one maintainer there. Also, there is no interest in join as a maintainer. @Autoplectic, as the main developer of `dit`, would you like to be add as maintainer?

Best regards,
Diego.
