### PR TITLE
Speed up test_igh

### DIFF
--- a/dit/pid/measures/igh.py
+++ b/dit/pid/measures/igh.py
@@ -60,7 +60,7 @@ class GHOptimizer(BaseConvexOptimizer, BaseAuxVarOptimizer):
 
         self._additional_options = {
             "options": {
-                "maxiter": 2500,
+                "maxiter": 300,
                 "ftol": 1e-6,
                 "eps": 1.4901161193847656e-9,
             }

--- a/tests/pid/test_igh.py
+++ b/tests/pid/test_igh.py
@@ -35,6 +35,7 @@ def test_pid_gh2():
     assert pid[((0, 1),)] == pytest.approx(0.5, abs=1e-4)
 
 
+@pytest.mark.slow
 @pytest.mark.flaky(reruns=5)
 def test_pid_gh3():
     """
@@ -48,6 +49,7 @@ def test_pid_gh3():
     assert pid[((0, 1),)] == pytest.approx(0.0, abs=1e-4)
 
 
+@pytest.mark.slow
 @pytest.mark.flaky(reruns=5)
 def test_pid_gh4():
     """


### PR DESCRIPTION
## Summary
- Cap `GHOptimizer`'s `maxiter` from 2500 to 300 in `dit/pid/measures/igh.py`. The old budget was wasted iterations inside the convex restart fallback; `test_pid_gh2` is fully converged at 300 (worst error 9.4e-07 across 20 seeds, identical to maxiter 500/800). This roughly halves the file's runtime (~38s -> ~19s when all tests run).
- Mark `test_pid_gh3` and `test_pid_gh4` as `@pytest.mark.slow` so they are excluded from the default run (`addopts` already filters `-m "not slow and not very_slow"`).

## Why gh3/gh4 are marked rather than sped up
- `gh3`: the first optimizer starts land far from the equality constraint, so the multi-restart feasibility fallback in `BaseConvexOptimizer` does real work. `maxiter` helps only partially; the rest is inherent.
- `gh4`: time is entirely SLSQP-internal linear algebra (optvec dim 272 from the aux-var bound). Shrinking the bound is unsafe — `bound=5` returns a wrong value (0.0198 vs correct 0.0347) and bounds 8-9 spike to 60-70s.

## Test plan
- [x] `uv run pytest tests/pid/test_igh.py -o addopts="" -m "not slow and not very_slow"` -> gh1, gh2 pass (gh3, gh4 deselected)
- [x] `uv run pytest tests/pid/test_igh.py -o addopts="" -m slow` -> gh3, gh4 pass
- [x] `uv run pytest tests/pid/test_igh.py -o addopts=""` -> all 4 pass (~19s)

Made with [Cursor](https://cursor.com)