### PR TITLE
Deflake convex optimizer: retry when no start is feasible

### DIFF
--- a/dit/algorithms/optimization.py
+++ b/dit/algorithms/optimization.py
@@ -1315,7 +1315,16 @@ class BaseConvexOptimizer(BaseOptimizer):
             # even though this is convex, there might still be some optimization
             # issues, so we use niter > 1.
             niter = 2
-        return self._optimize_shotgun(x0, minimizer_kwargs, niter=niter)
+        result = self._optimize_shotgun(x0, minimizer_kwargs, niter=niter)
+        if result is None:
+            # Every start was unsuccessful and none were feasible within
+            # tolerance. With only a couple of starts this happens
+            # intermittently (SLSQP with analytic Jacobians frequently reports
+            # success=False at feasible optima), producing flaky "No optima
+            # found" failures. Retry once with many more random starts before
+            # giving up; this never changes a result that already succeeded.
+            result = self._optimize_shotgun(x0, minimizer_kwargs, niter=max(25, niter))
+        return result
 
 
 class BaseNonConvexOptimizer(BaseOptimizer):


### PR DESCRIPTION
## Summary
- Fix the intermittent `OptimizationException: No optima found.` that flakes `tests/pid/test_igh.py::test_pid_gh4` on CI (most recently seen on macOS / Python 3.14).
- `BaseConvexOptimizer._optimization_backend` runs only **2 starts** by default. After igh gained an analytic SLSQP Jacobian (#225), SLSQP routinely returns `success=False` (e.g. "Positive directional derivative for linesearch") at feasible optima. When *both* starts are unsuccessful and neither is feasible within tolerance, `_optimize_shotgun` returns `None` and `optimize()` raises -- which the `_best_feasible` recovery from #226 cannot help with because there is no feasible candidate at all.
- Retry the shotgun once with many more random starts (`max(25, niter)`) when the first attempt returns `None`. This runs only on total failure and never changes a result that already succeeded.

## Why this is safe
- The success path is unchanged: when any start succeeds (or a feasible non-converged start exists), the first `_optimize_shotgun` returns a result and no retry happens.
- The retry only adds work in the rare all-infeasible case, drawing fresh random initial conditions, so the probability of a spurious "No optima found" drops by orders of magnitude.

## Test plan
- [x] `pytest tests/pid/test_igh.py` passes (Python 3.14)
- [x] Full default suite: 4166 passed (Python 3.14)
- [x] Deterministic check: backend retries with 25 starts when the first attempt returns `None`, and does not retry when it succeeds
- [x] `ruff check` + `ruff format --check` clean

Made with [Cursor](https://cursor.com)