### PR TITLE
Artemyk preceq rename

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ though it is not in the literature, the multivariate conditional exact common in
 | * Secrecy Capacity                       | * :math:`I_{dep}`                       | * Information Trimming            |
 | * Intrinsic Mutual Information           | * :math:`I_{RAV}`                       | * Lautum Information              |
 | * Reduced Intrinsic Mutual Information   | * :math:`I_{mmi}`                       | * LMPR Complexity                 |
-| * Minimal Intrinsic Mutual Information   | * :math:`I_{\preceq}`                   | * Marginal Utility of Information |
+| * Minimal Intrinsic Mutual Information   | * :math:`I_{\prec}`                     | * Marginal Utility of Information |
 | * Necessary Intrinsic Mutual Information | * :math:`I_{RA}`                        | * Maximum Correlation             |
 | * Two-Part Intrinsic Mutual Information  | * :math:`I_{SKAR}`                      | * Maximum Entropy Distributions   |
 |                                          |                                         | * Perplexity                      |

--- a/dit/pid/measures/__init__.py
+++ b/dit/pid/measures/__init__.py
@@ -11,7 +11,7 @@ from .imes import PID_MES
 from .imin import PID_WB
 from .immi import PID_MMI
 from .ipm import PID_PM
-from .ipreceq import PID_Preceq
+from .iprec import PID_Prec
 from .iproj import PID_Proj
 from .irav import PID_RAV
 from .irr import PID_RR

--- a/dit/pid/measures/__init__.py
+++ b/dit/pid/measures/__init__.py
@@ -34,6 +34,6 @@ __all_pids = [
     PID_RA,
     PID_RAV,
     PID_SKAR_owb,
-    PID_Preceq,
+    PID_Prec,
     PID_CT,
 ]

--- a/dit/pid/measures/igh.py
+++ b/dit/pid/measures/igh.py
@@ -143,7 +143,7 @@ class PID_GH(BasePID):
 
         Returns
         -------
-        ipreceq : float
+        igh : float
             The value of I_GH.
         """
         if len(sources) == 1:

--- a/dit/pid/measures/iprec.py
+++ b/dit/pid/measures/iprec.py
@@ -1,7 +1,7 @@
 """
-Add the I_\\preceq measure as defined in
+Add the I_\\prec measure as defined in
 
-A Kolchinsky, A novel approach to multivariate redundancy and synergy
+A Kolchinsky, A Novel Approach to the Partial Information Decomposition, Entropy, 2022.
 https://arxiv.org/abs/1908.08642
 
 Given a joint distribution p_{Y,X_1,X_2}, this redundancy measure is
@@ -32,23 +32,23 @@ from ...shannon import mutual_information
 
 
 __all__ = (
-    'PID_Preceq',
+    'PID_Prec',
 )
 
 
 
-class PID_Preceq(BasePID):
+class PID_Prec(BasePID):
     """
-    The I_\\preceq measure defined by Kolchinsky.
+    The I_\\prec measure defined by Kolchinsky.
     """
 
-    _name = "I_≼"
+    _name = "I_≺"
 
     @staticmethod
     def get_solution_information(d, sources, target):
         """
-        Compute I_preceq(inputs : output) =
-            \\max I[Q : output] such that Q \\preceq X_i
+        Compute I_prec(inputs : output) =
+            \\max I[Q : output] such that Q \\prec X_i
         and return information about value and optimal Q
 
         Parameters
@@ -62,8 +62,8 @@ class PID_Preceq(BasePID):
 
         Returns
         -------
-        ipreceq : float
-            The value of I_preceq.
+        iprec : float
+            The value of I_prec.
         sol : dict
             Dictionary containing solution information
 

--- a/tests/pid/test_ipreceq.py
+++ b/tests/pid/test_ipreceq.py
@@ -1,54 +1,54 @@
 """
-Tests for dit.pid.measures.ipreceq.
+Tests for dit.pid.measures.iprec.
 """
 
 import sys
 import pytest
 
 from dit import Distribution
-from dit.pid.measures.ipreceq import PID_Preceq
+from dit.pid.measures.iprec import PID_Prec
 from dit.pid.distributions import bivariates
 
 
-def test_pid_preceq1():
+def test_pid_prec1():
     """
-    Test ipreceq on a generic distribution.
+    Test iprec on a generic distribution.
     """
     d = bivariates['and']
-    pid = PID_Preceq(d, ((0,), (1,)), (2,))
+    pid = PID_Prec(d, ((0,), (1,)), (2,))
     assert pid[((0,), (1,))] == pytest.approx(0.31127812445913294, abs=1e-3)
     assert pid[((0,),)] == pytest.approx(0.0, abs=1e-3)
     assert pid[((1,),)] == pytest.approx(0.0, abs=1e-3)
     assert pid[((0, 1),)] == pytest.approx(0.5, abs=1e-3)
 
 
-def test_pid_preceq2():
+def test_pid_prec2():
     """
-    Test ipreceq on another generic distribution.
+    Test iprec on another generic distribution.
     """
     d = bivariates['sum']
-    pid = PID_Preceq(d, [[0], [1]], [2])
+    pid = PID_Prec(d, [[0], [1]], [2])
     assert pid[((0,), (1,))] == pytest.approx(0.5, abs=1e-3)
     assert pid[((0,),)] == pytest.approx(0.0, abs=1e-3)
     assert pid[((1,),)] == pytest.approx(0.0, abs=1e-3)
     assert pid[((0, 1),)] == pytest.approx(1.0, abs=1e-3)
 
 
-def test_pid_preceq3():
+def test_pid_prec3():
     """
-    Test ipreceq on a generic trivariate source distribution.
+    Test iprec on a generic trivariate source distribution.
     """
     events = ['0000', '0010', '0100', '0110', '1000', '1010', '1100', '1111']
     d = Distribution(events, [1 / 8] * 8)
-    pid = PID_Preceq(d, [[0], [1], [2]], [3])
+    pid = PID_Prec(d, [[0], [1], [2]], [3])
     assert pid[((0,), (1,), (2,))] == pytest.approx(0.13795718192252743, abs=1e-3)
 
 
-def test_pid_preceq4():
+def test_pid_prec4():
     """
-    Test ipreceq on unique gate X1,X2 -> X1, which should have redundancy equal to I(X1;X2)
+    Test iprec on unique gate X1,X2 -> X1, which should have redundancy equal to I(X1;X2)
     """
     d = Distribution(['000', '011', '100', '111'], [.35, .15, .15, .35])
-    pid = PID_Preceq(d, [[0], [1],], [2])
+    pid = PID_Prec(d, [[0], [1],], [2])
     assert pid[((0,), (1,),)] == pytest.approx(0.119, abs=1e-2)
 


### PR DESCRIPTION
My PID paper came out in Entropy. For notational reasons, my measure was renamed to I^\prec rather than I^\preceq. Fixing references in the code.