### PR TITLE
Fix flaky test_pid_tw1 by dropping the interactive SKAR subgradient

### DIFF
--- a/dit/multivariate/secret_key_agreement/interactive_intrinsic_mutual_informations.py
+++ b/dit/multivariate/secret_key_agreement/interactive_intrinsic_mutual_informations.py
@@ -119,37 +119,17 @@ class InteractiveSKARMixin:
 
         return objective
 
-    def _objective_gradient(self):
-        """
-        Gradient of ``-max_i sum(values[i:])`` w.r.t. the joint.
-
-        The objective is a ``max`` over partial sums of CMI differences; the
-        gradient of the active (argmax) slice is a valid subgradient.
-        """
-        arvs = sorted(self._arvs)
-
-        def _terms(builder):
-            evens = [
-                (builder(self._y, {arvs[i]}, set(arvs[:i])), builder(self._crvs, {arvs[i]}, set(arvs[:i])))
-                for i in range(0, self._rounds, 2)
-            ]
-            odds = [
-                (builder(self._x, {arvs[i]}, set(arvs[:i])), builder(self._crvs, {arvs[i]}, set(arvs[:i])))
-                for i in range(1, self._rounds, 2)
-            ]
-            return [term for term in chain.from_iterable(zip_longest(evens, odds)) if term]
-
-        value_terms = _terms(self._conditional_mutual_information)
-        grad_terms = _terms(self._conditional_mutual_information_grad)
-
-        def grad(pmf):
-            values = [a(pmf) - b(pmf) for a, b in value_terms]
-            sums = [sum(values[i:]) for i in range(self._rounds)]
-            istar = max(range(self._rounds), key=lambda i: sums[i])
-            g = sum(ga(pmf) - gb(pmf) for ga, gb in grad_terms[istar:])
-            return -g
-
-        return grad
+    # NOTE: No analytic ``_objective_gradient`` is provided on purpose. The
+    # objective is ``-max_i sum(values[i:])`` -- a non-smooth maximum over
+    # partial sums of CMI differences. The argmax-slice gradient is only a
+    # subgradient, and feeding it to SLSQP makes the line search stall just
+    # short of the exact vertex optimum (e.g. returning 0.124xx instead of the
+    # true 0.125 on the symmetric "erase" distribution), so the lower bound
+    # never matches the tight upper bound and ``two_way_skar`` returns nan
+    # (flaky test_pid_tw1). Falling back to SciPy's finite differences reaches
+    # the exact optimum reliably; combined with the ``_objective_bound`` set in
+    # ``__init__`` the optimizer early-stops there. Do not re-add an analytic
+    # gradient for this non-smooth objective.
 
 
 # ── Backward-compatible composed class (numpy backend) ────────────────────

--- a/tests/algorithms/test_optimizers.py
+++ b/tests/algorithms/test_optimizers.py
@@ -138,7 +138,6 @@ def _auxvar_gradient_cases():
     from dit.multivariate.secret_key_agreement.base_skar_optimizers import (
         InnerTwoPartIntrinsicMutualInformation,
     )
-    from dit.multivariate.secret_key_agreement.interactive_intrinsic_mutual_informations import InteractiveSKAR
     from dit.multivariate.secret_key_agreement.intrinsic_mutual_informations import (
         IntrinsicDualTotalCorrelation,
         IntrinsicTotalCorrelation,
@@ -168,7 +167,6 @@ def _auxvar_gradient_cases():
         ("minimal_tc", MinimalIntrinsicTotalCorrelation(skar_dist, [[0], [1]], [2], bound=3)),
         ("minimal_dtc", MinimalIntrinsicDualTotalCorrelation(skar_dist, [[0], [1]], [2], bound=3)),
         ("minimal_caekl", MinimalIntrinsicCAEKLMutualInformation(skar_dist, [[0], [1]], [2], bound=3)),
-        ("interactive_skar", InteractiveSKAR(skar_dist, rv_x=[0], rv_y=[1], rv_z=[2], rounds=3)),
         (
             "inner_two_part",
             InnerTwoPartIntrinsicMutualInformation(inner_dist, rvs=[[0], [1]], crvs=[2], j=[3], bound_u=2, bound_v=2),


### PR DESCRIPTION
## Summary

`test_pid_tw1` intermittently failed with `assert nan == 0.125`. `PID_SKAR_tw` calls `two_way_skar`, which returns `nan` unless its lower and upper bounds agree within `1e-6`. The tight upper bound is exactly `0.125`, but the interactive lower bound stalled at `0.124xx`.

Root cause: the `InteractiveSKAR` objective is a non-smooth `max` over partial sums of CMI differences. The argmax-slice subgradient added in #224 misleads SLSQP into stalling just short of the exact vertex optimum, so the lower bound never matches the upper bound. The symmetric `erase` distribution made this visible as asymmetric under-values across its two (provably equal) unique-information atoms.

- Remove the analytic `_objective_gradient` from `InteractiveSKARMixin`; SciPy falls back to finite differences, which reaches the exact optimum reliably. The existing `_objective_bound` (negative upper bound) then early-stops there, so it is also fast.
- Drop the now-invalid `interactive_skar` case from the analytic-vs-FD gradient check in `test_optimizers.py`.

## Audit of the other #224 gradients

The other analytic gradients were reviewed; only `MinimalIntrinsicCAEKLMutualInformation` shares the non-smooth (argmin) pattern. Tested analytic vs FD on all three `intrinsic_*` distributions: identical results, both matching the known `secret_rate` exactly, ~30x faster. It is checked at `abs=1e-2` (not a strict `1e-6` bounds gate), so it is left unchanged. All smooth-objective gradients (TC/DTC, inner two-part, one-way) are exact and safe.

## Test plan

- [x] `tests/pid/test_iskar.py` — 5 passed; `test_pid_tw1` reliably yields `0.125` for all four atoms (no reruns needed)
- [x] `PID_SKAR_tw` on `erase` — 5/5 runs exact
- [x] `tests/multivariate/secret_key_agreement/test_two_way_skar.py` — passed
- [x] `tests/multivariate/secret_key_agreement/test_interactive_intrinsic_mutual_information.py` — passed
- [x] `test_auxvar_analytic_gradients_match_fd` — 16 cases passed

Made with [Cursor](https://cursor.com)