### PR TITLE
Add analytic gradients to the slow SKAR optimizers

### DIFF
--- a/dit/algorithms/optimization.py
+++ b/dit/algorithms/optimization.py
@@ -810,6 +810,51 @@ class BaseOptimizer(metaclass=ABCMeta):
 
         return caekl_mutual_information
 
+    def _caekl_mutual_information_grad(self, rvs, crvs=None):
+        """
+        Gradient builder for :meth:`_caekl_mutual_information`.
+
+        CAEKL is a ``min`` over partitions; the gradient of the active (argmin)
+        partition is a valid subgradient (the same trick used by the ``min``/
+        ``max`` objectives elsewhere). Differentiable except on the measure-zero
+        set where the argmin switches.
+        """
+        if crvs is None:
+            crvs = set()
+        parts = [p for p in partitions(rvs) if len(p) > 1]
+        idx_parts = {}
+        for part in parts:
+            for p in part:
+                if p not in idx_parts:
+                    idx_parts[p] = tuple(self._all_vars - (p | crvs))
+        part_norms = [len(part) - 1 for part in parts]
+        idx_joint = tuple(self._all_vars - (rvs | crvs))
+        idx_crvs = tuple(self._all_vars - crvs)
+
+        def grad(pmf):
+            # Recompute the candidates to find the active (argmin) partition.
+            pmf_joint = pmf.sum(axis=idx_joint, keepdims=True)
+            pmf_parts = {p: pmf_joint.sum(axis=idx, keepdims=True) for p, idx in idx_parts.items()}
+            pmf_crvs = pmf_joint.sum(axis=idx_crvs, keepdims=True)
+
+            h_crvs = self._h(pmf_crvs)
+            h_joint = self._h(pmf_joint) - h_crvs
+
+            pairs = list(zip(parts, part_norms, strict=True))
+            candidates = [(sum(self._h(pmf_parts[p]) - h_crvs for p in part) - h_joint) / norm for part, norm in pairs]
+
+            idx_min = min(range(len(candidates)), key=lambda i: candidates[i])
+            part, norm = pairs[idx_min]
+
+            # d/dpmf of (sum_p H(p) - (|part|-1) H(crvs) - H(joint)) / norm.
+            g = sum(self._marginal_entropy_grad(pmf, idx_parts[p]) for p in part)
+            g = g - (len(part) - 1) * self._marginal_entropy_grad(pmf, idx_crvs)
+            g = g - self._marginal_entropy_grad(pmf, idx_joint)
+            g = g / norm
+            return self._full_grad(g, pmf)
+
+        return grad
+
     def _maximum_correlation(self, rv_x, rv_y):
         """
         Compute the maximum correlation.

--- a/dit/multivariate/secret_key_agreement/base_skar_optimizers.py
+++ b/dit/multivariate/secret_key_agreement/base_skar_optimizers.py
@@ -419,6 +419,16 @@ class InnerTwoPartIMIMixin:
 
         return objective
 
+    def _objective_gradient(self):
+        """Gradient of ``-(I[U:J|V] - I[U:Z|V])`` w.r.t. the joint."""
+        cmi1_grad = self._conditional_mutual_information_grad(self._u, self._j, self._v)
+        cmi2_grad = self._conditional_mutual_information_grad(self._u, self._crvs, self._v)
+
+        def grad(pmf):
+            return -(cmi1_grad(pmf) - cmi2_grad(pmf))
+
+        return grad
+
 
 class TwoPartIMIMixin:
     """

--- a/dit/multivariate/secret_key_agreement/interactive_intrinsic_mutual_informations.py
+++ b/dit/multivariate/secret_key_agreement/interactive_intrinsic_mutual_informations.py
@@ -119,6 +119,38 @@ class InteractiveSKARMixin:
 
         return objective
 
+    def _objective_gradient(self):
+        """
+        Gradient of ``-max_i sum(values[i:])`` w.r.t. the joint.
+
+        The objective is a ``max`` over partial sums of CMI differences; the
+        gradient of the active (argmax) slice is a valid subgradient.
+        """
+        arvs = sorted(self._arvs)
+
+        def _terms(builder):
+            evens = [
+                (builder(self._y, {arvs[i]}, set(arvs[:i])), builder(self._crvs, {arvs[i]}, set(arvs[:i])))
+                for i in range(0, self._rounds, 2)
+            ]
+            odds = [
+                (builder(self._x, {arvs[i]}, set(arvs[:i])), builder(self._crvs, {arvs[i]}, set(arvs[:i])))
+                for i in range(1, self._rounds, 2)
+            ]
+            return [term for term in chain.from_iterable(zip_longest(evens, odds)) if term]
+
+        value_terms = _terms(self._conditional_mutual_information)
+        grad_terms = _terms(self._conditional_mutual_information_grad)
+
+        def grad(pmf):
+            values = [a(pmf) - b(pmf) for a, b in value_terms]
+            sums = [sum(values[i:]) for i in range(self._rounds)]
+            istar = max(range(self._rounds), key=lambda i: sums[i])
+            g = sum(ga(pmf) - gb(pmf) for ga, gb in grad_terms[istar:])
+            return -g
+
+        return grad
+
 
 # ── Backward-compatible composed class (numpy backend) ────────────────────
 

