### PR TITLE
Add the Salamatian-Cohen-Médard Maximum Entropy Function

### DIFF
--- a/dit/multivariate/common_informations/__init__.py
+++ b/dit/multivariate/common_informations/__init__.py
@@ -10,6 +10,7 @@ from .kamath_common_information import (
     directed_kamath_common_information,
     kamath_common_information,
 )
+from .maxent_function import maxent_function, plot_maxent_function
 from .mss_common_information import mss_common_information
 from .stochastic_gk_common_information import stochastic_gk_common_information
 from .wyner_common_information import wyner_common_information

--- a/dit/multivariate/common_informations/maxent_function.py
+++ b/dit/multivariate/common_informations/maxent_function.py
@@ -1,0 +1,323 @@
+"""
+The Salamatian-Cohen-Médard Maximum Entropy Function.
+
+An approximate Gács-Körner common information that allows a small helper
+rate.  See Salamatian, Cohen, & Médard, "Maximum Entropy Functions:
+Approximate Gács-Körner for Distributed Compression", Information Theory
+and Applications Workshop (ITA), 2016 (arXiv:1604.03877).
+"""
+
+import numpy as np
+
+from ...exceptions import ditException
+from ...helpers import normalize_rvs
+from ...utils import unitful
+
+__all__ = (
+    "maxent_function",
+    "plot_maxent_function",
+)
+
+
+def _coalesced_pmf(dist, rvs):
+    """Return the (n_X, n_Y) joint pmf for the two random variables."""
+    d = dist.copy().coalesce(rvs)
+    d.make_dense()
+    return d.pmf.reshape(list(map(len, d.alphabet)))
+
+
+def _q_matrix(pXY):
+    """
+    Build Q = D_X^{-1/2} P D_Y^{-1/2} (Witsenhausen 1975 / Salamatian §II-C).
+    """
+    pX = pXY.sum(axis=1)
+    pY = pXY.sum(axis=0)
+    Dx = np.where(pX > 0, 1.0 / np.sqrt(pX), 0.0)
+    Dy = np.where(pY > 0, 1.0 / np.sqrt(pY), 0.0)
+    return Dx[:, None] * pXY * Dy[None, :]
+
+
+def _second_singular_vectors(pXY):
+    """
+    Return the second left/right singular vectors of Q.
+
+    Subtracts the trivial rank-1 component sqrt(p_X) sqrt(p_Y)^T (which
+    always carries the unit singular value of Q) before taking the SVD,
+    so the leading vectors of the residual are exactly the paper's u, v
+    even when Q's top singular value has multiplicity > 1 (the
+    Gács-Körner-positive regime).
+
+    Returns
+    -------
+    u, v : np.ndarray or None
+        The (left, right) singular vectors, or (None, None) when one of
+        the alphabets is degenerate (size < 2).
+    """
+    if min(pXY.shape) < 2:
+        return None, None
+
+    Q = _q_matrix(pXY)
+    sx = np.sqrt(pXY.sum(axis=1))
+    sy = np.sqrt(pXY.sum(axis=0))
+    Q_resid = Q - np.outer(sx, sy)
+
+    U, _, Vt = np.linalg.svd(Q_resid, full_matrices=False)
+    return U[:, 0], Vt[0, :]
+
+
+def _h2(*probs):
+    """Shannon entropy (base 2) of a list of probabilities."""
+    p = np.asarray(probs, dtype=float)
+    p = p[p > 0]
+    if p.size == 0:
+        return 0.0
+    return float(-np.sum(p * np.log2(p)))
+
+
+def _eval_phi(pXY, phi_x, phi_y):
+    """
+    Return (H(phi_X(X)), H(phi_X(X) | phi_Y(Y))) for ±1 label vectors.
+    """
+    px_pos = phi_x > 0
+    py_pos = phi_y > 0
+
+    p_pp = float(pXY[np.ix_(px_pos, py_pos)].sum())
+    p_pn = float(pXY[np.ix_(px_pos, ~py_pos)].sum())
+    p_np = float(pXY[np.ix_(~px_pos, py_pos)].sum())
+    p_nn = float(pXY[np.ix_(~px_pos, ~py_pos)].sum())
+
+    p_x_pos = p_pp + p_pn
+    p_x_neg = p_np + p_nn
+    p_y_pos = p_pp + p_np
+    p_y_neg = p_pn + p_nn
+
+    H_phi_x = _h2(p_x_pos, p_x_neg)
+    H_phi_y = _h2(p_y_pos, p_y_neg)
+    H_joint = _h2(p_pp, p_pn, p_np, p_nn)
+
+    H_cond = max(0.0, H_joint - H_phi_y)
+    return H_phi_x, H_cond
+
+
+def _threshold_sweep(pXY):
+    """
+    Evaluate the spectral algorithm at every distinct threshold position.
+
+    Distinct thresholds are taken as the midpoints between sorted entries
+    of the left singular vector u, padded with sentinels below the min
+    and above the max so the all-plus and all-minus partitions are
+    included exactly once each.
+
+    Returns
+    -------
+    points : list of (t, H_phi_x, H_cond, phi_x, phi_y)
+        One entry per distinct threshold, sorted by t.  Empty list if
+        the alphabet is degenerate.
+    """
+    u, v = _second_singular_vectors(pXY)
+    if u is None:
+        return []
+
+    su = np.sort(u)
+    midpoints = (su[:-1] + su[1:]) / 2.0
+    ts = np.concatenate(([su[0] - 1.0], midpoints, [su[-1] + 1.0]))
+
+    points = []
+    for t in ts:
+        phi_x = np.where(u > t, 1, -1)
+        phi_y = np.where(v > t, 1, -1)
+        H_x, H_cond = _eval_phi(pXY, phi_x, phi_y)
+        points.append((float(t), H_x, H_cond, phi_x.copy(), phi_y.copy()))
+
+    return points
+
+
+def _spectral_value(pXY, epsilon):
+    """Max H(phi_X) over the spectral threshold sweep with H_cond <= eps."""
+    points = _threshold_sweep(pXY)
+    feasible = [H_x for (_, H_x, H_cond, _, _) in points if H_cond <= epsilon + 1e-12]
+    return max(feasible, default=0.0)
+
+
+def _iter_binary_partitions(n):
+    """
+    Yield each binary partition of {0..n-1} once, as a length-n ±1 vector.
+
+    The constant +1 vector is yielded first; then phi[0] is held to +1
+    to break the symmetry between phi and -phi (which give identical
+    H(phi(X)) and H(phi_X|phi_Y) values).
+    """
+    yield np.ones(n, dtype=int)
+    for mask in range(1, 1 << max(n - 1, 0)):
+        phi = np.ones(n, dtype=int)
+        for i in range(n - 1):
+            if (mask >> i) & 1:
+                phi[i + 1] = -1
+        yield phi
+
+
+_EXACT_MAX_PAIRS = 1 << 20  # ~1e6 partition pairs
+
+
+def _exact_value(pXY, epsilon):
+    """Brute-force max H(phi_X) over all binary partitions of X and Y."""
+    n_x, n_y = pXY.shape
+    n_pairs = (1 << max(n_x - 1, 0)) * (1 << max(n_y - 1, 0))
+    if n_pairs > _EXACT_MAX_PAIRS:
+        msg = (
+            f"exact maxent_function refuses to enumerate {n_pairs} partition "
+            f"pairs for alphabets of size {n_x} x {n_y}; use method='spectral' "
+            f"or coarsen the support."
+        )
+        raise ditException(msg)
+
+    partitions_y = list(_iter_binary_partitions(n_y))
+
+    best = 0.0
+    for phi_x in _iter_binary_partitions(n_x):
+        for phi_y in partitions_y:
+            H_x, H_cond = _eval_phi(pXY, phi_x, phi_y)
+            if H_cond <= epsilon + 1e-12 and H_x > best:
+                best = H_x
+    return best
+
+
+def _prepare(dist, rvs, crvs):
+    """Validate rvs/crvs and return the (n_X, n_Y) joint pmf."""
+    rvs, crvs = normalize_rvs(dist, rvs, crvs)
+    if crvs:
+        msg = (
+            "maxent_function does not support conditioning; "
+            "Salamatian et al. 2016 is strictly bivariate, unconditional."
+        )
+        raise ditException(msg)
+    if len(rvs) != 2:
+        msg = f"maxent_function requires exactly 2 random variables, got {len(rvs)}."
+        raise ditException(msg)
+    return _coalesced_pmf(dist, rvs)
+
+
+@unitful
+def maxent_function(dist, epsilon, rvs=None, crvs=None, method="spectral"):
+    """
+    The Salamatian-Cohen-Médard Maximum Entropy Function:
+
+    .. math::
+
+        M_{\\epsilon}(X; Y) = \\max_{\\phi_X, \\phi_Y}
+            H(\\phi_X(X)) \\quad \\text{s.t.} \\quad
+            H(\\phi_X(X) \\mid \\phi_Y(Y)) \\le \\epsilon
+
+    where the maximization is over binary-valued functions
+    :math:`\\phi_X: \\mathcal{X} \\to \\{-1, +1\\}` and
+    :math:`\\phi_Y: \\mathcal{Y} \\to \\{-1, +1\\}`.  This is an
+    approximate Gács-Körner common information that admits a helper
+    of rate up to :math:`\\epsilon`.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The distribution from which to compute the measure.
+    epsilon : float
+        The maximum allowed helper rate
+        :math:`H(\\phi_X(X) \\mid \\phi_Y(Y))`.
+    rvs : list, None
+        A list selecting exactly two random variables (by index or name).
+        If None, all variables of `dist` are used; `dist` must therefore
+        be bivariate.
+    crvs : list, None
+        Not supported; passing a non-empty `crvs` raises
+        :class:`ditException`.
+    method : {"spectral", "exact"}
+        - ``"spectral"`` (default): the paper's §IV-A approximation.
+          Thresholds the second left/right singular vectors of
+          :math:`Q = D_X^{-1/2} P D_Y^{-1/2}` across all distinct cuts
+          and returns the largest feasible :math:`H(\\phi_X(X))`.
+        - ``"exact"``: brute force over every binary partition of
+          :math:`\\mathcal{X}` and :math:`\\mathcal{Y}`.  Refuses to run
+          when the alphabets would produce more than ~:math:`2^{20}`
+          partition pairs.
+
+    Returns
+    -------
+    M : float
+        The Maximum Entropy Function value (in bits when units are off).
+
+    Raises
+    ------
+    ditException
+        If `crvs` is provided, `rvs` does not select exactly two
+        variables, the method is unknown, or `method="exact"` is requested
+        on an alphabet that is too large to enumerate.
+    """
+    pXY = _prepare(dist, rvs, crvs)
+
+    if method == "spectral":
+        return _spectral_value(pXY, float(epsilon))
+    if method == "exact":
+        return _exact_value(pXY, float(epsilon))
+
+    msg = f"Unknown method {method!r}; expected 'spectral' or 'exact'."
+    raise ditException(msg)
+
+
+def plot_maxent_function(dist, rvs=None, crvs=None, ax=None, **plot_kwargs):
+    """
+    Plot the spectral Maximum Entropy Function value :math:`H(\\phi_X(X))`
+    as a function of the threshold :math:`t`.
+
+    At each distinct threshold position on the second left singular
+    vector :math:`u` of :math:`Q = D_X^{-1/2} P D_Y^{-1/2}`, the binary
+    function :math:`\\phi_X(i) = \\mathrm{sign}(u_i - t)` (and similarly
+    :math:`\\phi_Y` from the second right singular vector :math:`v`) is
+    constructed per Salamatian et al. 2016 §IV-A, and
+    :math:`H(\\phi_X(X))` is plotted at each :math:`t`.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The distribution from which to compute the curve.
+    rvs : list, None
+        A list selecting exactly two random variables (by index or name).
+        If None, all variables of `dist` are used; `dist` must therefore
+        be bivariate.
+    crvs : list, None
+        Not supported; passing a non-empty `crvs` raises
+        :class:`ditException`.
+    ax : matplotlib.axes.Axes, None
+        The axis to draw on.  A new figure and axis are created if None.
+    **plot_kwargs
+        Forwarded to :meth:`matplotlib.axes.Axes.plot`.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axis containing the plot.
+
+    Raises
+    ------
+    ditException
+        If `crvs` is provided, `rvs` does not select exactly two
+        variables, or the joint pmf is too degenerate for a spectral
+        sweep (one of the alphabets has size < 2).
+    """
+    import matplotlib.pyplot as plt
+
+    pXY = _prepare(dist, rvs, crvs)
+    points = _threshold_sweep(pXY)
+
+    if not points:
+        msg = "spectral threshold sweep is empty; both alphabets must have size >= 2."
+        raise ditException(msg)
+
+    ts = [t for (t, _, _, _, _) in points]
+    H_xs = [H_x for (_, H_x, _, _, _) in points]
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    plot_kwargs.setdefault("marker", "o")
+    ax.plot(ts, H_xs, **plot_kwargs)
+    ax.set_xlabel(r"threshold $t$")
+    ax.set_ylabel(r"$H(\phi_X(X))$ [bits]")
+    return ax

