### PR TITLE
Add fast coverage tests for synergistic disclosure and multivariate time series

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "boltons",
     "debtcollector",
-    "lattices>=0.3.5",
+    "lattices>=0.4.0",
     "loguru",
     "networkx>=2.6",
     "numpy>=1.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ dev = [
 [tool.uv]
 override-dependencies = ["pycddlib; sys_platform == 'never'"]
 
+[tool.uv.sources]
+# lattices 0.4.0 (adds Lattice.chains(), required by ShapleyDependencyDecomposition)
+# is tagged on GitHub but not yet on PyPI; install it from the tag until released.
+lattices = { git = "https://github.com/dit/lattices.git", tag = "v0.4.0" }
+
 # ── Build configuration ─────────────────────────────────────────────────
 
 [tool.hatch.version]

--- a/tests/inference/test_timeseries.py
+++ b/tests/inference/test_timeseries.py
@@ -67,3 +67,30 @@ def test_dfts4():
     d1 = dist_from_timeseries(ts)
     d2 = Distribution([(0, 0), (0, 1), (1, 0)], [1 / 3, 1 / 3, 1 / 3])
     assert d1.is_approx_equal(d2, atol=1e-3)
+
+
+def test_dfts_multivariate_history1():
+    """
+    Multivariate series with history_length=1 triggers the variable-grouped
+    reorder branch; outcomes are (past1, past2, present1, present2).
+    """
+    obs = [(0, 1), (1, 0)] * 50
+    d = dist_from_timeseries(obs, history_length=1)
+    assert d.outcome_length() == 4
+    assert set(d.outcomes) == {(0, 1, 1, 0), (1, 0, 0, 1)}
+
+
+def test_dfts_multivariate_history2():
+    """
+    Multivariate series with history_length=2 regroups each length-3 window
+    from time-interleaved (v1_t0, v2_t0, ...) to variable-grouped
+    (p1_t0, p1_t1, p2_t0, p2_t1, present1, present2).
+    """
+    obs = [(0, 0), (0, 1), (1, 0)] * 40
+    d = dist_from_timeseries(obs, history_length=2)
+    assert d.outcome_length() == 6
+    assert set(d.outcomes) == {
+        (0, 0, 0, 1, 1, 0),
+        (0, 1, 1, 0, 0, 0),
+        (1, 0, 0, 0, 0, 1),
+    }

--- a/tests/multivariate/test_synergistic_disclosure.py
+++ b/tests/multivariate/test_synergistic_disclosure.py
@@ -7,6 +7,7 @@ import pytest
 from dit.distconst import uniform
 from dit.multivariate.synergistic_disclosure import (
     backbone_disclosure,
+    modified_synergistic_disclosure,
     self_synergy,
     synergistic_disclosure,
 )
@@ -39,6 +40,39 @@ def test_synergistic_disclosure_empty_alpha():
     d = bivariates["synergy"]
     val = synergistic_disclosure(d, [[0], [1]], [2], alpha=[])
     assert val == pytest.approx(1.0, abs=1e-4)
