### PR TITLE
Fixing _close.pyx to be compatible with OS X

### DIFF
--- a/dit/math/_close.pyx
+++ b/dit/math/_close.pyx
@@ -1,26 +1,12 @@
 #!/usr/bin/env python
+#cython: language_level=3
 
 """
 Low level implementation of scalar `allclose`.
 """
-import sys
 
-cdef extern from "math.h":
-    double fabs(double)
-    int isinf(double)
-    int isnan(double)
+from libc.math cimport isnan, isinf, fabs
 
-cdef extern from "float.h":
-    double fabs(double)
-    int _isnan(double)
-    int _finite(double)
-
-
-if sys.platform in ('win32', 'cygwin'):
-    def isnan(double x):
-        return _isnan(x)
-    def isinf(double x):
-        return 1 - _finite(x)
 
 
 def close(double x, double y, double rtol, double atol):


### PR DESCRIPTION
Currently I cannot run `python3 setup.py develop` in macOS 12 as there is an error during compilation:
```
...
building 'dit.math._close' extension
creating build
creating build/temp.macosx-11-x86_64-3.9
creating build/temp.macosx-11-x86_64-3.9/dit
creating build/temp.macosx-11-x86_64-3.9/dit/math
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -fwrapv -Wall -O3 -DNDEBUG -I/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c dit/math/_close.c -o build/temp.macosx-11-x86_64-3.9/dit/math/_close.o
dit/math/_close.c:1301:36: error: implicit declaration of function '_isnan' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  __pyx_t_1 = __Pyx_PyInt_From_int(_isnan(__pyx_v_x)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 21, __pyx_L1_error)
                                   ^
dit/math/_close.c:1301:36: note: did you mean '__nan'?
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h:558:14: note: '__nan' declared here
extern float __nan(void)
             ^
dit/math/_close.c:1377:42: error: implicit declaration of function '_finite' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  __pyx_t_1 = __Pyx_PyInt_From_long((1 - _finite(__pyx_v_x))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 23, __pyx_L1_error)
                                         ^
dit/math/_close.c:1377:42: note: did you mean 'finite'?
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h:752:12: note: 'finite' declared here
extern int finite(double)
           ^
2 errors generated.
error: command '/usr/bin/clang' failed with exit code 1
```
This PR fixes this issue, using latest isinf, isnan, and fabs from libc.math.