--- a/dit/pid/measures/ido.py
+++ b/dit/pid/measures/ido.py
@@ -56,11 +56,7 @@ def _intervened_joint(p_xyz):
         p_xi_given_y = np.where(p_y[None, :] > 0, p_xi_y / p_y[None, :], 0.0)
         p_y_given_xj = np.where(p_xj[:, None] > 0, p_xj_y / p_xj[:, None], 0.0)
 
-    return (
-        p_xj[None, :, None]
-        * p_y_given_xj[None, :, :]
-        * p_xi_given_y[:, None, :]
-    )
+    return p_xj[None, :, None] * p_y_given_xj[None, :, :] * p_xi_given_y[:, None, :]
 
 
 def _mi_from_joint(q_ab):

--- a/docs/measures/multivariate/kamath_common_information.rst
+++ b/docs/measures/multivariate/kamath_common_information.rst
@@ -17,7 +17,7 @@ Kamath and Anantharam show this quantity has a strikingly simple closed form. De
 
 The asymmetric quantity :math:`\Phi^X_Y` is exactly the **minimal sufficient statistic** of :math:`Y` about :math:`X` (Kamath & Anantharam 2010, Lemma 3.5(5)) — two values of :math:`Y` collapse iff they induce the same conditional distribution over :math:`X`. So :math:`G(Y \to X)` is the entropy of the partition of the alphabet of :math:`Y` into "conditional-distribution-equivalent" classes.
 