+
+
+def test_synergistic_disclosure_empty_alpha_fast():
+    """Empty alpha takes the optimizer-free coinformation fallback."""
+    d = bivariates["redundant"]
+    val = synergistic_disclosure(d, [[0], [1]], [2], alpha=[])
+    assert val == pytest.approx(1.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# modified_synergistic_disclosure
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_modified_synergistic_disclosure_empty_alpha():
+    """Empty alpha falls back to the full source-target coinformation."""
+    d = bivariates["synergy"]
+    val = modified_synergistic_disclosure(d, [[0], [1]], [2], alpha=[])
+    assert val == pytest.approx(1.0)
+
+
+def test_modified_synergistic_disclosure_singleton_alpha_synergy():
+    """Singleton alpha uses I(T:all) - I(T:alpha); XOR leaks all 1 bit."""
+    d = bivariates["synergy"]
+    val = modified_synergistic_disclosure(d, [[0], [1]], [2], alpha=[[0]])
+    assert val == pytest.approx(1.0)
+
+
+def test_modified_synergistic_disclosure_singleton_alpha_redundant():
+    """A constrained source carrying all the target info leaves nothing."""
+    d = bivariates["redundant"]
+    val = modified_synergistic_disclosure(d, [[0], [1]], [2], alpha=[[0]])
+    assert val == pytest.approx(0.0)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/profiles/test_shapley_info_decomposition.py
+++ b/tests/profiles/test_shapley_info_decomposition.py
@@ -1,0 +1,82 @@
+"""
+Tests for dit.profiles.shapley_info_decomposition.
+"""
+
+import pytest
+
+from dit import Distribution
+from dit.example_dists import Xor, n_mod_m
+from dit.params import ditParams
+from dit.profiles.shapley_info_decomposition import (
+    ShapleyDependencyDecomposition,
+    ShapleyShannonDecomposition,
+)
+
+
+def _labelled(decomp):
+    """Map each predictor to a readable label for easy assertions."""
+    return {ShapleyDependencyDecomposition._stringify_predictor(k): v for k, v in decomp.contributions.items()}
+
+
+def test_xor_is_pure_synergy():
+    """XOR with default sources/target: all information is in {0,1}."""
+    s = ShapleyDependencyDecomposition(Xor())
+    contribs = _labelled(s)
+    assert contribs["{0}"] == pytest.approx(0.0, abs=1e-6)
+    assert contribs["{1}"] == pytest.approx(0.0, abs=1e-6)
+    assert contribs["{0,1}"] == pytest.approx(1.0, abs=1e-6)
+    assert sum(s.contributions.values()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_explicit_sources_and_target():
+    """A redundant copy (X=Y=Z) splits its 1 bit equally between sources."""
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    s = ShapleyDependencyDecomposition(d, sources=[[0], [1]], target=[2])
+    contribs = _labelled(s)
+    assert contribs["{0}"] == pytest.approx(0.5, abs=1e-6)
+    assert contribs["{1}"] == pytest.approx(0.5, abs=1e-6)
+    assert contribs["{0,1}"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_three_sources_parity():
+    """3-bit parity: the full triple carries all the information."""
+    s = ShapleyDependencyDecomposition(n_mod_m(4, 2))
+    contribs = _labelled(s)
+    assert contribs["{0,1,2}"] == pytest.approx(1.0, abs=1e-6)
+    assert sum(s.contributions.values()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_getitem():
+    """__getitem__ retrieves a predictor's contribution."""
+    s = ShapleyDependencyDecomposition(Xor())
+    key = frozenset({frozenset({0, 1})})
+    assert s[key] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_str_table():
+    """str() renders the table with each predictor and rounds near-zero to 0."""
+    s = ShapleyDependencyDecomposition(Xor())
+    out = str(s)
+    assert "Shapley Dependency Decomposition" in out
+    for label in ("{0}", "{1}", "{0,1}"):
+        assert label in out
+
+
+def test_repr_respects_ditparams():
+    """__repr__ prints the table only when repr.print is set."""
+    s = ShapleyDependencyDecomposition(Xor())
+    original = ditParams["repr.print"]
+    try:
+        ditParams["repr.print"] = True
+        assert repr(s) == s.to_string()
+        ditParams["repr.print"] = False
+        assert repr(s).startswith("<")
+    finally:
+        ditParams["repr.print"] = original
+
+
+def test_shannon_alias_is_dependency_decomposition():
+    """ShapleyShannonDecomposition aliases the Shannon DependencyDecomposition."""
+    from dit.profiles.information_partitions import ShapleyDecomposition
+
+    assert ShapleyShannonDecomposition is ShapleyDecomposition

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ requires-dist = [
     { name = "jax", marker = "extra == 'jax'" },
     { name = "jaxlib", marker = "extra == 'dev'" },
     { name = "jaxlib", marker = "extra == 'jax'" },
-    { name = "lattices", specifier = ">=0.3.5" },
+    { name = "lattices", git = "https://github.com/dit/lattices.git?tag=v0.4.0" },
     { name = "loguru" },
     { name = "matplotlib", marker = "extra == 'dev'" },
     { name = "matplotlib", marker = "extra == 'docs'" },
@@ -1202,14 +1202,10 @@ wheels = [
 
 [[package]]
 name = "lattices"
-version = "0.3.5"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.0"
+source = { git = "https://github.com/dit/lattices.git?tag=v0.4.0#9f04e8a56fe9d699f33fad2e9dc89045c510bfcd" }
 dependencies = [
     { name = "networkx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/b7/957f1d77abccc49d655e6e9b935f412d88858ac7b5cede1e1c55000119c5/lattices-0.3.5.tar.gz", hash = "sha256:0598f7cf0b439ba000b5d554b47200e075fabf2ca75ec47daf5373abf1327b3b", size = 17342, upload-time = "2020-01-24T03:19:04.552Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/60/3a3d5e8667551328c9df7899cd952c4d50ca1e1a6ef94763cac4bc71ffb3/lattices-0.3.5-py2.py3-none-any.whl", hash = "sha256:600b5f5bf45980822952f565a821748182ca303ff96a2e4eaf787cbd21632808", size = 26799, upload-time = "2020-01-24T03:19:02.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add fast, deterministic tests for the optimizer-free branches of `synergistic_disclosure` (empty-alpha coinformation fallback) and the previously untested `modified_synergistic_disclosure` (empty and singleton alpha).
- Add tests for the multivariate variable-grouped reorder path in `dist_from_timeseries` (`history_length` 1 and 2), which existing single-variable tests never exercised.
- Add tests for `ShapleyDependencyDecomposition` (default + explicit sources/target, 2- and 3-source cases, `__getitem__`, table rendering, `repr.print` toggle), and bump the `lattices` pin to `>=0.4.0` (the decomposition needs `lattices.Lattice.chains()`, added in 0.4.0).
- All new tests are unmarked (no `@slow`), so they run in CI.

## Coverage impact
- `dit/inference/time_series.py`: 63.2% -> 100%
- `dit/multivariate/synergistic_disclosure.py`: 18.8% -> 52% (remaining gaps are slow optimizer paths covered by existing `@slow` tests)
- `dit/profiles/shapley_info_decomposition.py`: 29.2% -> 100%

## Dependency note
`lattices` 0.4.0 (which adds `Lattice.chains()`) is tagged on GitHub but **not yet on PyPI**. As an interim, `[tool.uv.sources]` pins `lattices` to the `v0.4.0` git tag and `uv.lock` is refreshed accordingly, so CI can resolve the dependency. **Follow-up:** once `lattices` 0.4.0 is published to PyPI, drop the `[tool.uv.sources]` entry and re-run `uv lock` to return to the plain `lattices>=0.4.0` PyPI requirement.

## Test plan
- [x] `pytest tests/multivariate/test_synergistic_disclosure.py tests/inference/test_timeseries.py tests/profiles/test_shapley_info_decomposition.py`
- [x] Full default suite: 4179 passed (with lattices 0.4.0)
- [x] `uv sync --extra test --extra optional` resolves from the git tag
- [x] `ruff check` + `ruff format --check` clean