### PR TITLE
The bound parameter of the Information Bottleneck optimimzer has not been used so far

### DIFF
--- a/dit/rate_distortion/information_bottleneck.py
+++ b/dit/rate_distortion/information_bottleneck.py
@@ -78,7 +78,7 @@ class InformationBottleneck(BaseAuxVarOptimizer):
         # tbound = int(np.ceil(perplexity(dist, rvs[0])))
         bound = min([bound, tbound]) if bound is not None else tbound
 
-        self._construct_auxvars([(self._x | self._z, tbound)])
+        self._construct_auxvars([(self._x | self._z, bound)])
 
         self.complexity = self._conditional_mutual_information(self._x, self._t, self._z)
         self.entropy = self._entropy(self._t, self._z)


### PR DESCRIPTION
The ` bound ` sets a maximum to the cardinality of `X` as set in the parameter description. 

In the code this parameter does not have any effect. 

I think my proposal creates the intended behaviour.