-For :math:`n > 2` random variables, ``dit`` generalizes :math:`U` analogously to how :ref:`mss_common_information` extends:
+For :math:`n > 2` random variables, ``dit`` generalizes :math:`U` analogously to how :doc:`mss_common_information` extends:
 
 .. math::
 
@@ -47,7 +47,7 @@ with rows indexed by :math:`X \in \{a, b, c\}` and columns by :math:`Y \in \{\al
 
    In [2]: from dit.multivariate import kamath_common_information as U
 
-   In [3]: from dit.multivariate import directed_kamath_common_information as G
+   In [3]: from dit.multivariate import directed_kamath_common_information as G_dir
 
    In [4]: outcomes = ['aα', 'bβ', 'bγ', 'bδ', 'cβ', 'cγ', 'cδ']
 
@@ -56,11 +56,11 @@ with rows indexed by :math:`X \in \{a, b, c\}` and columns by :math:`Y \in \{\al
    In [6]: d = D(outcomes, pmf)
 
    @doctest float
-   In [7]: G(d, rvs=[1], about=[0])
+   In [7]: G_dir(d, rvs=[1], about=[0])
    Out[7]: 1.0414647631411194
 
    @doctest float
-   In [8]: G(d, rvs=[0], about=[1])
+   In [8]: G_dir(d, rvs=[0], about=[1])
    Out[8]: 1.3712481855145016
 
    @doctest float

--- a/docs/measures/multivariate/maxent_function.rst
+++ b/docs/measures/multivariate/maxent_function.rst
@@ -1,0 +1,95 @@
+.. maxent_function.rst
+.. py:module:: dit.multivariate.common_informations.maxent_function
+
+*************************
+Maximum Entropy Function
+*************************
+
+The Maximum Entropy Function of Salamatian, Cohen, and Médard :cite:`salamatian2016maxent` is an *approximate* :ref:`gács-körner common information` that admits a small "helper" rate. It captures the largest entropy of a binary function :math:`\phi_X(X) \in \{-1, +1\}` of one source whose agreement with a binary function :math:`\phi_Y(Y) \in \{-1, +1\}` of the other source costs at most :math:`\epsilon` bits to repair:
+
+.. math::
+
+   M_\epsilon(X; Y) =
+       \max_{\phi_X, \phi_Y}
+       \H{\phi_X(X)}
+       \quad \text{s.t.} \quad
+       \H{\phi_X(X) \mid \phi_Y(Y)} \le \epsilon.
+
+When the bipartite graph of :math:`p_{X,Y}` has disjoint components, the optimal pair is the connected-component indicator and :math:`M_0 = \K{X : Y}`. Allowing :math:`\epsilon > 0` lets the optimizer commit to a "near"-Gács-Körner partition that misses agreement on a small fraction of joint outcomes (an "almost" common variable that a helper of rate :math:`\epsilon` can patch up).
+
+
+Algorithms
+==========
+
+``dit`` exposes both the exact optimization (Definition 3 in the paper) and the spectral approximation (Section IV-A) through a single function with a ``method`` argument.
+
+* ``method="spectral"`` (default) — the paper's spectral algorithm. Compute :math:`Q = D_X^{-1/2}\, P\, D_Y^{-1/2}` where :math:`D_X, D_Y` are diagonal matrices of marginals. Subtract the trivial rank-one component :math:`\sqrt{p_X}\sqrt{p_Y}^T` (which always carries the unit singular value of :math:`Q`) and take the leading left/right singular vectors :math:`u, v` of the residual. For a real threshold :math:`t`, set :math:`\phi_X(i) = \mathrm{sign}(u_i - t)` and :math:`\phi_Y(j) = \mathrm{sign}(v_j - t)`. Sweep :math:`t` across every distinct cut of :math:`u` and return the largest feasible :math:`\H{\phi_X(X)}`.
+
+* ``method="exact"`` — brute force over every binary partition of :math:`\mathcal{X}` and :math:`\mathcal{Y}`. Refuses to run when the alphabets would generate more than :math:`2^{20}` partition pairs.
+
+
+Worked example
+==============
+
+The paper's two leading examples both live on a :math:`4 \times 4` joint with two disjoint blocks, optionally connected by a small "leak" edge.
+
+The clean block-diagonal joint has Gács-Körner :math:`= 1` bit; the binary indicator :math:`\phi_X(i) = +1` iff :math:`i \in \{0, 1\}` (and the same for :math:`\phi_Y`) achieves :math:`\H{\phi_X(X)} = 1` and :math:`\H{\phi_X(X) \mid \phi_Y(Y)} = 0`.
+
+.. ipython::
+
+   In [1]: from dit import Distribution as D
+
+   In [2]: from dit.multivariate import maxent_function
+
+   In [3]: outcomes = ['00', '01', '10', '11', '22', '23', '32', '33']
+
+   In [4]: pmf = [1/8] * 8
+
+   In [5]: d = D(outcomes, pmf)
+
+   @doctest float
+   In [6]: maxent_function(d, epsilon=0.0, method='exact')
+   Out[6]: 1.0
+
+   @doctest float
+   In [7]: maxent_function(d, epsilon=0.0, method='spectral')
+   Out[7]: 1.0
+
+Moving the :math:`(1, 1)` atom to :math:`(1, 2)` joins the two blocks; Gács-Körner drops to :math:`0` and :math:`M_0` follows it. But once the helper is allowed enough rate to repair the leaked outcome, the original block partition becomes feasible again and :math:`M_\epsilon` jumps back to :math:`1` bit.
+
+.. ipython::
+
+   In [8]: from dit.multivariate import gk_common_information
+
+   In [9]: leak = D(['00', '01', '10', '12', '22', '23', '32', '33'], [1/8] * 8)
+
+   @doctest float
+   In [10]: gk_common_information(leak)
+   Out[10]: 0.0
+
+   @doctest float
+   In [11]: maxent_function(leak, epsilon=0.0, method='exact')
+   Out[11]: 0.0
+
+   @doctest float
+   In [12]: maxent_function(leak, epsilon=0.6, method='exact')
+   Out[12]: 1.0
+
+
+Threshold sweep
+===============
+
+The spectral threshold :math:`t` parameterises the binary partitions returned by the algorithm; :func:`plot_maxent_function` plots :math:`\H{\phi_X(X))}` at every distinct threshold position.
+
+.. ipython::
+
+   In [13]: from dit.multivariate import plot_maxent_function
+
+   In [14]: ax = plot_maxent_function(leak)
+
+
+API
+===
+
+.. autofunction:: maxent_function
+.. autofunction:: plot_maxent_function

--- a/docs/measures/multivariate/multivariate.rst
+++ b/docs/measures/multivariate/multivariate.rst
@@ -64,6 +64,7 @@ These measures all somehow measure shared information, but do not equal the mutu
    exact_common_information
    functional_common_information
    kamath_common_information
+   maxent_function
    mss_common_information
 
 Ordering

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -300,6 +300,7 @@ We can also plot all four on the same entropy triangle:
 We can plot these same distributions on a slightly different entropy triangle as well, :class:`EntropyTriangle2`, one comparing the :doc:`measures/multivariate/residual_entropy`, :doc:`measures/multivariate/total_correlation`, and :doc:`measures/multivariate/dual_total_correlation`:
 
 .. ipython::
+   :okwarning:
 
    @savefig entropy_triangle2_example.png width=500 align=center
    In [33]: EntropyTriangle2(dists).draw();

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -176,6 +176,15 @@
   year={2022}
 }
 