--- a/dit/multivariate/secret_key_agreement/minimal_intrinsic_mutual_informations.py
+++ b/dit/multivariate/secret_key_agreement/minimal_intrinsic_mutual_informations.py
@@ -115,6 +115,16 @@ class MinimalIntrinsicCAEKLMutualInformation(BaseMinimalIntrinsicMutualInformati
         """
         return self._caekl_mutual_information(rvs, crvs)
 
+    def _objective_gradient(self):
+        """Gradient of ``J[X:Y:...|U] + I[XY:U|Z]`` w.r.t. the joint."""
+        caekl_grad = self._caekl_mutual_information_grad(self._rvs, self._arvs)
+        cmi_grad = self._conditional_mutual_information_grad(self._rvs, self._arvs, self._crvs)
+
+        def grad(pmf):
+            return caekl_grad(pmf) + cmi_grad(pmf)
+
+        return grad
+
 
 minimal_intrinsic_CAEKL_mutual_information = MinimalIntrinsicCAEKLMutualInformation.functional()
 

--- a/tests/algorithms/test_optimizers.py
+++ b/tests/algorithms/test_optimizers.py
@@ -136,11 +136,16 @@ def _auxvar_gradient_cases():
         DeWeeseDualTotalCorrelation,
         DeWeeseTotalCorrelation,
     )
+    from dit.multivariate.secret_key_agreement.base_skar_optimizers import (
+        InnerTwoPartIntrinsicMutualInformation,
+    )
+    from dit.multivariate.secret_key_agreement.interactive_intrinsic_mutual_informations import InteractiveSKAR
     from dit.multivariate.secret_key_agreement.intrinsic_mutual_informations import (
         IntrinsicDualTotalCorrelation,
         IntrinsicTotalCorrelation,
     )
     from dit.multivariate.secret_key_agreement.minimal_intrinsic_mutual_informations import (
+        MinimalIntrinsicCAEKLMutualInformation,
         MinimalIntrinsicDualTotalCorrelation,
         MinimalIntrinsicTotalCorrelation,
     )
@@ -154,6 +159,7 @@ def _auxvar_gradient_cases():
 
     xor = Xor()
     skar_dist = uniform(["000", "011", "101", "110"])
+    inner_dist = uniform(["0000", "0011", "0101", "0110", "1001", "1010", "1100", "1111"])
     rd_dist = uniform(["000", "011", "101", "110", "001", "010"])
     return [
         ("exact", ExactCommonInformation(xor, [[0], [1]], [2])),
@@ -162,6 +168,12 @@ def _auxvar_gradient_cases():
         ("intrinsic_dtc", IntrinsicDualTotalCorrelation(xor, [[0], [1]], [2], bound=2)),
         ("minimal_tc", MinimalIntrinsicTotalCorrelation(skar_dist, [[0], [1]], [2], bound=3)),
         ("minimal_dtc", MinimalIntrinsicDualTotalCorrelation(skar_dist, [[0], [1]], [2], bound=3)),
+        ("minimal_caekl", MinimalIntrinsicCAEKLMutualInformation(skar_dist, [[0], [1]], [2], bound=3)),
+        ("interactive_skar", InteractiveSKAR(skar_dist, rv_x=[0], rv_y=[1], rv_z=[2], rounds=3)),
+        (
+            "inner_two_part",
+            InnerTwoPartIntrinsicMutualInformation(inner_dist, rvs=[[0], [1]], crvs=[2], j=[3], bound_u=2, bound_v=2),
+        ),
         ("deweese_tc", DeWeeseTotalCorrelation(xor, [[0], [1], [2]], [])),
         ("deweese_coi", DeWeeseCoInformation(xor, [[0], [1], [2]], [])),
         ("deweese_dtc", DeWeeseDualTotalCorrelation(xor, [[0], [1], [2]], [])),


### PR DESCRIPTION
The slowest secret-key-agreement tests were finite-differencing their objectives. Add analytic _objective_gradient methods so SciPy uses exact gradients (FD fallback preserved if absent):

- inner two-part: -(I[U:J|V] - I[U:Z|V]) via conditional-MI grads; this is the nested inner solve that dominates two_way_skar.
- CAEKL minimal: new _caekl_mutual_information_grad (argmin-partition subgradient) wired into MinimalIntrinsicCAEKLMutualInformation.
- interactive: argmax-slice subgradient of the CMI-difference terms.

Results unchanged. Local before/after: test_two_way_skar2 75s->4.8s (~16x), CAEKL test_3 54s->1.8s (~31x). Adds analytic-vs-FD gradient checks for all three to test_optimizers.py.