+% approximate Gács-Körner via maximum entropy functions
+@inproceedings{salamatian2016maxent,
+  title={Maximum Entropy Functions: Approximate {G}{\'a}cs-{K}{\"o}rner for Distributed Compression},
+  author={Salamatian, Salman and Cohen, Asaf and M{\'e}dard, Muriel},
+  booktitle={Information Theory and Applications Workshop (ITA)},
+  year={2016},
+  note={arXiv:1604.03877}
+}
+
 % wyner common information
 @article{wyner1975common,
   title={The common information of two dependent random variables},

--- a/tests/multivariate/common_informations/test_maxent_function.py
+++ b/tests/multivariate/common_informations/test_maxent_function.py
@@ -1,0 +1,191 @@
+"""
+Tests for dit.multivariate.common_informations.maxent_function.
+"""
+
+import numpy as np
+import pytest
+
+from dit import Distribution
+from dit.exceptions import ditException
+from dit.multivariate import gk_common_information as K
+from dit.multivariate import maxent_function, plot_maxent_function
+
+
+def _h2(*probs):
+    p = np.asarray(probs, dtype=float)
+    p = p[p > 0]
+    return float(-np.sum(p * np.log2(p)))
+
+
+@pytest.fixture
+def block_diag():
+    """
+    Salamatian et al. 2016, §II-B example.  P/(1/8) = block-diag of two
+    2x2 blocks of ones, so the bipartite graph has two disjoint
+    components and Gács-Körner = 1 bit.
+    """
+    outcomes = ["00", "01", "10", "11", "22", "23", "32", "33"]
+    pmf = [1 / 8] * 8
+    return Distribution(outcomes, pmf)
+
+
+@pytest.fixture
+def leak_distribution():
+    """
+    Salamatian et al. 2016, §III-B example with delta = 1: the block
+    diagonal P with the (1,1) atom moved to (1,2), connecting the two
+    components.  Gács-Körner = 0, but the (+1,+1,-1,-1) partition is
+    still nearly optimal once a helper is allowed.
+    """
+    outcomes = ["00", "01", "10", "12", "22", "23", "32", "33"]
+    pmf = [1 / 8] * 8
+    return Distribution(outcomes, pmf)
+
+
+def test_block_diag_exact_recovers_gk(block_diag):
+    """Exact M_0 = K = 1 on disjoint components."""
+    assert maxent_function(block_diag, epsilon=0.0, method="exact") == pytest.approx(1.0)
+    assert K(block_diag) == pytest.approx(1.0)
+
+
+def test_block_diag_spectral_recovers_gk(block_diag):
+    """Spectral M_0 = 1 on disjoint components."""
+    assert maxent_function(block_diag, epsilon=0.0, method="spectral") == pytest.approx(1.0)
+
+
+def test_leak_at_eps_zero_is_zero(leak_distribution):
+    """K = 0 forces both methods to the trivial value at epsilon = 0."""
+    assert K(leak_distribution) == pytest.approx(0.0)
+    assert maxent_function(leak_distribution, epsilon=0.0, method="exact") == pytest.approx(0.0)
+    assert maxent_function(leak_distribution, epsilon=0.0, method="spectral") == pytest.approx(0.0)
+
+
+def test_leak_with_helper_reaches_one_bit(leak_distribution):
+    """
+    With delta = 1 the (+1,+1,-1,-1) partition has H(phi_X) = 1 bit and
+    H(phi_X | phi_Y) = (5/8) * h(1/5).  At that helper rate both methods
+    should attain the full bit.
+    """
+    helper = (5 / 8) * _h2(1 / 5, 4 / 5)
+    assert maxent_function(leak_distribution, epsilon=helper, method="exact") == pytest.approx(1.0)
+    assert maxent_function(leak_distribution, epsilon=helper, method="spectral") == pytest.approx(1.0)
+
+
+def test_eps_below_zero_returns_zero(block_diag):
+    """Negative epsilon admits no partition at all."""
+    assert maxent_function(block_diag, epsilon=-0.1, method="exact") == pytest.approx(0.0)
+    assert maxent_function(block_diag, epsilon=-0.1, method="spectral") == pytest.approx(0.0)
+
+
+def test_large_eps_bounded_by_one(block_diag, leak_distribution):
+    """Binary functions have entropy at most 1 bit regardless of epsilon."""
+    for dist in (block_diag, leak_distribution):
+        for method in ("exact", "spectral"):
+            assert maxent_function(dist, epsilon=10.0, method=method) <= 1.0 + 1e-9
+
+
+def test_independent_uniforms_gives_zero_at_eps_zero():
+    """For X _||_ Y, H(phi_X | phi_Y) = H(phi_X) > 0 for any non-trivial phi."""
+    outcomes = ["00", "01", "10", "11"]
+    pmf = [1 / 4] * 4
+    d = Distribution(outcomes, pmf)
+    assert maxent_function(d, epsilon=0.0, method="exact") == pytest.approx(0.0)
+    assert maxent_function(d, epsilon=0.0, method="spectral") == pytest.approx(0.0)
+
+
+def test_giant_bit_full_correlation():
+    """For perfectly correlated bits, M_0 = K = 1 bit."""
+    d = Distribution(["00", "11"], [1 / 2] * 2)
+    assert maxent_function(d, epsilon=0.0, method="exact") == pytest.approx(1.0)
+    assert maxent_function(d, epsilon=0.0, method="spectral") == pytest.approx(1.0)
+
+
+def test_spectral_lower_bound_by_exact(leak_distribution):
+    """
+    The spectral algorithm is a feasibility-preserving heuristic on the
+    same search space as the exact brute force, so it can never exceed
+    the exact value at the same epsilon.
+    """
+    for eps in (0.0, 0.2, 0.5, 0.8):
+        spec = maxent_function(leak_distribution, epsilon=eps, method="spectral")
+        exact = maxent_function(leak_distribution, epsilon=eps, method="exact")
+        assert spec <= exact + 1e-9
+
+
+def test_method_monotone_in_eps(leak_distribution):
+    """M_eps is monotone non-decreasing in epsilon."""
+    eps_grid = [0.0, 0.1, 0.3, 0.6, 1.0, 5.0]
+    for method in ("exact", "spectral"):
+        values = [maxent_function(leak_distribution, epsilon=e, method=method) for e in eps_grid]
+        for v_prev, v_next in zip(values[:-1], values[1:], strict=True):
+            assert v_next + 1e-9 >= v_prev
+
+
+def test_rv_names_accepted(block_diag):
+    """Random-variable names should be accepted wherever indices are."""
+    block_diag.set_rv_names("XY")
+    assert maxent_function(block_diag, epsilon=0.0, rvs=[["X"], ["Y"]], method="exact") == pytest.approx(1.0)
+    assert maxent_function(block_diag, epsilon=0.0, rvs=[["X"], ["Y"]], method="spectral") == pytest.approx(1.0)
+
+
+def test_crvs_rejected(block_diag):
+    """Conditioning is not implemented; must raise."""
+    with pytest.raises(ditException):
+        maxent_function(block_diag, epsilon=0.5, rvs=[[0], [1]], crvs=[0])
+
+
+def test_requires_two_variables():
+    """Strictly bivariate; an n != 2 rvs list must raise."""
+    d = Distribution(["000", "111"], [1 / 2] * 2)
+    with pytest.raises(ditException):
+        maxent_function(d, epsilon=0.5)
+    with pytest.raises(ditException):
+        maxent_function(d, epsilon=0.5, rvs=[[0]])
+    with pytest.raises(ditException):
+        maxent_function(d, epsilon=0.5, rvs=[[0], [1], [2]])
+
+
+def test_unknown_method_raises(block_diag):
+    """Misspelled method should fail loudly."""
+    with pytest.raises(ditException):
+        maxent_function(block_diag, epsilon=0.5, method="lagrangian")
+
+
+def test_exact_alphabet_cap_raises():
+    """Exact mode refuses absurdly large alphabets."""
+    n = 14  # 2^13 * 2^13 = 2^26, > 2^20
+    outcomes = [f"{i:02d}{j:02d}" for i in range(n) for j in range(n)]
+    pmf = [1 / (n * n)] * (n * n)
+    d = Distribution(outcomes, pmf)
+    with pytest.raises(ditException):
+        maxent_function(d, epsilon=0.0, method="exact")
+
+
+def test_plot_returns_axes_with_curve(block_diag):
+    """Smoke test: plot helper returns an axis with a single line."""
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+
+    ax = plot_maxent_function(block_diag)
+    lines = ax.get_lines()
+    assert len(lines) == 1
+    xs, ys = lines[0].get_data()
+    assert len(xs) == len(ys) >= 4  # at least 4 distinct thresholds for n_X = 4
+    assert max(ys) == pytest.approx(1.0)
+    assert all(0.0 - 1e-9 <= y <= 1.0 + 1e-9 for y in ys)
+
+
+def test_plot_accepts_kwargs_and_axis(block_diag):
+    """plot_maxent_function should respect a user-supplied axis and kwargs."""
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    out = plot_maxent_function(block_diag, ax=ax, color="red", linestyle="--", marker="x")
+    assert out is ax
+    line = ax.get_lines()[0]
+    assert line.get_color() == "red"
+    assert line.get_linestyle() == "--"
+    assert line.get_marker() == "x"
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Adds the Maximum Entropy Function of Salamatian, Cohen, & Médard (ITA 2016, arXiv:1604.03877) — an approximate Gács-Körner common information that admits a small helper rate ε.

- **`maxent_function(dist, epsilon, rvs=None, crvs=None, method='spectral')`** in `dit/multivariate/common_informations/maxent_function.py`. Two methods:
  - `'spectral'` (default): the paper's §IV-A algorithm. Subtracts the trivial `sqrt(p_X) sqrt(p_Y)^T` rank-1 component from `Q = D_X^{-1/2} P D_Y^{-1/2}` so the leading singular vectors of the residual are the paper's `u, v` (robust to the Gács-Körner-positive regime where Q's top SV has multiplicity > 1). Sweeps a single shared threshold `t` across all distinct cuts of `u` and returns the largest feasible `H(φ_X(X))`.
  - `'exact'`: brute force over every binary partition of `𝒳` and `𝒴`. Hard cap at `2^20` partition pairs raises `ditException`.
- **`plot_maxent_function(dist, rvs=None, crvs=None, ax=None, **kwargs)`**: traces `H(φ_X(X))` against the spectral threshold `t`. Lazy-imports `matplotlib`.
- `crvs` is rejected (paper is strictly bivariate, unconditional); `rvs` must select exactly two variables, matching `maximum_correlation`'s contract.
- Docs page (`docs/measures/multivariate/maxent_function.rst`) with worked examples on the paper's block-diagonal joint and its leaked variant, plus a new bib entry and a toctree entry.

## Test plan

- [x] `pytest tests/multivariate/common_informations/test_maxent_function.py` — 17 new tests pass (paper's two leading examples for both methods, sanity bounds, monotonicity in ε, error paths, plot smoke tests gated by `pytest.importorskip("matplotlib")`).
- [x] `pytest tests/multivariate/common_informations/ -m "not slow"` — full 78-test non-slow suite passes.
- [ ] Slow ordering tests (`test_cis1`, `test_cis2`) — out of scope; `test_cis2` is a pre-existing flaky hypothesis property test on the `F ≤ U` ordering that does not import or touch `maxent_function`.

Made with [Cursor](https://cursor.com)