### PR TITLE
Add dit.coding module for source and channel coding

### DIFF
--- a/dit/__init__.py
+++ b/dit/__init__.py
@@ -27,6 +27,7 @@ _logger.disable("dit")
 
 import dit.algorithms  # noqa: E402
 import dit.channelorder  # noqa: E402
+import dit.coding  # noqa: E402
 import dit.divergences  # noqa: E402
 import dit.example_dists  # noqa: E402
 import dit.inference  # noqa: E402

--- a/dit/__init__.py
+++ b/dit/__init__.py
@@ -29,6 +29,7 @@ import dit.algorithms  # noqa: E402
 import dit.channelorder  # noqa: E402
 import dit.coding  # noqa: E402
 import dit.divergences  # noqa: E402
+import dit.example_channels  # noqa: E402
 import dit.example_dists  # noqa: E402
 import dit.inference  # noqa: E402
 import dit.multivariate  # noqa: E402

--- a/dit/coding/__init__.py
+++ b/dit/coding/__init__.py
@@ -14,7 +14,7 @@ conditional :class:`~dit.Distribution` ``p(Y|X)`` (decoding, block-error
 probability, and gap to capacity).
 """
 
-from ._channel import binary_erasure_channel, binary_symmetric_channel
+from ..example_channels import binary_erasure_channel, binary_symmetric_channel
 from .base import ChannelCoding, SourceCoding
 from .block_codes import golay, hamming, parity_check, reed_muller, repetition
 from .codes import (

--- a/dit/coding/__init__.py
+++ b/dit/coding/__init__.py
@@ -1,0 +1,78 @@
+"""
+Coding: building source and channel codes.
+
+The source-coding half constructs lossless codes for a source
+:class:`~dit.Distribution` using a variety of classical algorithms, and exposes
+the code-theoretic properties of the resulting codes (rate, redundancy,
+efficiency, the Kraft sum, whether the code is prefix-free / uniquely decodable /
+optimal, ...).
+
+The channel-coding half builds binary (GF(2)) channel codes -- linear block codes
+(repetition, parity-check, Hamming, Reed-Muller, Golay), LDPC, polar, and
+convolutional codes -- and evaluates them against an arbitrary channel given as a
+conditional :class:`~dit.Distribution` ``p(Y|X)`` (decoding, block-error
+probability, and gap to capacity).
+"""
+
+from ._channel import binary_erasure_channel, binary_symmetric_channel
+from .base import ChannelCoding, SourceCoding
+from .block_codes import golay, hamming, parity_check, reed_muller, repetition
+from .codes import (
+    fano,
+    golomb,
+    huffman,
+    length_limited_huffman,
+    rice,
+    shannon,
+    shannon_fano_elias,
+)
+from .convolutional import ConvolutionalCode, convolutional
+from .ldpc import LDPCCode, gallager, ldpc
+from .linear import LinearCode
+from .polar import PolarCode, polar
+from .symbol_code import SymbolCode
+from .tunstall import TunstallCode, tunstall
+from .universal import (
+    elias_delta,
+    elias_gamma,
+    elias_omega,
+    fibonacci,
+    unary,
+    universal_code,
+)
+
+__all__ = (
+    "ChannelCoding",
+    "ConvolutionalCode",
+    "LDPCCode",
+    "LinearCode",
+    "PolarCode",
+    "SourceCoding",
+    "SymbolCode",
+    "TunstallCode",
+    "binary_erasure_channel",
+    "binary_symmetric_channel",
+    "convolutional",
+    "elias_delta",
+    "elias_gamma",
+    "elias_omega",
+    "fano",
+    "fibonacci",
+    "gallager",
+    "golay",
+    "golomb",
+    "hamming",
+    "huffman",
+    "ldpc",
+    "length_limited_huffman",
+    "parity_check",
+    "polar",
+    "reed_muller",
+    "repetition",
+    "rice",
+    "shannon",
+    "shannon_fano_elias",
+    "tunstall",
+    "unary",
+    "universal_code",
+)

--- a/dit/coding/_channel.py
+++ b/dit/coding/_channel.py
@@ -2,8 +2,9 @@
 Channel helpers for the channel-coding evaluation layer.
 
 A channel is a conditional :class:`~dit.Distribution` ``p(Y | X)``, matching what
-:func:`dit.algorithms.channel_capacity` consumes. The erasure symbol of the binary
-erasure channel is the integer ``2`` (so that all alphabets stay sortable).
+:func:`dit.algorithms.channel_capacity` consumes. Concrete example channels (the
+binary symmetric channel, binary erasure channel, ...) live in
+:mod:`dit.example_channels`.
 """
 
 import itertools
@@ -14,65 +15,9 @@ import numpy as np
 from ..exceptions import ditException
 
 __all__ = (
-    "binary_erasure_channel",
-    "binary_symmetric_channel",
     "channel_arrays",
     "log_likelihoods",
 )
-
-ERASURE = 2
-
-
-def binary_symmetric_channel(p):
-    """
-    The binary symmetric channel with crossover probability ``p``.
-
-    Parameters
-    ----------
-    p : float
-        The probability that a transmitted bit is flipped.
-
-    Returns
-    -------
-    channel : Distribution
-        The conditional distribution ``p(Y | X)`` over ``{0, 1}``.
-    """
-    from ..distribution import Distribution
-
-    joint = Distribution(
-        {(0, 0): 0.5 * (1 - p), (0, 1): 0.5 * p, (1, 0): 0.5 * p, (1, 1): 0.5 * (1 - p)},
-        rv_names=["X", "Y"],
-    )
-    return joint.condition_on("X")
-
-
-def binary_erasure_channel(epsilon):
-    """
-    The binary erasure channel with erasure probability ``epsilon``.
-
-    Parameters
-    ----------
-    epsilon : float
-        The probability that a transmitted bit is erased.
-
-    Returns
-    -------
-    channel : Distribution
-        The conditional distribution ``p(Y | X)`` with output alphabet
-        ``{0, 1, 2}``, where ``2`` denotes an erasure.
-    """
-    from ..distribution import Distribution
-
-    joint = Distribution(
-        {
-            (0, 0): 0.5 * (1 - epsilon),
-            (0, ERASURE): 0.5 * epsilon,
-            (1, 1): 0.5 * (1 - epsilon),
-            (1, ERASURE): 0.5 * epsilon,
-        },
-        rv_names=["X", "Y"],
-    )
-    return joint.condition_on("X")
 
 
 def channel_arrays(channel):

--- a/dit/coding/_channel.py
+++ b/dit/coding/_channel.py
@@ -1,0 +1,174 @@
+"""
+Channel helpers for the channel-coding evaluation layer.
+
+A channel is a conditional :class:`~dit.Distribution` ``p(Y | X)``, matching what
+:func:`dit.algorithms.channel_capacity` consumes. The erasure symbol of the binary
+erasure channel is the integer ``2`` (so that all alphabets stay sortable).
+"""
+
+import itertools
+from math import log, sqrt
+
+import numpy as np
+
+from ..exceptions import ditException
+
+__all__ = (
+    "binary_erasure_channel",
+    "binary_symmetric_channel",
+    "channel_arrays",
+    "log_likelihoods",
+)
+
+ERASURE = 2
+
+
+def binary_symmetric_channel(p):
+    """
+    The binary symmetric channel with crossover probability ``p``.
+
+    Parameters
+    ----------
+    p : float
+        The probability that a transmitted bit is flipped.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, 1}``.
+    """
+    from ..distribution import Distribution
+
+    joint = Distribution(
+        {(0, 0): 0.5 * (1 - p), (0, 1): 0.5 * p, (1, 0): 0.5 * p, (1, 1): 0.5 * (1 - p)},
+        rv_names=["X", "Y"],
+    )
+    return joint.condition_on("X")
+
+
+def binary_erasure_channel(epsilon):
+    """
+    The binary erasure channel with erasure probability ``epsilon``.
+
+    Parameters
+    ----------
+    epsilon : float
+        The probability that a transmitted bit is erased.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` with output alphabet
+        ``{0, 1, 2}``, where ``2`` denotes an erasure.
+    """
+    from ..distribution import Distribution
+
+    joint = Distribution(
+        {
+            (0, 0): 0.5 * (1 - epsilon),
+            (0, ERASURE): 0.5 * epsilon,
+            (1, 1): 0.5 * (1 - epsilon),
+            (1, ERASURE): 0.5 * epsilon,
+        },
+        rv_names=["X", "Y"],
+    )
+    return joint.condition_on("X")
+
+
+def channel_arrays(channel):
+    """
+    Extract ``(inputs, outputs, P)`` from a conditional distribution ``p(Y | X)``.
+
+    Parameters
+    ----------
+    channel : Distribution
+        A conditional distribution ``p(Y | X)``.
+
+    Returns
+    -------
+    inputs : list
+        The input alphabet.
+    outputs : list
+        The output alphabet.
+    P : ndarray
+        ``P[i, j] = p(Y = outputs[j] | X = inputs[i])``.
+    """
+    from ..distribution import Distribution
+
+    if not (isinstance(channel, Distribution) and channel.is_conditional()):
+        raise ditException("A channel must be a conditional Distribution p(Y | X).")
+
+    lin = channel._linear_data()
+    given_dims = [d for d in channel.dims if d in channel.given_vars]
+    free_dims = [d for d in channel.dims if d in channel.free_vars]
+    reordered = lin.transpose(*given_dims, *free_dims)
+    in_coords = [channel.data.coords[d].values for d in given_dims]
+    out_coords = [channel.data.coords[d].values for d in free_dims]
+    n_in = int(np.prod([len(c) for c in in_coords]))
+    n_out = int(np.prod([len(c) for c in out_coords]))
+    P = reordered.values.reshape(n_in, n_out)
+
+    def _native(v):
+        return v.item() if hasattr(v, "item") else v
+
+    def _combo(coords):
+        result = []
+        for combo in itertools.product(*coords):
+            combo = tuple(_native(v) for v in combo)
+            result.append(combo[0] if len(combo) == 1 else combo)
+        return result
+
+    return _combo(in_coords), _combo(out_coords), P
+
+
+def log_likelihoods(channel):
+    """
+    Per-output-symbol log-likelihood ratios for a binary-input channel.
+
+    Parameters
+    ----------
+    channel : Distribution
+        A conditional distribution ``p(Y | X)`` with binary input ``{0, 1}``.
+
+    Returns
+    -------
+    llr : dict
+        A mapping ``output_symbol -> log p(y|0) / p(y|1)``, clipped to a finite
+        range.
+    """
+    inputs, outputs, P = channel_arrays(channel)
+    if list(inputs) != [0, 1]:
+        raise ditException("Soft decoding requires a binary-input channel with inputs {0, 1}.")
+    clip = 40.0
+    llr = {}
+    for j, y in enumerate(outputs):
+        p0, p1 = P[0, j], P[1, j]
+        if p0 <= 0 and p1 <= 0:
+            value = 0.0
+        elif p1 <= 0:
+            value = clip
+        elif p0 <= 0:
+            value = -clip
+        else:
+            value = max(-clip, min(clip, log(p0) - log(p1)))
+        llr[y] = value
+    return llr
+
+
+def bhattacharyya(channel):
+    """
+    The Bhattacharyya parameter of a binary-input channel.
+
+    Parameters
+    ----------
+    channel : Distribution
+        A conditional distribution ``p(Y | X)`` with binary input ``{0, 1}``.
+
+    Returns
+    -------
+    Z : float
+    """
+    inputs, _, P = channel_arrays(channel)
+    if list(inputs) != [0, 1]:
+        raise ditException("The Bhattacharyya parameter requires a binary-input channel.")
+    return float(sum(sqrt(P[0, j] * P[1, j]) for j in range(P.shape[1])))

--- a/dit/coding/_gf2.py
+++ b/dit/coding/_gf2.py
@@ -1,0 +1,128 @@
+"""
+Minimal GF(2) linear algebra for the channel-coding constructions.
+"""
+
+import numpy as np
+
+from ..exceptions import ditException
+
+__all__ = (
+    "inverse",
+    "matvec",
+    "nullspace",
+    "rank",
+    "rref",
+)
+
+
+def matvec(A, x):
+    """Matrix-vector product over GF(2)."""
+    return (np.asarray(A, dtype=int) @ np.asarray(x, dtype=int)) % 2
+
+
+def rref(matrix):
+    """
+    Reduced row-echelon form over GF(2).
+
+    Parameters
+    ----------
+    matrix : array-like
+        A binary matrix.
+
+    Returns
+    -------
+    R : ndarray
+        The reduced row-echelon form.
+    pivots : list of int
+        The pivot column indices.
+    """
+    M = np.asarray(matrix, dtype=int).copy() % 2
+    rows, cols = M.shape
+    pivots = []
+    r = 0
+    for c in range(cols):
+        pivot = None
+        for i in range(r, rows):
+            if M[i, c]:
+                pivot = i
+                break
+        if pivot is None:
+            continue
+        M[[r, pivot]] = M[[pivot, r]]
+        for i in range(rows):
+            if i != r and M[i, c]:
+                M[i] = (M[i] + M[r]) % 2
+        pivots.append(c)
+        r += 1
+        if r == rows:
+            break
+    return M, pivots
+
+
+def rank(matrix):
+    """The rank of a binary matrix over GF(2)."""
+    _, pivots = rref(matrix)
+    return len(pivots)
+
+
+def nullspace(matrix):
+    """
+    A basis for the null space ``{x : matrix @ x = 0}`` over GF(2).
+
+    Parameters
+    ----------
+    matrix : array-like
+        A binary matrix with ``n`` columns.
+
+    Returns
+    -------
+    basis : ndarray
+        An array whose rows span the null space.
+    """
+    M = np.asarray(matrix, dtype=int) % 2
+    n = M.shape[1]
+    R, pivots = rref(M)
+    pivot_set = set(pivots)
+    free = [c for c in range(n) if c not in pivot_set]
+    basis = []
+    for f in free:
+        v = np.zeros(n, dtype=int)
+        v[f] = 1
+        for ri, pc in enumerate(pivots):
+            v[pc] = R[ri, f]
+        basis.append(v % 2)
+    return np.array(basis, dtype=int).reshape(len(basis), n)
+
+
+def inverse(matrix):
+    """
+    The inverse of a square binary matrix over GF(2).
+
+    Parameters
+    ----------
+    matrix : array-like
+        A square, invertible binary matrix.
+
+    Returns
+    -------
+    inv : ndarray
+    """
+    M = np.asarray(matrix, dtype=int).copy() % 2
+    k = M.shape[0]
+    if M.shape[0] != M.shape[1]:
+        raise ditException("Matrix must be square to invert.")
+    # Gauss-Jordan elimination on [M | I]; the right block becomes the inverse.
+    A = np.hstack([M, np.eye(k, dtype=int)])
+    for c in range(k):
+        pivot = None
+        for i in range(c, k):
+            if A[i, c]:
+                pivot = i
+                break
+        if pivot is None:
+            raise ditException("Matrix is singular over GF(2).")
+        A[[c, pivot]] = A[[pivot, c]]
+        for i in range(k):
+            if i != c and A[i, c]:
+                A[i] = (A[i] + A[c]) % 2
+    return A[:, k:]

--- a/dit/coding/_util.py
+++ b/dit/coding/_util.py
@@ -1,0 +1,76 @@
+"""
+Shared helpers for the coding module.
+"""
+
+from ..exceptions import ditException
+
+# Digit alphabet for radix-ary codewords; supports radices up to 36.
+DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+def check_radix(radix):
+    """
+    Validate a radix and return it.
+
+    Parameters
+    ----------
+    radix : int
+        The candidate code-alphabet size.
+
+    Returns
+    -------
+    radix : int
+    """
+    if not isinstance(radix, int) or radix < 2 or radix > len(DIGITS):
+        raise ditException(f"radix must be an integer in [2, {len(DIGITS)}], got {radix!r}.")
+    return radix
+
+
+def linear_outcomes_probs(dist):
+    """
+    Return ``(outcomes, probs)`` for `dist` in linear probability space.
+
+    Zero-probability outcomes are dropped.
+
+    Parameters
+    ----------
+    dist : Distribution
+
+    Returns
+    -------
+    outcomes : list
+    probs : list of float
+    """
+    d = dist.copy(base="linear") if dist.is_log() else dist
+    pairs = [(o, float(p)) for o, p in zip(d.outcomes, d.pmf, strict=True) if p > 0]
+    outcomes = [o for o, _ in pairs]
+    probs = [p for _, p in pairs]
+    return outcomes, probs
+
+
+def radix_expansion(frac, length, radix):
+    """
+    The first `length` digits of the base-`radix` expansion of ``frac``.
+
+    Parameters
+    ----------
+    frac : float
+        A number in ``[0, 1)``.
+    length : int
+        The number of digits to emit.
+    radix : int
+        The base of the expansion.
+
+    Returns
+    -------
+    codeword : str
+    """
+    digits = []
+    for _ in range(length):
+        frac *= radix
+        d = int(frac)
+        if d >= radix:  # guard against floating-point overshoot
+            d = radix - 1
+        digits.append(DIGITS[d])
+        frac -= d
+    return "".join(digits)

--- a/dit/coding/base.py
+++ b/dit/coding/base.py
@@ -1,0 +1,248 @@
+"""
+Abstract base classes for coding.
+
+A code is a map between a source (or a channel) and a set of codewords. The two
+fundamental families are:
+
+- :class:`SourceCoding` -- lossless representation of a source distribution, the
+  goal being to minimize the expected number of code symbols per source symbol
+  (the *rate*).
+- :class:`ChannelCoding` -- reliable transmission of messages across a noisy
+  channel, the goal being to approach the channel capacity while controlling the
+  probability of error.
+
+Only source codes are implemented concretely; :class:`ChannelCoding` is provided
+as scaffolding for future channel codes (e.g. repetition, polar, LDPC).
+"""
+
+from abc import ABC, abstractmethod
+from math import log2
+
+from ..exceptions import ditException
+from ..shannon import entropy
+
+__all__ = (
+    "ChannelCoding",
+    "SourceCoding",
+)
+
+
+class SourceCoding(ABC):
+    """
+    Abstract base class for source codes.
+
+    A source code maps the outcomes of a :class:`~dit.Distribution` to codewords
+    over a `radix`-ary code alphabet. Concrete subclasses define how outcomes are
+    encoded and decoded, and what the code's `rate` is; this base class provides
+    the comparisons to the source entropy that are common to all source codes.
+
+    Parameters
+    ----------
+    dist : Distribution, None
+        The source distribution the code is built for. Required for any of the
+        rate-based properties.
+    radix : int
+        The size of the code alphabet. Default is 2 (binary).
+    """
+
+    def __init__(self, dist=None, radix=2):
+        self.dist = dist
+        self.radix = radix
+
+    @abstractmethod
+    def encode(self, source):
+        """
+        Encode a sequence of source outcomes into a sequence of code symbols.
+        """
+
+    @abstractmethod
+    def decode(self, encoded):
+        """
+        Decode a sequence of code symbols back into source outcomes.
+        """
+
+    @abstractmethod
+    def rate(self):
+        """
+        The expected number of code symbols emitted per source symbol.
+        """
+
+    def source_entropy(self):
+        """
+        The entropy of the source, in units of `radix`-ary digits.
+
+        This is the fundamental lower bound on the rate of any uniquely decodable
+        source code (the source coding theorem; Cover & Thomas, Ch. 5).
+
+        Returns
+        -------
+        H : float
+            The source entropy, ``H[X] / log2(radix)``.
+        """
+        if self.dist is None:
+            raise ditException("A source distribution is required to compute the entropy.")
+        dist = self.dist.copy(base="linear") if self.dist.is_log() else self.dist
+        return entropy(dist) / log2(self.radix)
+
+    def redundancy(self):
+        """
+        The rate in excess of the source entropy, ``rate - source_entropy``.
+
+        Returns
+        -------
+        r : float
+            The redundancy, in `radix`-ary digits per source symbol. Always
+            non-negative for a uniquely decodable code.
+        """
+        return self.rate() - self.source_entropy()
+
+    def efficiency(self):
+        """
+        The ratio of the source entropy to the rate, in ``[0, 1]``.
+
+        Returns
+        -------
+        e : float
+            The coding efficiency, ``source_entropy / rate``.
+        """
+        return self.source_entropy() / self.rate()
+
+
+class ChannelCoding(ABC):
+    """
+    Abstract base class for channel codes.
+
+    A channel code adds redundancy to a message so that it can be recovered after
+    transmission across a noisy channel. This class is scaffolding for future
+    channel codes (repetition, polar, LDPC, ...); no concrete subclass is provided
+    yet.
+
+    Concrete subclasses are expected to implement :meth:`encode` (message ->
+    codeword), :meth:`decode` (received word -> message), and :meth:`rate` (message
+    symbols per channel use), and may additionally expose channel-code properties
+    such as the minimum distance, the block error probability for a given channel,
+    and the gap to capacity (via :func:`dit.algorithms.channel_capacity`).
+
+    Parameters
+    ----------
+    channel : Distribution, None
+        The channel, as a conditional distribution ``p(output | input)``.
+    radix : int
+        The size of the code alphabet. Default is 2 (binary).
+    """
+
+    def __init__(self, channel=None, radix=2):
+        self.channel = channel
+        self.radix = radix
+
+    @abstractmethod
+    def encode(self, message):
+        """
+        Encode a message into a channel codeword.
+        """
+
+    @abstractmethod
+    def decode(self, received, channel=None):
+        """
+        Decode a received word back into a message.
+
+        Soft-decision decoders use `channel` (a conditional ``p(Y|X)``
+        distribution) to form log-likelihood ratios; hard-decision decoders
+        ignore it.
+        """
+
+    @abstractmethod
+    def rate(self):
+        """
+        The number of message symbols transmitted per channel use.
+        """
+
+    def capacity_gap(self, channel):
+        """
+        The gap between the channel capacity and the code rate.
+
+        Parameters
+        ----------
+        channel : Distribution
+            The channel, as a conditional distribution ``p(Y|X)``.
+
+        Returns
+        -------
+        gap : float
+            ``capacity(channel) - rate``, in bits per channel use. Positive when
+            the code operates below capacity.
+        """
+        from ..algorithms import channel_capacity
+
+        capacity, _ = channel_capacity(channel)
+        return capacity - self.rate()
+
+    def probability_of_error(self, channel, method="auto", samples=10000, prng=None):
+        """
+        The block error probability of the code over a channel.
+
+        The code's own :meth:`decode` is used (passing `channel` so soft-decision
+        decoders engage). With ``method='exact'`` every message and every received
+        word is enumerated -- feasible only for small codes -- while
+        ``method='montecarlo'`` estimates the probability by sampling.
+
+        Parameters
+        ----------
+        channel : Distribution
+            The channel, as a conditional distribution ``p(Y|X)``.
+        method : str
+            ``'exact'``, ``'montecarlo'``, or ``'auto'`` (exact when small).
+        samples : int
+            The number of Monte Carlo samples.
+        prng : numpy.random.Generator, None
+            The random number generator for Monte Carlo sampling.
+
+        Returns
+        -------
+        pe : float
+            The probability that the decoded message differs from the sent one.
+        """
+        import itertools
+
+        import numpy as np
+
+        from ._channel import channel_arrays
+
+        inputs, outputs, P = channel_arrays(channel)
+        in_index = {v: i for i, v in enumerate(inputs)}
+        k = self.message_length
+        n = len(self.encode((0,) * k))
+
+        if method == "auto":
+            method = "exact" if (2**k) * (len(outputs) ** n) <= 2**20 else "montecarlo"
+
+        if method == "exact":
+            total = 0.0
+            for message in itertools.product((0, 1), repeat=k):
+                codeword = self.encode(message)
+                rows = [P[in_index[bit]] for bit in codeword]
+                for cols in itertools.product(range(len(outputs)), repeat=n):
+                    prob = 1.0
+                    for i, j in enumerate(cols):
+                        prob *= rows[i][j]
+                        if prob == 0.0:
+                            break
+                    if prob == 0.0:
+                        continue
+                    received = tuple(outputs[j] for j in cols)
+                    decoded = tuple(self.decode(received, channel=channel))
+                    if decoded != tuple(message):
+                        total += prob
+            return total / (2**k)
+
+        if prng is None:
+            prng = np.random.default_rng()
+        errors = 0
+        for _ in range(samples):
+            message = tuple(int(b) for b in prng.integers(0, 2, size=k))
+            codeword = self.encode(message)
+            received = tuple(outputs[prng.choice(len(outputs), p=P[in_index[bit]])] for bit in codeword)
+            decoded = tuple(self.decode(received, channel=channel))
+            if decoded != message:
+                errors += 1
+        return errors / samples

--- a/dit/coding/block_codes.py
+++ b/dit/coding/block_codes.py
@@ -1,0 +1,147 @@
+"""
+Constructors for classical linear block codes.
+"""
+
+import itertools
+from math import comb
+
+import numpy as np
+
+from ..exceptions import ditException
+from . import _gf2
+from .linear import LinearCode
+
+__all__ = (
+    "golay",
+    "hamming",
+    "parity_check",
+    "reed_muller",
+    "repetition",
+)
+
+
+def repetition(n, channel=None):
+    """
+    The ``[n, 1, n]`` repetition code.
+
+    Parameters
+    ----------
+    n : int
+        The block length.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LinearCode
+    """
+    if n < 1:
+        raise ditException("The repetition length must be at least 1.")
+    G = np.ones((1, n), dtype=int)
+    return LinearCode(G, channel=channel)
+
+
+def parity_check(k, channel=None):
+    """
+    The ``[k+1, k, 2]`` single-parity-check code.
+
+    Parameters
+    ----------
+    k : int
+        The number of information bits.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LinearCode
+    """
+    if k < 1:
+        raise ditException("The parity-check dimension must be at least 1.")
+    G = np.hstack([np.eye(k, dtype=int), np.ones((k, 1), dtype=int)])
+    return LinearCode(G, channel=channel)
+
+
+def hamming(r, channel=None):
+    """
+    The ``[2^r - 1, 2^r - 1 - r, 3]`` Hamming code.
+
+    Parameters
+    ----------
+    r : int
+        The number of parity bits (``r >= 2``).
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LinearCode
+    """
+    if r < 2:
+        raise ditException("The Hamming parameter r must be at least 2.")
+    columns = [[(value >> bit) & 1 for bit in range(r)] for value in range(1, 2**r)]
+    H = np.array(columns, dtype=int).T
+    G = _gf2.nullspace(H)
+    return LinearCode(G, channel=channel)
+
+
+def reed_muller(r, m, channel=None):
+    """
+    The Reed-Muller code ``RM(r, m)``.
+
+    Parameters
+    ----------
+    r : int
+        The order (``0 <= r <= m``).
+    m : int
+        The number of variables; the block length is ``2^m``.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LinearCode
+    """
+    if not 0 <= r <= m:
+        raise ditException("Reed-Muller requires 0 <= r <= m.")
+    n = 2**m
+    points = list(itertools.product((0, 1), repeat=m))
+    rows = []
+    for degree in range(r + 1):
+        for subset in itertools.combinations(range(m), degree):
+            row = [int(all(point[i] for i in subset)) for point in points]
+            rows.append(row)
+    G = np.array(rows, dtype=int)
+    assert G.shape == (sum(comb(m, i) for i in range(r + 1)), n)
+    return LinearCode(G, channel=channel)
+
+
+# Generator polynomial of the [23, 12, 7] binary Golay code:
+# g(x) = x^11 + x^9 + x^7 + x^6 + x^5 + x + 1.
+_GOLAY_G = [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1]
+
+
+def golay(extended=False, channel=None):
+    """
+    The binary Golay code.
+
+    Parameters
+    ----------
+    extended : bool
+        If True, return the extended ``[24, 12, 8]`` code; otherwise the perfect
+        ``[23, 12, 7]`` code.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LinearCode
+    """
+    k, n = 12, 23
+    G = np.zeros((k, n), dtype=int)
+    for i in range(k):
+        G[i, i : i + len(_GOLAY_G)] = _GOLAY_G
+    if extended:
+        parity = G.sum(axis=1) % 2
+        G = np.hstack([G, parity[:, None]])
+    return LinearCode(G, channel=channel)

--- a/dit/coding/codes.py
+++ b/dit/coding/codes.py
@@ -1,0 +1,391 @@
+"""
+Symbol-code constructors.
+
+Each function takes a source :class:`~dit.Distribution` and returns a
+:class:`SymbolCode` built by the named algorithm.
+
+References
+----------
+Shannon, Fano, Shannon-Fano-Elias, Huffman, and the Kraft inequality follow
+Cover & Thomas, *Elements of Information Theory*, Ch. 5. Length-limited Huffman
+uses the package-merge algorithm (Larmore & Hirschberg, 1990); Golomb codes
+follow Golomb (1966).
+"""
+
+import heapq
+import itertools
+from math import ceil, floor, log, log2
+
+from ..exceptions import ditException
+from ._util import DIGITS, check_radix, linear_outcomes_probs, radix_expansion
+from .symbol_code import SymbolCode
+
+__all__ = (
+    "fano",
+    "golomb",
+    "huffman",
+    "length_limited_huffman",
+    "rice",
+    "shannon",
+    "shannon_fano_elias",
+)
+
+
+def _sorted_pairs(dist):
+    """Return ``(outcome, prob)`` pairs sorted by decreasing probability."""
+    outcomes, probs = linear_outcomes_probs(dist)
+    pairs = list(zip(outcomes, probs, strict=True))
+    # Sort by decreasing probability; break ties by outcome repr for determinism.
+    pairs.sort(key=lambda op: (-op[1], repr(op[0])))
+    return pairs
+
+
+def shannon(dist, radix=2):
+    """
+    Build a Shannon code.
+
+    Codeword lengths are ``ceil(log_radix(1/p))`` and codewords are read off the
+    base-`radix` expansion of the cumulative distribution (outcomes sorted by
+    decreasing probability).
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution.
+    radix : int
+        The size of the code alphabet. Default is 2.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    pairs = _sorted_pairs(dist)
+    if len(pairs) == 1:
+        return SymbolCode({pairs[0][0]: DIGITS[0]}, dist=dist, radix=radix)
+
+    codebook = {}
+    cumulative = 0.0
+    for outcome, p in pairs:
+        length = max(1, ceil(-log(p) / log(radix)))
+        codebook[outcome] = radix_expansion(cumulative, length, radix)
+        cumulative += p
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def shannon_fano_elias(dist, radix=2):
+    """
+    Build a Shannon-Fano-Elias code.
+
+    Codeword lengths are ``ceil(log_radix(1/p)) + 1`` and codewords are read off
+    the base-`radix` expansion of the *midpoint* cumulative distribution
+    ``F_bar(x) = sum_{y<x} p(y) + p(x)/2``. The result is prefix-free.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution.
+    radix : int
+        The size of the code alphabet. Default is 2.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    pairs = _sorted_pairs(dist)
+
+    codebook = {}
+    cumulative = 0.0
+    for outcome, p in pairs:
+        length = ceil(-log(p) / log(radix)) + 1
+        midpoint = cumulative + p / 2
+        codebook[outcome] = radix_expansion(midpoint, length, radix)
+        cumulative += p
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def fano(dist, radix=2):
+    """
+    Build a Fano code (the Shannon-Fano top-down splitting method).
+
+    Outcomes are sorted by probability and recursively partitioned into two
+    groups of as-equal-as-possible total probability; one bit distinguishes the
+    groups at each level.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution.
+    radix : int
+        The size of the code alphabet. Only ``radix=2`` is currently supported.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    if radix != 2:
+        raise ditException("Fano coding currently supports only binary codes (radix=2).")
+    pairs = _sorted_pairs(dist)
+    if len(pairs) == 1:
+        return SymbolCode({pairs[0][0]: DIGITS[0]}, dist=dist, radix=radix)
+
+    codebook = {outcome: "" for outcome, _ in pairs}
+
+    def split(items):
+        if len(items) == 1:
+            return
+        total = sum(p for _, p in items)
+        # Find the split point minimizing the imbalance between the two halves.
+        best_index, best_diff, left = 1, None, 0.0
+        for i in range(1, len(items)):
+            left += items[i - 1][1]
+            diff = abs(total - 2 * left)
+            if best_diff is None or diff < best_diff:
+                best_diff, best_index = diff, i
+        for outcome, _ in items[:best_index]:
+            codebook[outcome] += "0"
+        for outcome, _ in items[best_index:]:
+            codebook[outcome] += "1"
+        split(items[:best_index])
+        split(items[best_index:])
+
+    split(pairs)
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def huffman(dist, radix=2):
+    """
+    Build a Huffman code, the optimal symbol code for the source.
+
+    For ``radix > 2`` the alphabet is padded with zero-probability dummy symbols
+    so that every internal node has exactly `radix` children.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution.
+    radix : int
+        The size of the code alphabet. Default is 2.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    pairs = _sorted_pairs(dist)
+    if len(pairs) == 1:
+        return SymbolCode({pairs[0][0]: DIGITS[0]}, dist=dist, radix=radix)
+
+    dummy = object()
+    nodes = [(p, ("leaf", outcome)) for outcome, p in pairs]
+    if radix > 2:
+        while (len(nodes) - 1) % (radix - 1) != 0:
+            nodes.append((0.0, ("leaf", dummy)))
+
+    counter = itertools.count()
+    heap = [(p, next(counter), node) for p, node in nodes]
+    heapq.heapify(heap)
+    while len(heap) > 1:
+        children = [heapq.heappop(heap) for _ in range(min(radix, len(heap)))]
+        weight = sum(c[0] for c in children)
+        node = ("internal", [c[2] for c in children])
+        heapq.heappush(heap, (weight, next(counter), node))
+
+    codebook = {}
+
+    def assign(node, prefix):
+        kind, payload = node
+        if kind == "leaf":
+            if payload is not dummy:
+                codebook[payload] = prefix
+        else:
+            for digit, child in enumerate(payload):
+                assign(child, prefix + DIGITS[digit])
+
+    assign(heap[0][2], "")
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def length_limited_huffman(dist, max_length, radix=2):
+    """
+    Build an optimal prefix code whose codewords are at most `max_length` long.
+
+    Uses the package-merge algorithm (Larmore & Hirschberg, 1990).
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution.
+    max_length : int
+        The maximum allowed codeword length.
+    radix : int
+        The size of the code alphabet. Only ``radix=2`` is currently supported.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    if radix != 2:
+        raise ditException("Length-limited Huffman coding currently supports only binary codes (radix=2).")
+    pairs = _sorted_pairs(dist)
+    n = len(pairs)
+    if n == 1:
+        return SymbolCode({pairs[0][0]: DIGITS[0]}, dist=dist, radix=radix)
+    if 2**max_length < n:
+        raise ditException(f"max_length={max_length} is too small to code {n} symbols.")
+
+    weights = [p for _, p in pairs]
+    lengths = _package_merge(weights, max_length)
+    codebook = _canonical_codewords([outcome for outcome, _ in pairs], lengths)
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def _package_merge(weights, max_length):
+    """
+    Compute optimal length-limited codeword lengths via package-merge.
+
+    Parameters
+    ----------
+    weights : list of float
+        The symbol probabilities.
+    max_length : int
+        The maximum codeword length.
+
+    Returns
+    -------
+    lengths : list of int
+        ``lengths[i]`` is the codeword length for symbol ``i``.
+    """
+    n = len(weights)
+    coins = sorted(((w, (i,)) for i, w in enumerate(weights)), key=lambda c: c[0])
+    packages = list(coins)
+    for _ in range(max_length - 1):
+        paired = [
+            (packages[i][0] + packages[i + 1][0], packages[i][1] + packages[i + 1][1])
+            for i in range(0, len(packages) - 1, 2)
+        ]
+        packages = sorted(coins + paired, key=lambda c: c[0])
+
+    lengths = [0] * n
+    for _, indices in packages[: 2 * (n - 1)]:
+        for i in indices:
+            lengths[i] += 1
+    return lengths
+
+
+def _canonical_codewords(outcomes, lengths):
+    """
+    Assign canonical prefix-free codewords to outcomes given their lengths.
+
+    Parameters
+    ----------
+    outcomes : list
+        The source outcomes.
+    lengths : list of int
+        The codeword length for each outcome.
+
+    Returns
+    -------
+    codebook : dict
+    """
+    order = sorted(range(len(outcomes)), key=lambda i: (lengths[i], repr(outcomes[i])))
+    codebook = {}
+    code = 0
+    prev_length = None
+    for i in order:
+        length = lengths[i]
+        if prev_length is not None:
+            code = (code + 1) << (length - prev_length)
+        codebook[outcomes[i]] = format(code, f"0{length}b")
+        prev_length = length
+    return codebook
+
+
+def _truncated_binary(value, m):
+    """The truncated binary codeword for ``value`` in ``[0, m)``."""
+    b = floor(log2(m)) if m > 1 else 0
+    cutoff = (1 << (b + 1)) - m
+    if value < cutoff:
+        return format(value, f"0{b}b") if b > 0 else ""
+    return format(value + cutoff, f"0{b + 1}b")
+
+
+def _golomb_codeword(n, m):
+    """The Golomb codeword for non-negative integer ``n`` with parameter ``m``."""
+    quotient, remainder = divmod(n, m)
+    return "1" * quotient + "0" + _truncated_binary(remainder, m)
+
+
+def _optimal_golomb_m(dist):
+    """The optimal Golomb parameter ``m`` for a (geometric) source."""
+    outcomes, probs = linear_outcomes_probs(dist)
+    mean = sum(o * p for o, p in zip(outcomes, probs, strict=True))
+    if mean <= 0:
+        return 1
+    # theta is the geometric ratio implied by the mean: E[n] = theta / (1 - theta).
+    theta = mean / (1 + mean)
+    if theta <= 0 or theta >= 1:
+        return 1
+    return max(1, ceil(-1 / log2(theta)))
+
+
+def golomb(dist, m=None, radix=2):
+    """
+    Build a Golomb code over non-negative-integer outcomes.
+
+    Each codeword is the unary-coded quotient ``n // m`` followed by the
+    truncated-binary remainder ``n % m``. Golomb codes are optimal prefix codes
+    for geometrically distributed sources.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution; its outcomes must be non-negative integers.
+    m : int, None
+        The Golomb parameter. If None, the parameter optimal for the (assumed
+        geometric) source is chosen from its mean.
+    radix : int
+        The size of the code alphabet. Only ``radix=2`` is currently supported.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    check_radix(radix)
+    if radix != 2:
+        raise ditException("Golomb coding is binary (radix=2).")
+    outcomes, _ = linear_outcomes_probs(dist)
+    if not all(isinstance(o, int) and o >= 0 for o in outcomes):
+        raise ditException("Golomb coding requires non-negative integer outcomes.")
+    if m is None:
+        m = _optimal_golomb_m(dist)
+    if m < 1:
+        raise ditException(f"The Golomb parameter m must be >= 1, got {m!r}.")
+    codebook = {o: _golomb_codeword(o, m) for o in outcomes}
+    return SymbolCode(codebook, dist=dist, radix=radix)
+
+
+def rice(dist, k=None):
+    """
+    Build a Rice code, the Golomb code with parameter ``m = 2 ** k``.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution; its outcomes must be non-negative integers.
+    k : int, None
+        The Rice parameter. If None, it is chosen from the optimal Golomb
+        parameter for the source.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    if k is None:
+        k = max(0, round(log2(_optimal_golomb_m(dist))))
+    if k < 0:
+        raise ditException(f"The Rice parameter k must be >= 0, got {k!r}.")
+    return golomb(dist, m=2**k)

--- a/dit/coding/convolutional.py
+++ b/dit/coding/convolutional.py
@@ -1,0 +1,166 @@
+"""
+Convolutional codes with Viterbi decoding.
+
+A rate-``1/n`` :class:`ConvolutionalCode` is defined by ``n`` generator
+polynomials (given in octal). Encoding runs the input through a shift register
+with zero-termination; decoding is the Viterbi algorithm over the trellis
+(Viterbi, 1967), hard-decision by default and soft-decision when a channel is
+given.
+"""
+
+from math import log
+
+from ..exceptions import ditException
+from .base import ChannelCoding
+
+__all__ = (
+    "ConvolutionalCode",
+    "convolutional",
+)
+
+
+def _parity(value):
+    return bin(value).count("1") % 2
+
+
+class ConvolutionalCode(ChannelCoding):
+    """
+    A rate-``1/n`` convolutional code.
+
+    Parameters
+    ----------
+    generators : sequence of int
+        The generator polynomials, in octal (e.g. ``(0o7, 0o5)``).
+    message_length : int
+        The number of information bits per encoded block.
+    channel : Distribution, None
+        A default channel.
+    """
+
+    def __init__(self, generators, message_length, channel=None):
+        super().__init__(channel=channel, radix=2)
+        self.generators = tuple(generators)
+        self.n_outputs = len(self.generators)
+        self.constraint_length = max(g.bit_length() for g in self.generators)
+        self.K = self.constraint_length
+        self._message_length = message_length
+        self._n_states = 1 << (self.K - 1)
+        self._transitions = self._build_transitions()
+
+    @property
+    def message_length(self):
+        return self._message_length
+
+    def rate(self):
+        """The code rate ``1 / n_outputs``."""
+        return 1 / self.n_outputs
+
+    def _build_transitions(self):
+        """For each (state, input bit): the next state and output bits."""
+        transitions = {}
+        mask = (1 << (self.K - 1)) - 1
+        for state in range(self._n_states):
+            for bit in (0, 1):
+                reg = (state << 1) | bit
+                outputs = tuple(_parity(reg & g) for g in self.generators)
+                next_state = reg & mask
+                transitions[(state, bit)] = (next_state, outputs)
+        return transitions
+
+    def encode(self, message):
+        """
+        Encode a message, appending ``K - 1`` zeros to terminate the trellis.
+        """
+        bits = list(message) + [0] * (self.K - 1)
+        state = 0
+        out = []
+        for bit in bits:
+            next_state, outputs = self._transitions[(state, bit)]
+            out.extend(outputs)
+            state = next_state
+        return tuple(out)
+
+    def decode(self, received, channel=None):
+        """
+        Decode by the Viterbi algorithm (soft when a channel is given).
+        """
+        n = self.n_outputs
+        steps = len(received) // n
+        chunks = [tuple(received[i * n : (i + 1) * n]) for i in range(steps)]
+        metric = self._branch_metric(channel)
+
+        inf = float("inf")
+        path = [inf] * self._n_states
+        path[0] = 0.0
+        backpointers = []
+        for chunk in chunks:
+            new_path = [inf] * self._n_states
+            back = [-1] * self._n_states
+            for state in range(self._n_states):
+                if path[state] == inf:
+                    continue
+                for bit in (0, 1):
+                    next_state, outputs = self._transitions[(state, bit)]
+                    cost = path[state] + metric(outputs, chunk)
+                    if cost < new_path[next_state]:
+                        new_path[next_state] = cost
+                        back[next_state] = state
+            path = new_path
+            backpointers.append(back)
+
+        # The trellis is terminated, so the final state is 0.
+        state = 0
+        inputs = []
+        for back in reversed(backpointers):
+            previous = back[state]
+            # Recover the input bit that took `previous` -> `state`.
+            bit = 1 if self._transitions[(previous, 1)][0] == state else 0
+            inputs.append(bit)
+            state = previous
+        inputs.reverse()
+        return inputs[: self._message_length]
+
+    def _branch_metric(self, channel):
+        if channel is None:
+
+            def metric(outputs, chunk):
+                return sum(o != r for o, r in zip(outputs, chunk, strict=True))
+
+            return metric
+
+        from ._channel import channel_arrays
+
+        inputs, outputs_alpha, P = channel_arrays(channel)
+        in_index = {v: i for i, v in enumerate(inputs)}
+        out_index = {v: i for i, v in enumerate(outputs_alpha)}
+
+        def metric(outputs, chunk):
+            cost = 0.0
+            for o, r in zip(outputs, chunk, strict=True):
+                p = P[in_index[o], out_index[r]]
+                cost += -log(p) if p > 0 else float("inf")
+            return cost
+
+        return metric
+
+
+def convolutional(generators, message_length, channel=None):
+    """
+    Build a rate-``1/n`` convolutional code.
+
+    Parameters
+    ----------
+    generators : sequence of int
+        The generator polynomials in octal (e.g. ``(0o7, 0o5)``).
+    message_length : int
+        The number of information bits per encoded block.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : ConvolutionalCode
+    """
+    if len(generators) < 2:
+        raise ditException("A convolutional code needs at least two generators.")
+    return ConvolutionalCode(generators, message_length, channel=channel)

--- a/dit/coding/ldpc.py
+++ b/dit/coding/ldpc.py
@@ -1,0 +1,154 @@
+"""
+Low-density parity-check (LDPC) codes with belief-propagation decoding.
+
+An :class:`LDPCCode` is a linear code defined by a sparse parity-check matrix
+``H``, decoded with the sum-product algorithm on its Tanner graph (Gallager,
+1962). Encoding and the algebraic properties are inherited from
+:class:`~dit.coding.linear.LinearCode`.
+"""
+
+import numpy as np
+
+from ..exceptions import ditException
+from . import _gf2
+from .linear import LinearCode
+
+__all__ = (
+    "LDPCCode",
+    "gallager",
+    "ldpc",
+)
+
+
+class LDPCCode(LinearCode):
+    """
+    A linear code decoded by belief propagation on a sparse parity-check matrix.
+
+    Parameters
+    ----------
+    H : array-like
+        An ``m x n`` binary parity-check matrix (typically sparse).
+    channel : Distribution, None
+        A default channel.
+    max_iterations : int
+        The maximum number of belief-propagation iterations.
+    """
+
+    def __init__(self, H, channel=None, max_iterations=50):
+        H = np.asarray(H, dtype=int) % 2
+        G = _gf2.nullspace(H)
+        if G.shape[0] == 0:
+            raise ditException("The parity-check matrix leaves no information bits.")
+        super().__init__(G, channel=channel)
+        self.H = H
+        self.max_iterations = max_iterations
+        self._check_vars = [np.flatnonzero(H[c]).tolist() for c in range(H.shape[0])]
+        self._var_checks = [np.flatnonzero(H[:, v]).tolist() for v in range(H.shape[1])]
+
+    def decode(self, received, channel=None):
+        """
+        Decode by belief propagation when a channel is given, else hard decoding.
+        """
+        if channel is None:
+            return self._syndrome_decode(received)
+        return self._belief_propagation(received, channel)
+
+    def _belief_propagation(self, received, channel):
+        from ._channel import log_likelihoods
+
+        llr_map = log_likelihoods(channel)
+        L = np.array([llr_map[y] for y in received], dtype=float)
+        n, m = self.n, self.H.shape[0]
+
+        # Variable-to-check and check-to-variable messages.
+        M_vc = {(v, c): L[v] for v in range(n) for c in self._var_checks[v]}
+        M_cv = {(c, v): 0.0 for c in range(m) for v in self._check_vars[c]}
+
+        clip = 1 - 1e-12
+        for _ in range(self.max_iterations):
+            for c in range(m):
+                vs = self._check_vars[c]
+                taus = {v: np.tanh(np.clip(M_vc[(v, c)] / 2, -30, 30)) for v in vs}
+                for v in vs:
+                    product = 1.0
+                    for v2 in vs:
+                        if v2 != v:
+                            product *= taus[v2]
+                    product = np.clip(product, -clip, clip)
+                    M_cv[(c, v)] = 2 * np.arctanh(product)
+
+            total = L.copy()
+            for v in range(n):
+                for c in self._var_checks[v]:
+                    total[v] += M_cv[(c, v)]
+            xhat = (total < 0).astype(int)
+
+            if not np.any(_gf2.matvec(self.H, xhat)):
+                break
+
+            for v in range(n):
+                for c in self._var_checks[v]:
+                    M_vc[(v, c)] = L[v] + sum(M_cv[(c2, v)] for c2 in self._var_checks[v] if c2 != c)
+
+        return list(self._codeword_to_message(xhat))
+
+
+def ldpc(H, channel=None, max_iterations=50):
+    """
+    Build an LDPC code from a parity-check matrix.
+
+    Parameters
+    ----------
+    H : array-like
+        An ``m x n`` binary parity-check matrix.
+    channel : Distribution, None
+        A default channel.
+    max_iterations : int
+        The maximum number of belief-propagation iterations.
+
+    Returns
+    -------
+    code : LDPCCode
+    """
+    return LDPCCode(H, channel=channel, max_iterations=max_iterations)
+
+
+def gallager(n, wc, wr, prng=None, channel=None):
+    """
+    Build a regular Gallager LDPC code.
+
+    Parameters
+    ----------
+    n : int
+        The block length; must be divisible by ``wr``.
+    wc : int
+        The column weight (variable degree).
+    wr : int
+        The row weight (check degree); ``wc < wr``.
+    prng : numpy.random.Generator, None
+        The random number generator used to permute the sub-bands.
+    channel : Distribution, None
+        A default channel.
+
+    Returns
+    -------
+    code : LDPCCode
+    """
+    if n % wr != 0:
+        raise ditException("Gallager construction requires n divisible by wr.")
+    if not 0 < wc < wr:
+        raise ditException("Gallager construction requires 0 < wc < wr.")
+    if prng is None:
+        prng = np.random.default_rng()
+
+    band_rows = n // wr
+    base = np.zeros((band_rows, n), dtype=int)
+    for row in range(band_rows):
+        base[row, row * wr : (row + 1) * wr] = 1
+
+    bands = [base]
+    for _ in range(wc - 1):
+        permutation = prng.permutation(n)
+        bands.append(base[:, permutation])
+    H = np.vstack(bands)
+    return LDPCCode(H, channel=channel)

--- a/dit/coding/linear.py
+++ b/dit/coding/linear.py
@@ -1,0 +1,197 @@
+"""
+Linear block codes over GF(2).
+
+A :class:`LinearCode` is defined by a generator matrix ``G`` (``k x n``); the
+parity-check matrix ``H`` is derived as a basis for the null space of ``G``. This
+is the workhorse for the classical binary block codes (repetition, parity-check,
+Hamming, Reed-Muller, Golay) and the base for LDPC and polar codes.
+"""
+
+import itertools
+from collections import Counter
+
+import numpy as np
+
+from ..exceptions import ditException
+from . import _gf2
+from .base import ChannelCoding
+
+__all__ = ("LinearCode",)
+
+_MAX_ENUMERATION = 20
+
+
+class LinearCode(ChannelCoding):
+    """
+    A linear block code over GF(2).
+
+    Parameters
+    ----------
+    G : array-like
+        A ``k x n`` binary generator matrix of full row rank.
+    channel : Distribution, None
+        A default channel, as a conditional distribution ``p(Y|X)``.
+    """
+
+    def __init__(self, G, channel=None):
+        super().__init__(channel=channel, radix=2)
+        self.G = np.asarray(G, dtype=int) % 2
+        self.k, self.n = self.G.shape
+        self.H = _gf2.nullspace(self.G)
+        self._codewords = None
+        self._coset_leaders = None
+        self._info_set = None
+        self._G_inv = None
+
+    # ── basic parameters ─────────────────────────────────────────────────
+
+    @property
+    def length(self):
+        """The block length ``n``."""
+        return self.n
+
+    @property
+    def dimension(self):
+        """The number of information bits ``k``."""
+        return self.k
+
+    @property
+    def message_length(self):
+        """The number of message bits per codeword (``k``)."""
+        return self.k
+
+    def rate(self):
+        """The code rate ``k / n``."""
+        return self.k / self.n
+
+    def __repr__(self):
+        try:
+            d = self.minimum_distance()
+            return f"LinearCode[{self.n}, {self.k}, {d}]"
+        except ditException:
+            return f"LinearCode[{self.n}, {self.k}]"
+
+    # ── encoding ─────────────────────────────────────────────────────────
+
+    def encode(self, message):
+        """
+        Encode a length-``k`` message into a length-``n`` codeword.
+        """
+        m = np.asarray(message, dtype=int) % 2
+        return tuple(int(b) for b in _gf2.matvec(self.G.T, m))
+
+    # ── derived structure (lazy) ─────────────────────────────────────────
+
+    def _ensure_codewords(self):
+        if self._codewords is not None:
+            return
+        if self.k > _MAX_ENUMERATION:
+            raise ditException(f"Enumerating 2^{self.k} codewords is intractable.")
+        self._codewords = [
+            tuple(int(b) for b in _gf2.matvec(self.G.T, np.array(m, dtype=int)))
+            for m in itertools.product((0, 1), repeat=self.k)
+        ]
+
+    def _ensure_inverse(self):
+        if self._info_set is not None:
+            return
+        _, pivots = _gf2.rref(self.G)
+        self._info_set = list(pivots)
+        self._G_inv = _gf2.inverse(self.G[:, self._info_set])
+
+    def _ensure_coset_leaders(self):
+        if self._coset_leaders is not None:
+            return
+        m = self.H.shape[0]
+        if m > _MAX_ENUMERATION:
+            raise ditException(f"Syndrome decoding over 2^{m} syndromes is intractable.")
+        leaders = {tuple([0] * m): tuple([0] * self.n)}
+        weight = 1
+        while len(leaders) < 2**m and weight <= self.n:
+            for positions in itertools.combinations(range(self.n), weight):
+                e = np.zeros(self.n, dtype=int)
+                e[list(positions)] = 1
+                syndrome = tuple(int(b) for b in _gf2.matvec(self.H, e))
+                if syndrome not in leaders:
+                    leaders[syndrome] = tuple(int(b) for b in e)
+            weight += 1
+        self._coset_leaders = leaders
+
+    def _codeword_to_message(self, codeword):
+        self._ensure_inverse()
+        c = np.asarray(codeword, dtype=int)
+        m = _gf2.matvec(self._G_inv.T, c[self._info_set])
+        return tuple(int(b) for b in m)
+
+    # ── decoding ─────────────────────────────────────────────────────────
+
+    def decode(self, received, channel=None):
+        """
+        Decode a received word.
+
+        With no channel, hard-decision syndrome decoding is used. With a channel,
+        maximum-likelihood decoding over the codebook is used.
+        """
+        if channel is None:
+            return self._syndrome_decode(received)
+        return self._ml_decode(received, channel)
+
+    def _syndrome_decode(self, received):
+        self._ensure_coset_leaders()
+        y = np.asarray(received, dtype=int) % 2
+        syndrome = tuple(int(b) for b in _gf2.matvec(self.H, y))
+        error = np.asarray(self._coset_leaders[syndrome], dtype=int)
+        codeword = (y - error) % 2
+        return list(self._codeword_to_message(codeword))
+
+    def _ml_decode(self, received, channel):
+        from ._channel import channel_arrays
+
+        inputs, outputs, P = channel_arrays(channel)
+        in_index = {v: i for i, v in enumerate(inputs)}
+        out_index = {v: i for i, v in enumerate(outputs)}
+        self._ensure_codewords()
+        cols = [out_index[y] for y in received]
+        best, best_score = None, None
+        for codeword in self._codewords:
+            score = 0.0
+            for i, bit in enumerate(codeword):
+                p = P[in_index[bit], cols[i]]
+                score += np.log(p) if p > 0 else -np.inf
+            if best_score is None or score > best_score:
+                best, best_score = codeword, score
+        return list(self._codeword_to_message(best))
+
+    # ── code-theoretic properties ────────────────────────────────────────
+
+    def codewords(self):
+        """The list of all codewords."""
+        self._ensure_codewords()
+        return list(self._codewords)
+
+    def weight_enumerator(self):
+        """A ``Counter`` mapping each codeword weight to its multiplicity."""
+        self._ensure_codewords()
+        return Counter(sum(c) for c in self._codewords)
+
+    def minimum_distance(self):
+        """
+        The minimum distance: the least weight among nonzero codewords.
+        """
+        self._ensure_codewords()
+        weights = [sum(c) for c in self._codewords if any(c)]
+        return min(weights)
+
+    def error_correcting_capability(self):
+        """The number of errors the code can correct, ``floor((d - 1) / 2)``."""
+        return (self.minimum_distance() - 1) // 2
+
+    @property
+    def generator_matrix(self):
+        """The generator matrix ``G``."""
+        return self.G
+
+    @property
+    def parity_check_matrix(self):
+        """The parity-check matrix ``H``."""
+        return self.H

--- a/dit/coding/polar.py
+++ b/dit/coding/polar.py
@@ -1,0 +1,143 @@
+"""
+Polar codes with successive-cancellation decoding (Arikan, 2009).
+
+A :class:`PolarCode` freezes the least reliable synthesized bit-channels (ranked
+by their Bhattacharyya parameter) and carries information on the rest. Encoding is
+the Arikan polar transform; decoding is successive cancellation using channel
+log-likelihood ratios.
+"""
+
+from math import log2
+
+import numpy as np
+
+from ..exceptions import ditException
+from .linear import LinearCode
+
+__all__ = (
+    "PolarCode",
+    "polar",
+)
+
+
+def _polar_transform(u):
+    """The Arikan polar transform of a bit vector (``x = u F^{otimes m}``)."""
+    n = len(u)
+    if n == 1:
+        return list(u)
+    half = n // 2
+    upper = [u[i] ^ u[i + half] for i in range(half)]
+    return _polar_transform(upper) + _polar_transform(u[half:])
+
+
+def _bhattacharyya_zs(z0, m):
+    """The Bhattacharyya parameters of the ``2^m`` synthesized channels."""
+    z = [z0]
+    for _ in range(m):
+        z = [value for zi in z for value in (2 * zi - zi * zi, zi * zi)]
+    return z
+
+
+class PolarCode(LinearCode):
+    """
+    A polar code of length ``n = 2^m`` with ``k`` information bits.
+
+    Parameters
+    ----------
+    n : int
+        The block length; must be a power of two.
+    k : int
+        The number of information bits.
+    channel : Distribution
+        The channel used both to select the frozen set and to decode.
+    """
+
+    def __init__(self, n, k, channel):
+        if n & (n - 1) != 0:
+            raise ditException("The polar block length n must be a power of two.")
+        if not 0 < k <= n:
+            raise ditException("The polar dimension k must satisfy 0 < k <= n.")
+        m = int(log2(n))
+
+        from ._channel import bhattacharyya
+
+        z = _bhattacharyya_zs(bhattacharyya(channel), m)
+        # The most reliable channels (smallest Bhattacharyya) carry information.
+        order = sorted(range(n), key=lambda i: z[i])
+        self.info_indices = sorted(order[:k])
+        self.frozen = np.ones(n, dtype=bool)
+        self.frozen[self.info_indices] = False
+
+        rows = []
+        for i in self.info_indices:
+            e = [0] * n
+            e[i] = 1
+            rows.append(_polar_transform(e))
+        G = np.array(rows, dtype=int)
+        super().__init__(G, channel=channel)
+
+    @property
+    def message_length(self):
+        return len(self.info_indices)
+
+    def decode(self, received, channel=None):
+        """
+        Decode by successive cancellation using channel LLRs.
+        """
+        channel = channel if channel is not None else self.channel
+        if channel is None:
+            raise ditException("Polar decoding requires a channel.")
+        from ._channel import log_likelihoods
+
+        llr_map = log_likelihoods(channel)
+        llrs = [llr_map[y] for y in received]
+        decisions = [None] * self.n
+        self._sc(llrs, list(range(self.n)), decisions)
+        return [decisions[i] for i in self.info_indices]
+
+    def _sc(self, llrs, indices, decisions):
+        """Recursive successive cancellation; returns this subtree's codeword bits."""
+        if len(indices) == 1:
+            i = indices[0]
+            if self.frozen[i]:
+                decisions[i] = 0
+            else:
+                decisions[i] = 0 if llrs[0] >= 0 else 1
+            return [decisions[i]]
+
+        half = len(indices) // 2
+        left_llr = [_f(llrs[i], llrs[i + half]) for i in range(half)]
+        enc_left = self._sc(left_llr, indices[:half], decisions)
+        right_llr = [_g(llrs[i], llrs[i + half], enc_left[i]) for i in range(half)]
+        enc_right = self._sc(right_llr, indices[half:], decisions)
+        return [enc_left[i] ^ enc_right[i] for i in range(half)] + enc_right
+
+
+def _f(a, b):
+    """The check-node (min-sum) update for successive cancellation."""
+    return float(np.sign(a) * np.sign(b) * min(abs(a), abs(b)))
+
+
+def _g(a, b, u):
+    """The variable-node update for successive cancellation."""
+    return b - a if u else b + a
+
+
+def polar(n, k, channel):
+    """
+    Build a polar code.
+
+    Parameters
+    ----------
+    n : int
+        The block length; must be a power of two.
+    k : int
+        The number of information bits.
+    channel : Distribution
+        The channel used to select the frozen set and to decode.
+
+    Returns
+    -------
+    code : PolarCode
+    """
+    return PolarCode(n, k, channel)

--- a/dit/coding/symbol_code.py
+++ b/dit/coding/symbol_code.py
@@ -1,0 +1,258 @@
+"""
+Symbol codes: one codeword per source outcome.
+
+A :class:`SymbolCode` is the codebook-based realization of a source code, where
+each source outcome is mapped to a single codeword. This covers Shannon, Fano,
+Shannon-Fano-Elias, Huffman (and its length-limited variant), Golomb/Rice, and
+the universal integer codes.
+"""
+
+from math import isclose
+
+from ..exceptions import ditException
+from ._util import linear_outcomes_probs
+from .base import SourceCoding
+
+__all__ = ("SymbolCode",)
+
+
+class SymbolCode(SourceCoding):
+    """
+    A source code that maps each outcome to a single codeword.
+
+    Parameters
+    ----------
+    codebook : dict
+        A mapping from source outcomes to codeword strings (e.g. ``'010'``).
+    dist : Distribution, None
+        The source distribution. Required for the rate-based properties
+        (:meth:`rate`, :meth:`average_length`, :meth:`redundancy`, ...).
+    radix : int
+        The size of the code alphabet. Default is 2 (binary).
+    """
+
+    def __init__(self, codebook, dist=None, radix=2):
+        super().__init__(dist=dist, radix=radix)
+        self.codebook = dict(codebook)
+        if len(set(self.codebook.values())) != len(self.codebook):
+            raise ditException("Codewords must be distinct (the code is singular).")
+        self._trie = None
+
+    # ── representation ───────────────────────────────────────────────────
+
+    def __repr__(self):
+        probs = self._prob_dict()
+        rows = sorted(self.codebook.items(), key=lambda kv: (len(kv[1]), kv[1]))
+        width = max((len(repr(o)) for o in self.codebook), default=7)
+        lines = [f"{'outcome':>{width}}   p        codeword"]
+        for outcome, word in rows:
+            p = probs.get(outcome)
+            p_str = f"{p:<7.4f}" if p is not None else "  -    "
+            lines.append(f"{outcome!r:>{width}}   {p_str}  {word}")
+        return "\n".join(lines)
+
+    # ── helpers ──────────────────────────────────────────────────────────
+
+    def _prob_dict(self):
+        """A dict mapping each outcome to its (linear) probability."""
+        if self.dist is None:
+            return {}
+        outcomes, probs = linear_outcomes_probs(self.dist)
+        return dict(zip(outcomes, probs, strict=True))
+
+    def _build_trie(self):
+        """Build a decoding trie; leaves carry the outcome under the ``''`` key."""
+        if not self.is_prefix_free():
+            raise ditException("Decoding is only supported for prefix-free codes.")
+        trie = {}
+        for outcome, word in self.codebook.items():
+            node = trie
+            for symbol in word:
+                node = node.setdefault(symbol, {})
+            node[""] = outcome
+        return trie
+
+    # ── encode / decode ──────────────────────────────────────────────────
+
+    def encode(self, source):
+        """
+        Encode a sequence of source outcomes into a string of code symbols.
+
+        Parameters
+        ----------
+        source : iterable
+            A sequence of source outcomes.
+
+        Returns
+        -------
+        encoded : str
+            The concatenated codewords.
+        """
+        try:
+            return "".join(self.codebook[outcome] for outcome in source)
+        except KeyError as e:
+            raise ditException(f"Outcome {e.args[0]!r} is not in the codebook.") from None
+
+    def decode(self, encoded):
+        """
+        Decode a string of code symbols back into source outcomes.
+
+        Parameters
+        ----------
+        encoded : str
+            A concatenation of codewords.
+
+        Returns
+        -------
+        source : list
+            The decoded sequence of source outcomes.
+        """
+        if self._trie is None:
+            self._trie = self._build_trie()
+        source = []
+        node = self._trie
+        for symbol in encoded:
+            try:
+                node = node[symbol]
+            except KeyError:
+                raise ditException(f"Code symbol {symbol!r} is not part of any codeword.") from None
+            if "" in node:
+                source.append(node[""])
+                node = self._trie
+        if node is not self._trie:
+            raise ditException("The encoded string is not a valid sequence of codewords.")
+        return source
+
+    # ── rate-based properties ────────────────────────────────────────────
+
+    def average_length(self):
+        """
+        The expected codeword length, ``sum_x p(x) * len(codeword(x))``.
+
+        Returns
+        -------
+        L : float
+        """
+        probs = self._prob_dict()
+        if not probs:
+            raise ditException("A source distribution is required to compute the average length.")
+        return sum(p * len(self.codebook[outcome]) for outcome, p in probs.items())
+
+    def rate(self):
+        """
+        The expected number of code symbols per source symbol.
+
+        For a symbol code this is exactly the average codeword length.
+        """
+        return self.average_length()
+
+    def length_variance(self):
+        """
+        The variance of the codeword length under the source distribution.
+
+        Among optimal codes (which share the minimal average length) one often
+        prefers the one of least length variance.
+
+        Returns
+        -------
+        var : float
+        """
+        probs = self._prob_dict()
+        if not probs:
+            raise ditException("A source distribution is required to compute the length variance.")
+        mean = self.average_length()
+        return sum(p * (len(self.codebook[outcome]) - mean) ** 2 for outcome, p in probs.items())
+
+    # ── structural properties ────────────────────────────────────────────
+
+    def kraft_sum(self):
+        """
+        The Kraft sum ``sum_x radix ** -len(codeword(x))``.
+
+        By the Kraft-McMillan inequality this is ``<= 1`` for any uniquely
+        decodable code, with equality iff the code is complete.
+
+        Returns
+        -------
+        K : float
+        """
+        return sum(self.radix ** -len(word) for word in self.codebook.values())
+
+    def is_complete(self):
+        """
+        Whether the code is complete (its Kraft sum equals 1).
+
+        Returns
+        -------
+        complete : bool
+        """
+        return isclose(self.kraft_sum(), 1.0, abs_tol=1e-9)
+
+    def is_prefix_free(self):
+        """
+        Whether no codeword is a prefix of another (the code is instantaneous).
+
+        Returns
+        -------
+        prefix_free : bool
+        """
+        words = sorted(self.codebook.values(), key=len)
+        seen = []
+        for word in words:
+            if any(word.startswith(s) for s in seen):
+                return False
+            seen.append(word)
+        return True
+
+    def is_uniquely_decodable(self):
+        """
+        Whether the code is uniquely decodable, via the Sardinas-Patterson test.
+
+        Returns
+        -------
+        unique : bool
+        """
+        words = set(self.codebook.values())
+        if "" in words:
+            return False
+
+        def dangling(c1, c2):
+            """Suffixes left after matching codewords of ``c1`` against ``c2``."""
+            suffixes = set()
+            for a in c1:
+                for b in c2:
+                    if a == b:
+                        continue
+                    if a.startswith(b):
+                        suffixes.add(a[len(b) :])
+                    elif b.startswith(a):
+                        suffixes.add(b[len(a) :])
+            return suffixes
+
+        # The first dangling set comes from matching codewords against each other.
+        current = dangling(words, words)
+        seen = set()
+        while current:
+            if words & current:
+                # A codeword is itself a dangling suffix => not uniquely decodable.
+                return False
+            if current <= seen:
+                break
+            seen |= current
+            current = dangling(words, current)
+        return True
+
+    def is_optimal(self):
+        """
+        Whether the code achieves the minimal average length (Huffman optimal).
+
+        Returns
+        -------
+        optimal : bool
+        """
+        if self.dist is None:
+            raise ditException("A source distribution is required to test optimality.")
+        from .codes import huffman
+
+        best = huffman(self.dist, radix=self.radix).average_length()
+        return isclose(self.average_length(), best, abs_tol=1e-9)

--- a/dit/coding/tunstall.py
+++ b/dit/coding/tunstall.py
@@ -1,0 +1,181 @@
+"""
+Tunstall coding: a variable-to-fixed-length source code.
+
+Where a symbol code (e.g. Huffman) maps each source symbol to a variable-length
+codeword, a Tunstall code parses the source into variable-length *words* drawn
+from a dictionary and maps each word to a fixed-length codeword. The dictionary
+is the set of leaves of a complete parse tree grown by repeatedly expanding the
+most probable leaf (Tunstall, 1967).
+"""
+
+import heapq
+import itertools
+
+from ..exceptions import ditException
+from ._util import DIGITS, check_radix, linear_outcomes_probs
+from .base import SourceCoding
+
+__all__ = (
+    "TunstallCode",
+    "tunstall",
+)
+
+
+def _fixed_radix(value, length, radix):
+    """The fixed-`length` base-`radix` representation of ``value``."""
+    digits = []
+    for _ in range(length):
+        value, d = divmod(value, radix)
+        digits.append(DIGITS[d])
+    return "".join(reversed(digits))
+
+
+class TunstallCode(SourceCoding):
+    """
+    A variable-to-fixed-length source code.
+
+    Parameters
+    ----------
+    word_to_code : dict
+        A mapping from source words (tuples of outcomes) to fixed-length
+        codeword strings.
+    word_probs : dict
+        A mapping from source words to their probabilities (used for the rate).
+    code_length : int
+        The fixed codeword length, in code symbols.
+    dist : Distribution, None
+        The source distribution.
+    radix : int
+        The size of the code alphabet. Default is 2.
+    """
+
+    def __init__(self, word_to_code, word_probs, code_length, dist=None, radix=2):
+        super().__init__(dist=dist, radix=radix)
+        self.word_to_code = dict(word_to_code)
+        self.code_to_word = {code: word for word, code in self.word_to_code.items()}
+        self.word_probs = dict(word_probs)
+        self.code_length = code_length
+
+    def __repr__(self):
+        rows = sorted(self.word_to_code.items(), key=lambda kv: kv[1])
+        lines = ["word        p        codeword"]
+        for word, code in rows:
+            p = self.word_probs.get(word, 0.0)
+            lines.append(f"{word!r:<10}  {p:<7.4f}  {code}")
+        return "\n".join(lines)
+
+    def expected_word_length(self):
+        """
+        The expected number of source symbols per dictionary word.
+
+        Returns
+        -------
+        L : float
+        """
+        return sum(p * len(word) for word, p in self.word_probs.items())
+
+    def rate(self):
+        """
+        The expected number of code symbols per source symbol.
+
+        Each word maps to ``code_length`` code symbols and spans
+        ``expected_word_length`` source symbols on average.
+        """
+        return self.code_length / self.expected_word_length()
+
+    def encode(self, source):
+        """
+        Encode a sequence of source outcomes by greedily parsing it into words.
+
+        Parameters
+        ----------
+        source : iterable
+            A sequence of source outcomes whose symbols form complete words.
+
+        Returns
+        -------
+        encoded : str
+        """
+        out = []
+        current = ()
+        for symbol in source:
+            current = current + (symbol,)
+            code = self.word_to_code.get(current)
+            if code is not None:
+                out.append(code)
+                current = ()
+        if current:
+            raise ditException("The source ends mid-word; cannot encode a partial Tunstall word.")
+        return "".join(out)
+
+    def decode(self, encoded):
+        """
+        Decode a string of code symbols back into source outcomes.
+
+        Parameters
+        ----------
+        encoded : str
+            A concatenation of fixed-length codewords.
+
+        Returns
+        -------
+        source : list
+        """
+        if len(encoded) % self.code_length != 0:
+            raise ditException("The encoded length is not a multiple of the code length.")
+        out = []
+        for i in range(0, len(encoded), self.code_length):
+            block = encoded[i : i + self.code_length]
+            try:
+                out.extend(self.code_to_word[block])
+            except KeyError:
+                raise ditException(f"{block!r} is not a Tunstall codeword.") from None
+        return out
+
+
+def tunstall(dist, code_length, radix=2):
+    """
+    Build a Tunstall code for a memoryless source.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution over single symbols (assumed i.i.d.).
+    code_length : int
+        The fixed codeword length, in code symbols. The dictionary holds up to
+        ``radix ** code_length`` words.
+    radix : int
+        The size of the code alphabet. Default is 2.
+
+    Returns
+    -------
+    code : TunstallCode
+    """
+    check_radix(radix)
+    outcomes, probs = linear_outcomes_probs(dist)
+    alphabet = list(zip(outcomes, probs, strict=True))
+    capacity = radix**code_length
+    if len(alphabet) > capacity:
+        raise ditException(
+            f"code_length={code_length} gives only {capacity} codewords, too few for a {len(alphabet)}-symbol source."
+        )
+
+    counter = itertools.count()
+    # Max-heap on probability via negation; leaves are (word, prob).
+    heap = [(-p, next(counter), (outcome,), p) for outcome, p in alphabet]
+    heapq.heapify(heap)
+    leaves = {(outcome,): p for outcome, p in alphabet}
+    expansion = len(alphabet) - 1
+
+    while len(leaves) + expansion <= capacity:
+        _, _, word, prob = heapq.heappop(heap)
+        del leaves[word]
+        for outcome, p in alphabet:
+            child = word + (outcome,)
+            child_prob = prob * p
+            leaves[child] = child_prob
+            heapq.heappush(heap, (-child_prob, next(counter), child, child_prob))
+
+    ordered = sorted(leaves, key=lambda w: (-leaves[w], tuple(map(repr, w))))
+    word_to_code = {word: _fixed_radix(i, code_length, radix) for i, word in enumerate(ordered)}
+    return TunstallCode(word_to_code, leaves, code_length, dist=dist, radix=radix)

--- a/dit/coding/universal.py
+++ b/dit/coding/universal.py
@@ -1,0 +1,130 @@
+"""
+Universal codes for the positive integers.
+
+These prefix-free codes encode the positive integers without reference to a
+source distribution, yet remain within a constant factor of optimal across a wide
+range of distributions. Provided are the unary code, the Elias gamma / delta /
+omega codes (Elias, 1975), and the Fibonacci code.
+
+Each function maps a positive integer to its codeword string. :func:`universal_code`
+wraps a chosen family into a :class:`SymbolCode` over an integer-valued source.
+"""
+
+from ..exceptions import ditException
+from ._util import linear_outcomes_probs
+from .symbol_code import SymbolCode
+
+__all__ = (
+    "elias_delta",
+    "elias_gamma",
+    "elias_omega",
+    "fibonacci",
+    "unary",
+    "universal_code",
+)
+
+
+def _check_positive(n):
+    if not isinstance(n, int) or n < 1:
+        raise ditException(f"Universal codes encode positive integers; got {n!r}.")
+
+
+def unary(n):
+    """
+    The unary codeword for ``n >= 1``: ``n - 1`` ones followed by a zero.
+    """
+    _check_positive(n)
+    return "1" * (n - 1) + "0"
+
+
+def elias_gamma(n):
+    """
+    The Elias gamma codeword for ``n >= 1``.
+
+    The codeword is ``floor(log2(n))`` zeros followed by the binary
+    representation of ``n``.
+    """
+    _check_positive(n)
+    binary = format(n, "b")
+    return "0" * (len(binary) - 1) + binary
+
+
+def elias_delta(n):
+    """
+    The Elias delta codeword for ``n >= 1``.
+
+    The codeword is the gamma code of the bit-length of ``n`` followed by the
+    bits of ``n`` below its leading one.
+    """
+    _check_positive(n)
+    binary = format(n, "b")
+    return elias_gamma(len(binary)) + binary[1:]
+
+
+def elias_omega(n):
+    """
+    The Elias omega (recursive) codeword for ``n >= 1``.
+    """
+    _check_positive(n)
+    code = "0"
+    k = n
+    while k > 1:
+        binary = format(k, "b")
+        code = binary + code
+        k = len(binary) - 1
+    return code
+
+
+def fibonacci(n):
+    """
+    The Fibonacci codeword for ``n >= 1`` (Zeckendorf representation + a ``1``).
+    """
+    _check_positive(n)
+    fibs = [1, 2]
+    while fibs[-1] <= n:
+        fibs.append(fibs[-1] + fibs[-2])
+    fibs = fibs[:-1]
+    used = []
+    remainder = n
+    for f in reversed(fibs):
+        if f <= remainder:
+            used.append(True)
+            remainder -= f
+        else:
+            used.append(False)
+    used.reverse()
+    return "".join("1" if u else "0" for u in used) + "1"
+
+
+_FAMILIES = {
+    "unary": unary,
+    "gamma": elias_gamma,
+    "delta": elias_delta,
+    "omega": elias_omega,
+    "fibonacci": fibonacci,
+}
+
+
+def universal_code(dist, kind="gamma"):
+    """
+    Build a :class:`SymbolCode` over integer outcomes using a universal code.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The source distribution; its outcomes must be positive integers.
+    kind : str
+        One of ``'unary'``, ``'gamma'``, ``'delta'``, ``'omega'``, or
+        ``'fibonacci'``.
+
+    Returns
+    -------
+    code : SymbolCode
+    """
+    try:
+        encoder = _FAMILIES[kind]
+    except KeyError:
+        raise ditException(f"Unknown universal code {kind!r}; choose from {sorted(_FAMILIES)}.") from None
+    outcomes, _ = linear_outcomes_probs(dist)
+    codebook = {o: encoder(o) for o in outcomes}
+    return SymbolCode(codebook, dist=dist, radix=2)

--- a/dit/example_channels/__init__.py
+++ b/dit/example_channels/__init__.py
@@ -1,0 +1,36 @@
+"""
+A catalog of canonical discrete memoryless channels.
+
+Each constructor returns a conditional :class:`~dit.Distribution` ``p(Y | X)`` --
+the representation consumed by :func:`dit.algorithms.channel_capacity` and the
+channel-coding evaluation layer in :mod:`dit.coding`. Alphabets are integer-valued;
+an erasure is the integer just past the input alphabet (binary erasure ``2``,
+q-ary erasure ``q``).
+"""
+
+from .binary import (
+    binary_asymmetric_channel,
+    binary_erasure_channel,
+    binary_symmetric_channel,
+    binary_symmetric_erasure_channel,
+    z_channel,
+)
+from .qary import (
+    noisy_typewriter,
+    q_ary_erasure_channel,
+    q_ary_symmetric_channel,
+)
+from .trivial import identity_channel, useless_channel
+
+__all__ = (
+    "binary_asymmetric_channel",
+    "binary_erasure_channel",
+    "binary_symmetric_channel",
+    "binary_symmetric_erasure_channel",
+    "identity_channel",
+    "noisy_typewriter",
+    "q_ary_erasure_channel",
+    "q_ary_symmetric_channel",
+    "useless_channel",
+    "z_channel",
+)

--- a/dit/example_channels/_util.py
+++ b/dit/example_channels/_util.py
@@ -1,0 +1,52 @@
+"""
+Shared helpers for building example channels.
+"""
+
+from math import isclose
+
+from ..exceptions import ditException
+
+__all__ = ()
+
+
+def conditional_from_matrix(P, inputs, outputs, input_name="X", output_name="Y"):
+    """
+    Build a conditional ``Distribution`` ``p(Y | X)`` from a transition matrix.
+
+    Parameters
+    ----------
+    P : sequence of sequence of float
+        The transition matrix, with ``P[i][j] = p(Y = outputs[j] | X = inputs[i])``.
+        Each row must sum to one.
+    inputs : sequence
+        The input alphabet (one entry per row of ``P``).
+    outputs : sequence
+        The output alphabet (one entry per column of ``P``).
+    input_name : str
+        The name of the input random variable.
+    output_name : str
+        The name of the output random variable.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)``.
+    """
+    from ..distribution import Distribution
+
+    if len(P) != len(inputs):
+        raise ditException("P must have one row per input symbol.")
+    n_in = len(inputs)
+    joint = {}
+    for i, x in enumerate(inputs):
+        row = P[i]
+        if len(row) != len(outputs):
+            raise ditException("P must have one column per output symbol.")
+        if not isclose(sum(row), 1.0, abs_tol=1e-9):
+            raise ditException(f"Row {i} of the transition matrix does not sum to one.")
+        for y, prob in zip(outputs, row, strict=True):
+            if prob > 0:
+                joint[(x, y)] = prob / n_in
+
+    dist = Distribution(joint, rv_names=[input_name, output_name])
+    return dist.condition_on(input_name)

--- a/dit/example_channels/binary.py
+++ b/dit/example_channels/binary.py
@@ -1,0 +1,142 @@
+"""
+Binary-input example channels.
+"""
+
+from ..exceptions import ditException
+from ._util import conditional_from_matrix
+
+__all__ = (
+    "binary_asymmetric_channel",
+    "binary_erasure_channel",
+    "binary_symmetric_channel",
+    "binary_symmetric_erasure_channel",
+    "z_channel",
+)
+
+# The erasure symbol; the integer just past the binary input alphabet {0, 1}.
+ERASURE = 2
+
+
+def binary_symmetric_channel(p):
+    """
+    The binary symmetric channel with crossover probability ``p``.
+
+    Each transmitted bit is independently flipped with probability ``p``. Its
+    capacity is :math:`1 - H_b(p)`.
+
+    Parameters
+    ----------
+    p : float
+        The probability that a transmitted bit is flipped.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, 1}``.
+    """
+    if not 0 <= p <= 1:
+        raise ditException("The crossover probability p must lie in [0, 1].")
+    P = [[1 - p, p], [p, 1 - p]]
+    return conditional_from_matrix(P, [0, 1], [0, 1])
+
+
+def binary_erasure_channel(epsilon):
+    """
+    The binary erasure channel with erasure probability ``epsilon``.
+
+    Each transmitted bit is independently erased with probability ``epsilon`` and
+    otherwise received unchanged. Its capacity is :math:`1 - \\epsilon`.
+
+    Parameters
+    ----------
+    epsilon : float
+        The probability that a transmitted bit is erased.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` with output alphabet
+        ``{0, 1, 2}``, where ``2`` denotes an erasure.
+    """
+    if not 0 <= epsilon <= 1:
+        raise ditException("The erasure probability epsilon must lie in [0, 1].")
+    P = [[1 - epsilon, 0, epsilon], [0, 1 - epsilon, epsilon]]
+    return conditional_from_matrix(P, [0, 1], [0, 1, ERASURE])
+
+
+def z_channel(p):
+    """
+    The Z-channel with crossover probability ``p``.
+
+    A ``0`` is always received correctly; a ``1`` is flipped to ``0`` with
+    probability ``p``. This is the canonical binary asymmetric channel.
+
+    Parameters
+    ----------
+    p : float
+        The probability that a transmitted ``1`` is received as ``0``.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, 1}``.
+    """
+    if not 0 <= p <= 1:
+        raise ditException("The crossover probability p must lie in [0, 1].")
+    P = [[1, 0], [p, 1 - p]]
+    return conditional_from_matrix(P, [0, 1], [0, 1])
+
+
+def binary_asymmetric_channel(p0, p1):
+    """
+    The binary asymmetric channel.
+
+    A ``0`` is flipped to ``1`` with probability ``p0``; a ``1`` is flipped to
+    ``0`` with probability ``p1``. The binary symmetric channel is the case
+    ``p0 == p1`` and the Z-channel is the case ``p0 == 0``.
+
+    Parameters
+    ----------
+    p0 : float
+        The probability that a transmitted ``0`` is received as ``1``.
+    p1 : float
+        The probability that a transmitted ``1`` is received as ``0``.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, 1}``.
+    """
+    if not 0 <= p0 <= 1 or not 0 <= p1 <= 1:
+        raise ditException("The crossover probabilities must lie in [0, 1].")
+    P = [[1 - p0, p0], [p1, 1 - p1]]
+    return conditional_from_matrix(P, [0, 1], [0, 1])
+
+
+def binary_symmetric_erasure_channel(p, epsilon):
+    """
+    The binary symmetric error-and-erasure channel.
+
+    A transmitted bit is erased with probability ``epsilon`` and flipped with
+    probability ``p``; the two events are disjoint, so ``p + epsilon <= 1``.
+
+    Parameters
+    ----------
+    p : float
+        The probability that a transmitted bit is flipped.
+    epsilon : float
+        The probability that a transmitted bit is erased.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` with output alphabet
+        ``{0, 1, 2}``, where ``2`` denotes an erasure.
+    """
+    if p < 0 or epsilon < 0 or p + epsilon > 1:
+        raise ditException("Require p >= 0, epsilon >= 0, and p + epsilon <= 1.")
+    P = [
+        [1 - p - epsilon, p, epsilon],
+        [p, 1 - p - epsilon, epsilon],
+    ]
+    return conditional_from_matrix(P, [0, 1], [0, 1, ERASURE])

--- a/dit/example_channels/qary.py
+++ b/dit/example_channels/qary.py
@@ -1,0 +1,99 @@
+"""
+q-ary example channels.
+"""
+
+from ..exceptions import ditException
+from ._util import conditional_from_matrix
+
+__all__ = (
+    "noisy_typewriter",
+    "q_ary_erasure_channel",
+    "q_ary_symmetric_channel",
+)
+
+
+def q_ary_symmetric_channel(q, p):
+    """
+    The q-ary symmetric channel.
+
+    A symbol is received correctly with probability ``1 - p`` and is otherwise
+    received as one of the other ``q - 1`` symbols, chosen uniformly. Its capacity
+    is :math:`\\log_2 q - H_b(p) - p \\log_2(q - 1)`. The binary symmetric channel
+    is the case ``q == 2``.
+
+    Parameters
+    ----------
+    q : int
+        The alphabet size (``q >= 2``).
+    p : float
+        The total probability that a symbol is received incorrectly.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, ..., q - 1}``.
+    """
+    if q < 2:
+        raise ditException("The alphabet size q must be at least 2.")
+    if not 0 <= p <= 1:
+        raise ditException("The error probability p must lie in [0, 1].")
+    off = p / (q - 1)
+    P = [[1 - p if i == j else off for j in range(q)] for i in range(q)]
+    return conditional_from_matrix(P, list(range(q)), list(range(q)))
+
+
+def q_ary_erasure_channel(q, epsilon):
+    """
+    The q-ary erasure channel.
+
+    A symbol is erased with probability ``epsilon`` and otherwise received
+    unchanged. Its capacity is :math:`(1 - \\epsilon) \\log_2 q`. The binary
+    erasure channel is the case ``q == 2``.
+
+    Parameters
+    ----------
+    q : int
+        The alphabet size (``q >= 2``).
+    epsilon : float
+        The probability that a symbol is erased.
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` with output alphabet
+        ``{0, ..., q - 1, q}``, where ``q`` denotes an erasure.
+    """
+    if q < 2:
+        raise ditException("The alphabet size q must be at least 2.")
+    if not 0 <= epsilon <= 1:
+        raise ditException("The erasure probability epsilon must lie in [0, 1].")
+    erasure = q
+    P = [[(1 - epsilon if j == i else 0) for j in range(q)] + [epsilon] for i in range(q)]
+    return conditional_from_matrix(P, list(range(q)), list(range(q)) + [erasure])
+
+
+def noisy_typewriter(n=26):
+    """
+    The noisy typewriter channel (Cover & Thomas).
+
+    Each of the ``n`` letters is received either unchanged or as the next letter
+    (cyclically), each with probability one half. Its capacity is
+    :math:`\\log_2(n / 2)`, achieved by using every other input letter.
+
+    Parameters
+    ----------
+    n : int
+        The alphabet size (``n >= 2``).
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, ..., n - 1}``.
+    """
+    if n < 2:
+        raise ditException("The alphabet size n must be at least 2.")
+    P = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        P[i][i] = 0.5
+        P[i][(i + 1) % n] = 0.5
+    return conditional_from_matrix(P, list(range(n)), list(range(n)))

--- a/dit/example_channels/trivial.py
+++ b/dit/example_channels/trivial.py
@@ -1,0 +1,57 @@
+"""
+Trivial endpoint channels: the noiseless and zero-capacity extremes.
+"""
+
+from ..exceptions import ditException
+from ._util import conditional_from_matrix
+
+__all__ = (
+    "identity_channel",
+    "useless_channel",
+)
+
+
+def identity_channel(n=2):
+    """
+    The noiseless channel over an ``n``-symbol alphabet.
+
+    Every symbol is received unchanged, so the channel has capacity
+    :math:`\\log_2 n`.
+
+    Parameters
+    ----------
+    n : int
+        The alphabet size (``n >= 1``).
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, ..., n - 1}``.
+    """
+    if n < 1:
+        raise ditException("The alphabet size n must be at least 1.")
+    P = [[1.0 if i == j else 0.0 for j in range(n)] for i in range(n)]
+    return conditional_from_matrix(P, list(range(n)), list(range(n)))
+
+
+def useless_channel(n=2):
+    """
+    The zero-capacity channel over an ``n``-symbol alphabet.
+
+    The output is uniform and independent of the input, so the channel carries no
+    information and has capacity ``0``.
+
+    Parameters
+    ----------
+    n : int
+        The alphabet size (``n >= 1``).
+
+    Returns
+    -------
+    channel : Distribution
+        The conditional distribution ``p(Y | X)`` over ``{0, ..., n - 1}``.
+    """
+    if n < 1:
+        raise ditException("The alphabet size n must be at least 1.")
+    P = [[1.0 / n for _ in range(n)] for _ in range(n)]
+    return conditional_from_matrix(P, list(range(n)), list(range(n)))

--- a/docs/channels.rst
+++ b/docs/channels.rst
@@ -1,0 +1,84 @@
+.. channels.rst
+.. py:module:: dit.example_channels
+
+Channels
+========
+
+The :mod:`dit.example_channels` module is a catalog of canonical discrete
+memoryless channels (DMCs). Each constructor returns a *conditional*
+:class:`~dit.Distribution` :math:`p(Y \mid X)` -- the representation consumed by
+:func:`~dit.algorithms.channel_capacity` and by the channel-coding evaluation
+layer in :mod:`dit.coding`. Alphabets are integer-valued; an erasure is the
+integer just past the input alphabet (binary erasure ``2``, q-ary erasure ``q``).
+
+The catalog
+-----------
+
+Binary-input channels:
+
+- :func:`binary_symmetric_channel` -- each bit is flipped with probability ``p``;
+  capacity :math:`1 - H_b(p)`,
+- :func:`binary_erasure_channel` -- each bit is erased with probability
+  :math:`\epsilon`; capacity :math:`1 - \epsilon`,
+- :func:`z_channel` -- a ``0`` is received perfectly while a ``1`` is flipped to
+  ``0`` with probability ``p`` (the canonical asymmetric channel),
+- :func:`binary_asymmetric_channel` -- independent crossover probabilities for
+  ``0`` and ``1`` (the BSC and Z-channel are special cases),
+- :func:`binary_symmetric_erasure_channel` -- errors and erasures together.
+
+q-ary channels:
+
+- :func:`q_ary_symmetric_channel` -- correct with probability ``1 - p``, else a
+  uniform wrong symbol; capacity :math:`\log_2 q - H_b(p) - p \log_2(q - 1)`,
+- :func:`q_ary_erasure_channel` -- erased with probability :math:`\epsilon`;
+  capacity :math:`(1 - \epsilon) \log_2 q`,
+- :func:`noisy_typewriter` -- each letter maps to itself or the next, each with
+  probability one half; capacity :math:`\log_2(n / 2)`.
+
+Trivial endpoints:
+
+- :func:`identity_channel` -- the noiseless channel, capacity :math:`\log_2 n`,
+- :func:`useless_channel` -- output independent of input, capacity ``0``.
+
+Example
+-------
+
+A channel can be fed directly to :func:`~dit.algorithms.channel_capacity` or to a
+code's :meth:`~dit.coding.ChannelCoding.probability_of_error`:
+
+.. ipython::
+
+   In [1]: from dit.example_channels import binary_symmetric_channel
+
+   In [2]: from dit.algorithms import channel_capacity
+
+   In [3]: bsc = binary_symmetric_channel(0.1)
+
+   In [4]: channel_capacity(bsc)[0]
+
+   In [5]: from dit.coding import hamming
+
+   In [6]: hamming(3).probability_of_error(bsc, method='exact')
+
+APIs
+====
+
+.. autofunction:: binary_symmetric_channel
+
+.. autofunction:: binary_erasure_channel
+
+.. autofunction:: z_channel
+
+.. autofunction:: binary_asymmetric_channel
+
+.. autofunction:: binary_symmetric_erasure_channel
+
+.. autofunction:: q_ary_symmetric_channel
+
+.. autofunction:: q_ary_erasure_channel
+
+.. autofunction:: noisy_typewriter
+
+.. autofunction:: identity_channel
+
+.. autofunction:: useless_channel

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -105,10 +105,10 @@ A *channel code* adds redundancy to a message so that it can be recovered after
 transmission over a noisy channel. All channel codes in :mod:`dit.coding` are
 binary (over :math:`\mathrm{GF}(2)`), and a channel is supplied as a conditional
 :class:`~dit.Distribution` :math:`p(Y \mid X)` -- a discrete memoryless channel
-applied independently to each transmitted symbol. The convenience constructors
-:func:`binary_symmetric_channel` and :func:`binary_erasure_channel` build the two
-standard binary channels (the erasure channel uses the integer ``2`` for an
-erasure).
+applied independently to each transmitted symbol. The :doc:`channels` page
+catalogs ready-made channels, including :func:`~dit.example_channels.binary_symmetric_channel`
+and :func:`~dit.example_channels.binary_erasure_channel` (re-exported from
+:mod:`dit.coding` for convenience).
 
 Every channel code derives from :class:`ChannelCoding`, which provides the
 information-theoretic evaluation common to all of them:
@@ -240,7 +240,3 @@ APIs
 .. autofunction:: polar
 
 .. autofunction:: convolutional
-
-.. autofunction:: binary_symmetric_channel
-
-.. autofunction:: binary_erasure_channel

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1,0 +1,246 @@
+.. coding.rst
+.. py:module:: dit.coding
+
+Coding
+======
+
+The :mod:`dit.coding` module builds both *source codes* (which compress a source
+:class:`~dit.Distribution`) and *channel codes* (which add redundancy to protect
+against channel noise), and exposes their code-theoretic properties.
+
+Source coding
+-------------
+
+A *source code* maps the outcomes of a source to codewords over a ``radix``-ary
+alphabet (binary by default), with the goal of minimizing the expected number of
+code symbols per source symbol -- the *rate*. By the source coding theorem
+:cite:`Cover2006`, no uniquely decodable code can have a rate below the source
+entropy :math:`\H{X}`.
+
+Base classes
+------------
+
+All source codes derive from :class:`SourceCoding`, which defines the
+:meth:`~SourceCoding.encode`, :meth:`~SourceCoding.decode`, and
+:meth:`~SourceCoding.rate` interface and provides the comparisons to the source
+entropy that are common to every source code:
+
+- :meth:`~SourceCoding.source_entropy` -- :math:`\H{X}` in ``radix``-ary digits,
+- :meth:`~SourceCoding.redundancy` -- ``rate - source_entropy``,
+- :meth:`~SourceCoding.efficiency` -- ``source_entropy / rate``.
+
+Channel codes derive from the companion :class:`ChannelCoding` base class,
+described under :ref:`channel-coding` below.
+
+Symbol codes
+------------
+
+A :class:`SymbolCode` assigns one codeword to each source outcome. The classic
+constructions are available:
+
+- :func:`shannon` -- lengths :math:`\lceil \log_D 1/p \rceil`, codewords from the
+  cumulative distribution,
+- :func:`fano` -- top-down balanced partitioning,
+- :func:`shannon_fano_elias` -- lengths :math:`\lceil \log_D 1/p \rceil + 1`,
+  codewords from the midpoint cumulative distribution,
+- :func:`huffman` -- the optimal symbol code,
+- :func:`length_limited_huffman` -- the optimal code subject to a maximum codeword
+  length (via package-merge),
+- :func:`golomb` / :func:`rice` -- optimal codes for geometric integer sources.
+
+Beyond the rate-based properties, a :class:`SymbolCode` reports the Kraft sum
+(:meth:`~SymbolCode.kraft_sum`), whether it is complete
+(:meth:`~SymbolCode.is_complete`), prefix-free (:meth:`~SymbolCode.is_prefix_free`),
+uniquely decodable (:meth:`~SymbolCode.is_uniquely_decodable`, via
+Sardinas-Patterson), and optimal (:meth:`~SymbolCode.is_optimal`).
+
+Example
+-------
+
+.. ipython::
+
+   In [1]: from dit.coding import huffman, shannon
+
+   In [2]: d = dit.Distribution(['a', 'b', 'c', 'd', 'e'], [0.4, 0.2, 0.2, 0.1, 0.1])
+
+   In [3]: code = huffman(d)
+
+   In [4]: code.average_length(), code.source_entropy()
+
+   In [5]: code.is_optimal(), code.is_prefix_free(), code.is_complete()
+
+   In [6]: seq = list(d.outcomes)
+
+   In [7]: code.decode(code.encode(seq)) == seq
+
+Huffman is optimal, so its average length is no larger than the Shannon code's:
+
+.. ipython::
+
+   In [8]: shannon(d).average_length()
+
+Universal integer codes
+-----------------------
+
+The universal codes encode the positive integers without reference to a source
+distribution, yet stay within a constant factor of optimal across a wide range of
+sources: :func:`unary`, :func:`elias_gamma`, :func:`elias_delta`,
+:func:`elias_omega`, and :func:`fibonacci`. The :func:`universal_code` helper wraps
+a chosen family into a :class:`SymbolCode` over an integer-valued source.
+
+Tunstall codes
+--------------
+
+Where a symbol code maps each symbol to a variable-length codeword, a
+:func:`tunstall` code parses the source into variable-length *words* and maps each
+word to a fixed-length codeword. It is the variable-to-fixed dual of Huffman and
+is realized by :class:`TunstallCode`.
+
+.. _channel-coding:
+
+Channel coding
+--------------
+
+A *channel code* adds redundancy to a message so that it can be recovered after
+transmission over a noisy channel. All channel codes in :mod:`dit.coding` are
+binary (over :math:`\mathrm{GF}(2)`), and a channel is supplied as a conditional
+:class:`~dit.Distribution` :math:`p(Y \mid X)` -- a discrete memoryless channel
+applied independently to each transmitted symbol. The convenience constructors
+:func:`binary_symmetric_channel` and :func:`binary_erasure_channel` build the two
+standard binary channels (the erasure channel uses the integer ``2`` for an
+erasure).
+
+Every channel code derives from :class:`ChannelCoding`, which provides the
+information-theoretic evaluation common to all of them:
+
+- :meth:`~ChannelCoding.capacity_gap` -- ``channel_capacity(channel) - rate``, the
+  gap to the channel coding theorem's limit :cite:`Cover2006`,
+- :meth:`~ChannelCoding.probability_of_error` -- the block-error probability under
+  the code's own decoder, computed exactly for small codes (enumerating every
+  message and received word) or by Monte Carlo otherwise.
+
+Linear block codes
+~~~~~~~~~~~~~~~~~~~
+
+A :class:`LinearCode` is specified by a generator matrix ``G``; the parity-check
+matrix ``H`` is derived as a basis for its null space. It supports
+hard-decision syndrome decoding (and maximum-likelihood decoding when a channel is
+given), and reports the :meth:`~LinearCode.minimum_distance`,
+:meth:`~LinearCode.weight_enumerator`, and
+:meth:`~LinearCode.error_correcting_capability`. The classical families are
+available as constructors: :func:`repetition`, :func:`parity_check`,
+:func:`hamming`, :func:`reed_muller`, and :func:`golay`.
+
+Modern codes
+~~~~~~~~~~~~
+
+Three modern codes specialize the decoder:
+
+- :func:`ldpc` / :func:`gallager` build an :class:`LDPCCode` decoded by
+  sum-product belief propagation over its Tanner graph :cite:`Cover2006`,
+- :func:`polar` builds a :class:`PolarCode`, freezing the least reliable
+  synthesized bit-channels (by Bhattacharyya parameter) and decoding by successive
+  cancellation,
+- :func:`convolutional` builds a :class:`ConvolutionalCode` from generator
+  polynomials, decoded with the Viterbi algorithm (soft-decision when a channel is
+  given).
+
+Channel coding example
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Hamming ``[7, 4, 3]`` code corrects any single error; over a binary symmetric
+channel its exact block-error probability matches the closed form
+:math:`1 - (1-p)^7 - 7p(1-p)^6`:
+
+.. ipython::
+
+   In [1]: from dit.coding import hamming, binary_symmetric_channel
+
+   In [2]: code = hamming(3)
+
+   In [3]: code.length, code.dimension, code.minimum_distance()
+
+   In [4]: bsc = binary_symmetric_channel(0.05)
+
+   In [5]: code.capacity_gap(bsc)
+
+   In [6]: code.probability_of_error(bsc, method='exact')
+
+   In [7]: 1 - 0.95**7 - 7 * 0.05 * 0.95**6
+
+APIs
+====
+
+.. autoclass:: SourceCoding
+   :members:
+
+.. autoclass:: ChannelCoding
+   :members:
+
+.. autoclass:: SymbolCode
+   :members:
+
+.. autoclass:: TunstallCode
+   :members:
+
+.. autofunction:: shannon
+
+.. autofunction:: fano
+
+.. autofunction:: shannon_fano_elias
+
+.. autofunction:: huffman
+
+.. autofunction:: length_limited_huffman
+
+.. autofunction:: golomb
+
+.. autofunction:: rice
+
+.. autofunction:: tunstall
+
+.. autofunction:: universal_code
+
+.. autofunction:: unary
+
+.. autofunction:: elias_gamma
+
+.. autofunction:: elias_delta
+
+.. autofunction:: elias_omega
+
+.. autofunction:: fibonacci
+
+.. autoclass:: LinearCode
+   :members:
+
+.. autoclass:: LDPCCode
+   :members:
+
+.. autoclass:: PolarCode
+   :members:
+
+.. autoclass:: ConvolutionalCode
+   :members:
+
+.. autofunction:: repetition
+
+.. autofunction:: parity_check
+
+.. autofunction:: hamming
+
+.. autofunction:: reed_muller
+
+.. autofunction:: golay
+
+.. autofunction:: ldpc
+
+.. autofunction:: gallager
+
+.. autofunction:: polar
+
+.. autofunction:: convolutional
+
+.. autofunction:: binary_symmetric_channel
+
+.. autofunction:: binary_erasure_channel

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Contents:
    profiles
    rate_distortion
    gray_wyner
+   coding
    measures/pid
    stumbling
    zreferences

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Contents:
    rate_distortion
    gray_wyner
    coding
+   channels
    measures/pid
    stumbling
    zreferences

--- a/tests/coding/test_base.py
+++ b/tests/coding/test_base.py
@@ -1,0 +1,45 @@
+"""
+Tests for the dit.coding base classes.
+"""
+
+import pytest
+
+from dit import Distribution as D
+from dit.coding import ChannelCoding, SourceCoding, huffman
+from dit.exceptions import ditException
+
+
+def test_source_coding_is_abstract():
+    """SourceCoding cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        SourceCoding()
+
+
+def test_channel_coding_is_abstract():
+    """ChannelCoding cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        ChannelCoding()
+
+
+def test_symbol_code_is_source_coding():
+    """A built symbol code is a SourceCoding instance."""
+    code = huffman(D(list(range(3)), [0.5, 0.3, 0.2]))
+    assert isinstance(code, SourceCoding)
+
+
+def test_redundancy_and_efficiency_consistent():
+    """redundancy = rate - entropy and efficiency = entropy / rate."""
+    code = huffman(D(list(range(5)), [0.4, 0.2, 0.2, 0.1, 0.1]))
+    assert code.redundancy() == pytest.approx(code.rate() - code.source_entropy())
+    assert code.efficiency() == pytest.approx(code.source_entropy() / code.rate())
+
+
+def test_properties_require_distribution():
+    """Rate-based properties need a source distribution."""
+    from dit.coding import SymbolCode
+
+    code = SymbolCode({"a": "0", "b": "1"})
+    with pytest.raises(ditException):
+        code.average_length()
+    with pytest.raises(ditException):
+        code.source_entropy()

--- a/tests/coding/test_channel.py
+++ b/tests/coding/test_channel.py
@@ -1,0 +1,60 @@
+"""
+Tests for the dit.coding channel helpers.
+"""
+
+import numpy as np
+import pytest
+
+from dit.algorithms import channel_capacity
+from dit.coding import binary_erasure_channel, binary_symmetric_channel
+from dit.coding._channel import bhattacharyya, channel_arrays, log_likelihoods
+
+
+def test_bsc_arrays():
+    """The BSC transition matrix matches its definition."""
+    inputs, outputs, P = channel_arrays(binary_symmetric_channel(0.1))
+    assert list(inputs) == [0, 1]
+    assert list(outputs) == [0, 1]
+    assert pytest.approx(np.array([[0.9, 0.1], [0.1, 0.9]])) == P
+
+
+def test_bec_arrays():
+    """The BEC has a three-symbol output alphabet with an erasure column."""
+    inputs, outputs, P = channel_arrays(binary_erasure_channel(0.2))
+    assert list(inputs) == [0, 1]
+    assert list(outputs) == [0, 1, 2]
+    assert pytest.approx(np.array([[0.8, 0.0, 0.2], [0.0, 0.8, 0.2]])) == P
+
+
+def test_bsc_capacity():
+    """The BSC capacity matches 1 - H(p)."""
+    p = 0.11
+    cap, _ = channel_capacity(binary_symmetric_channel(p))
+    expected = 1 + p * np.log2(p) + (1 - p) * np.log2(1 - p)
+    assert cap == pytest.approx(expected)
+
+
+def test_bec_capacity():
+    """The BEC capacity matches 1 - epsilon."""
+    eps = 0.25
+    cap, _ = channel_capacity(binary_erasure_channel(eps))
+    assert cap == pytest.approx(1 - eps)
+
+
+def test_log_likelihoods_symmetry():
+    """The BSC log-likelihood ratios are symmetric and opposite-signed."""
+    llr = log_likelihoods(binary_symmetric_channel(0.1))
+    assert llr[0] == pytest.approx(-llr[1])
+    assert llr[0] > 0
+
+
+def test_bec_erasure_llr_zero():
+    """An erasure carries no information (zero LLR)."""
+    llr = log_likelihoods(binary_erasure_channel(0.2))
+    assert llr[2] == pytest.approx(0.0)
+
+
+def test_bhattacharyya_bsc():
+    """The Bhattacharyya parameter of a BSC is 2 sqrt(p(1-p))."""
+    p = 0.1
+    assert bhattacharyya(binary_symmetric_channel(p)) == pytest.approx(2 * np.sqrt(p * (1 - p)))

--- a/tests/coding/test_channel_codes.py
+++ b/tests/coding/test_channel_codes.py
@@ -1,0 +1,146 @@
+"""
+Tests for dit.coding LDPC, polar, and convolutional codes.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+
+from dit.coding import (
+    LDPCCode,
+    binary_erasure_channel,
+    binary_symmetric_channel,
+    convolutional,
+    gallager,
+    hamming,
+    polar,
+)
+from dit.exceptions import ditException
+
+# ── LDPC ─────────────────────────────────────────────────────────────────
+
+
+def test_ldpc_noiseless_roundtrip():
+    """Belief propagation recovers every codeword in the noiseless limit."""
+    code = LDPCCode(hamming(3).H)
+    channel = binary_symmetric_channel(0.01)
+    for message in itertools.product((0, 1), repeat=code.message_length):
+        codeword = code.encode(message)
+        assert tuple(code.decode(codeword, channel=channel)) == message
+
+
+def test_ldpc_error_rate_increases_with_noise():
+    """A sparse Gallager code has a higher error rate at higher noise."""
+    code = gallager(20, 3, 5, prng=np.random.default_rng(0))
+    low = code.probability_of_error(
+        binary_symmetric_channel(0.01),
+        method="montecarlo",
+        samples=1000,
+        prng=np.random.default_rng(1),
+    )
+    high = code.probability_of_error(
+        binary_symmetric_channel(0.1),
+        method="montecarlo",
+        samples=1000,
+        prng=np.random.default_rng(2),
+    )
+    assert low < high
+
+
+def test_gallager_shape():
+    """The Gallager construction produces the expected parity-check shape."""
+    code = gallager(12, 2, 4, prng=np.random.default_rng(0))
+    assert code.H.shape == (6, 12)
+    assert all(code.H.sum(axis=1) == 4)  # row weight wr
+    assert all(code.H.sum(axis=0) == 2)  # column weight wc
+
+
+def test_gallager_requires_divisibility():
+    """An incompatible (n, wr) raises."""
+    with pytest.raises(ditException):
+        gallager(10, 2, 4)
+
+
+# ── polar ────────────────────────────────────────────────────────────────
+
+
+def test_polar_frozen_set_size():
+    """A polar code freezes exactly n - k bit-channels."""
+    code = polar(8, 4, binary_erasure_channel(0.3))
+    assert int(code.frozen.sum()) == 8 - 4
+    assert code.message_length == 4
+
+
+def test_polar_noiseless_roundtrip():
+    """Successive cancellation recovers messages over a near-perfect channel."""
+    code = polar(8, 4, binary_erasure_channel(0.3))
+    clean = binary_erasure_channel(1e-9)
+    for message in itertools.product((0, 1), repeat=4):
+        assert tuple(code.decode(code.encode(message), channel=clean)) == message
+
+
+def test_polar_error_rate_increases_with_erasure():
+    """The polar block-error probability grows with the erasure rate."""
+    code = polar(8, 4, binary_erasure_channel(0.3))
+    low = code.probability_of_error(
+        binary_erasure_channel(0.1),
+        method="montecarlo",
+        samples=3000,
+        prng=np.random.default_rng(0),
+    )
+    high = code.probability_of_error(
+        binary_erasure_channel(0.5),
+        method="montecarlo",
+        samples=3000,
+        prng=np.random.default_rng(1),
+    )
+    assert low < high
+
+
+def test_polar_requires_power_of_two():
+    """A non-power-of-two length raises."""
+    with pytest.raises(ditException):
+        polar(6, 3, binary_erasure_channel(0.3))
+
+
+# ── convolutional ──────────────────────────────────────────────────────────
+
+
+def test_convolutional_parameters():
+    """The (7, 5) code is rate 1/2 with constraint length 3."""
+    code = convolutional((0o7, 0o5), message_length=5)
+    assert code.rate() == pytest.approx(0.5)
+    assert code.K == 3
+
+
+def test_convolutional_noiseless_roundtrip():
+    """Hard-decision Viterbi recovers every terminated message."""
+    code = convolutional((0o7, 0o5), message_length=5)
+    for message in itertools.product((0, 1), repeat=5):
+        assert code.decode(code.encode(message)) == list(message)
+
+
+def test_convolutional_corrects_single_error():
+    """The (7, 5) code corrects every single-bit error via Viterbi."""
+    code = convolutional((0o7, 0o5), message_length=5)
+    for message in itertools.product((0, 1), repeat=5):
+        codeword = code.encode(message)
+        for i in range(len(codeword)):
+            received = list(codeword)
+            received[i] ^= 1
+            assert code.decode(received) == list(message)
+
+
+def test_convolutional_soft_decoding():
+    """Soft-decision Viterbi recovers messages over a clean BSC."""
+    code = convolutional((0o7, 0o5), message_length=5)
+    channel = binary_symmetric_channel(1e-6)
+    for message in itertools.product((0, 1), repeat=5):
+        assert code.decode(code.encode(message), channel=channel) == list(message)
+
+
+def test_convolutional_requires_two_generators():
+    """A single generator raises."""
+    with pytest.raises(ditException):
+        convolutional((0o7,), message_length=4)

--- a/tests/coding/test_golomb.py
+++ b/tests/coding/test_golomb.py
@@ -1,0 +1,76 @@
+"""
+Tests for dit.coding Golomb and Rice codes.
+"""
+
+import pytest
+
+from dit import Distribution as D
+from dit.coding import golomb, rice
+from dit.exceptions import ditException
+
+
+def geometric(theta, n):
+    """A truncated geometric distribution over 0..n-1."""
+    ps = [(1 - theta) * theta**k for k in range(n)]
+    total = sum(ps)
+    return D(list(range(n)), [p / total for p in ps])
+
+
+def test_golomb_roundtrip():
+    """Golomb codes recover the source sequence."""
+    d = geometric(0.6, 12)
+    code = golomb(d)
+    outcomes = d.outcomes
+    seq = [outcomes[i] for i in [0, 3, 1, 5, 2, 0, 8]]
+    assert code.decode(code.encode(seq)) == seq
+
+
+def test_golomb_prefix_free():
+    """Golomb codes are prefix-free."""
+    assert golomb(geometric(0.5, 16)).is_prefix_free()
+
+
+def test_golomb_optimal_on_dyadic_geometric():
+    """For theta=1/2 the optimal Golomb code achieves the entropy."""
+    d = geometric(0.5, 16)
+    code = golomb(d)
+    # Equality holds for the untruncated geometric; truncation leaves a tiny gap.
+    assert code.average_length() == pytest.approx(code.source_entropy(), abs=1e-3)
+
+
+def test_golomb_m_one_is_unary():
+    """Golomb with m=1 is the unary code on the integers."""
+    d = geometric(0.3, 6)
+    code = golomb(d, m=1)
+    assert code.codebook[0] == "0"
+    assert code.codebook[1] == "10"
+    assert code.codebook[3] == "1110"
+
+
+def test_rice_roundtrip():
+    """Rice codes recover the source sequence."""
+    d = geometric(0.7, 12)
+    code = rice(d)
+    outcomes = d.outcomes
+    seq = [outcomes[i] for i in [0, 2, 4, 1, 6]]
+    assert code.decode(code.encode(seq)) == seq
+
+
+def test_rice_is_power_of_two_golomb():
+    """Rice with parameter k equals Golomb with m=2**k."""
+    d = geometric(0.6, 12)
+    assert rice(d, k=2).codebook == golomb(d, m=4).codebook
+
+
+def test_golomb_requires_integers():
+    """Non-integer outcomes are rejected."""
+    d = D(["a", "b"], [0.5, 0.5])
+    with pytest.raises(ditException):
+        golomb(d)
+
+
+def test_golomb_binary_only():
+    """Golomb coding is binary."""
+    d = geometric(0.5, 8)
+    with pytest.raises(ditException):
+        golomb(d, radix=3)

--- a/tests/coding/test_linear.py
+++ b/tests/coding/test_linear.py
@@ -1,0 +1,115 @@
+"""
+Tests for dit.coding linear block codes and the evaluation layer.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+
+from dit.coding import (
+    binary_symmetric_channel,
+    golay,
+    hamming,
+    parity_check,
+    reed_muller,
+    repetition,
+)
+from dit.exceptions import ditException
+
+
+def test_repetition_parameters():
+    """The [n, 1, n] repetition code has the expected parameters."""
+    code = repetition(5)
+    assert code.length == 5
+    assert code.dimension == 1
+    assert code.minimum_distance() == 5
+    assert code.rate() == pytest.approx(1 / 5)
+
+
+def test_parity_check_parameters():
+    """The single-parity-check code has minimum distance 2."""
+    code = parity_check(4)
+    assert code.length == 5
+    assert code.dimension == 4
+    assert code.minimum_distance() == 2
+
+
+def test_hamming_parameters():
+    """The Hamming [7, 4] code has minimum distance 3 and corrects one error."""
+    code = hamming(3)
+    assert (code.length, code.dimension) == (7, 4)
+    assert code.minimum_distance() == 3
+    assert code.error_correcting_capability() == 1
+
+
+def test_hamming_corrects_every_single_error():
+    """Hard-decision decoding corrects every single-bit error."""
+    code = hamming(3)
+    for message in itertools.product((0, 1), repeat=4):
+        codeword = code.encode(message)
+        for i in range(7):
+            received = list(codeword)
+            received[i] ^= 1
+            assert tuple(code.decode(received)) == message
+
+
+def test_reed_muller_parameters():
+    """RM(1, 3) is the [8, 4, 4] first-order Reed-Muller code."""
+    code = reed_muller(1, 3)
+    assert (code.length, code.dimension) == (8, 4)
+    assert code.minimum_distance() == 4
+
+
+def test_golay_minimum_distances():
+    """The Golay codes have the textbook minimum distances."""
+    assert golay().minimum_distance() == 7
+    assert golay(extended=True).minimum_distance() == 8
+
+
+def test_encode_decode_roundtrip_noiseless():
+    """Every message round-trips through encode/decode without noise."""
+    code = hamming(3)
+    for message in itertools.product((0, 1), repeat=4):
+        assert tuple(code.decode(code.encode(message))) == message
+
+
+def test_weight_enumerator():
+    """The Hamming weight enumerator sums to the number of codewords."""
+    code = hamming(3)
+    enumerator = code.weight_enumerator()
+    assert sum(enumerator.values()) == 2**4
+    assert enumerator[0] == 1
+
+
+def test_capacity_gap_positive_below_capacity():
+    """A low-rate code over a clean-ish BSC operates below capacity."""
+    code = repetition(3)
+    gap = code.capacity_gap(binary_symmetric_channel(0.05))
+    assert gap > 0
+
+
+def test_probability_of_error_matches_closed_form():
+    """Hamming over a BSC matches the closed-form block-error probability."""
+    code = hamming(3)
+    p = 0.05
+    pe = code.probability_of_error(binary_symmetric_channel(p), method="exact")
+    closed = 1 - (1 - p) ** 7 - 7 * p * (1 - p) ** 6
+    assert pe == pytest.approx(closed)
+
+
+def test_probability_of_error_montecarlo_close_to_exact():
+    """Monte Carlo block-error probability tracks the exact value."""
+    code = hamming(3)
+    channel = binary_symmetric_channel(0.05)
+    exact = code.probability_of_error(channel, method="exact")
+    mc = code.probability_of_error(channel, method="montecarlo", samples=20000, prng=np.random.default_rng(0))
+    assert mc == pytest.approx(exact, abs=0.02)
+
+
+def test_intractable_enumeration_raises():
+    """Enumerating codewords for a large code raises a clear error."""
+    code = repetition(3)
+    code.k = 25  # force the guard
+    with pytest.raises(ditException):
+        code.minimum_distance()

--- a/tests/coding/test_symbol_codes.py
+++ b/tests/coding/test_symbol_codes.py
@@ -1,0 +1,178 @@
+"""
+Tests for dit.coding symbol codes.
+"""
+
+import pytest
+
+from dit import Distribution as D
+from dit.coding import (
+    SymbolCode,
+    fano,
+    huffman,
+    length_limited_huffman,
+    shannon,
+    shannon_fano_elias,
+)
+from dit.exceptions import ditException
+
+CONSTRUCTORS = [shannon, fano, shannon_fano_elias, huffman]
+
+
+def uniform(n):
+    """A uniform distribution over n integer outcomes."""
+    return D(list(range(n)), [1 / n] * n)
+
+
+def skewed():
+    """A fixed skewed distribution."""
+    return D(list(range(5)), [0.4, 0.2, 0.2, 0.1, 0.1])
+
+
+@pytest.mark.parametrize("construct", CONSTRUCTORS)
+def test_roundtrip(construct):
+    """Every symbol code recovers the source sequence."""
+    d = skewed()
+    code = construct(d)
+    outcomes = d.outcomes
+    seq = [outcomes[i] for i in [0, 1, 2, 3, 4, 0, 1, 0, 4, 2]]
+    assert code.decode(code.encode(seq)) == seq
+
+
+@pytest.mark.parametrize("construct", CONSTRUCTORS)
+def test_prefix_free_and_uniquely_decodable(construct):
+    """Every symbol code constructed here is prefix-free (hence UD)."""
+    code = construct(skewed())
+    assert code.is_prefix_free()
+    assert code.is_uniquely_decodable()
+
+
+@pytest.mark.parametrize("construct", CONSTRUCTORS)
+def test_kraft_inequality(construct):
+    """The Kraft sum is at most 1."""
+    code = construct(skewed())
+    assert code.kraft_sum() <= 1 + 1e-9
+
+
+@pytest.mark.parametrize("n", range(2, 9))
+def test_shannon_entropy_bound(n):
+    """Shannon coding satisfies H <= L < H + 1."""
+    d = uniform(n)
+    code = shannon(d)
+    H = code.source_entropy()
+    L = code.average_length()
+    assert H <= L + 1e-9
+    assert L < H + 1
+
+
+def test_huffman_optimal():
+    """Huffman is optimal; Shannon and Elias are not better."""
+    d = skewed()
+    h = huffman(d)
+    assert h.is_optimal()
+    assert h.average_length() <= shannon(d).average_length() + 1e-9
+    assert h.average_length() <= shannon_fano_elias(d).average_length() + 1e-9
+
+
+def test_huffman_is_complete():
+    """A binary Huffman code is complete."""
+    assert huffman(skewed()).is_complete()
+
+
+def test_huffman_cover_thomas_5_1():
+    """Cover & Thomas Example 5.1 pins exact Huffman lengths and length 2.3."""
+    d = D(list(range(5)), [0.25, 0.25, 0.2, 0.15, 0.15])
+    h = huffman(d)
+    lengths = sorted(len(w) for w in h.codebook.values())
+    assert lengths == [2, 2, 2, 3, 3]
+    assert h.average_length() == pytest.approx(2.3)
+
+
+@pytest.mark.parametrize("radix", [2, 3, 4])
+def test_huffman_radix(radix):
+    """D-ary Huffman is prefix-free and complete-ish under Kraft."""
+    d = D(list(range(7)), [0.3, 0.2, 0.15, 0.12, 0.1, 0.08, 0.05])
+    h = huffman(d, radix=radix)
+    assert h.is_prefix_free()
+    assert h.kraft_sum() <= 1 + 1e-9
+
+
+def test_radix_efficiency():
+    """Efficiency is the ratio of entropy to rate, in (0, 1]."""
+    code = huffman(skewed())
+    assert code.efficiency() == pytest.approx(code.source_entropy() / code.rate())
+    assert 0 < code.efficiency() <= 1 + 1e-9
+
+
+def test_length_limited_respects_bound():
+    """Length-limited Huffman never exceeds the max length."""
+    d = D(list(range(8)), [0.5, 0.2, 0.1, 0.08, 0.05, 0.03, 0.02, 0.02])
+    code = length_limited_huffman(d, max_length=4)
+    assert max(len(w) for w in code.codebook.values()) <= 4
+    assert code.is_prefix_free()
+
+
+def test_length_limited_matches_huffman_when_unconstrained():
+    """With a generous bound, length-limited Huffman equals Huffman."""
+    d = skewed()
+    relaxed = length_limited_huffman(d, max_length=10)
+    assert relaxed.average_length() == pytest.approx(huffman(d).average_length())
+
+
+def test_length_limited_infeasible():
+    """Too small a bound is rejected."""
+    d = uniform(8)
+    with pytest.raises(ditException):
+        length_limited_huffman(d, max_length=2)
+
+
+@pytest.mark.parametrize("construct", CONSTRUCTORS)
+def test_single_outcome(construct):
+    """A degenerate one-outcome source gets a length-1 codeword."""
+    d = D([0], [1.0])
+    code = construct(d)
+    assert len(code.codebook) == 1
+    word = next(iter(code.codebook.values()))
+    assert len(word) == 1
+    out = d.outcomes
+    assert code.decode(code.encode([out[0], out[0]])) == [out[0], out[0]]
+
+
+@pytest.mark.parametrize("construct", CONSTRUCTORS)
+def test_log_base_distribution(construct):
+    """Codes built from a log-space distribution match the linear ones."""
+    d = skewed()
+    dlog = d.copy()
+    dlog.set_base(2)
+    code = construct(dlog)
+    assert code.average_length() == pytest.approx(construct(d).average_length())
+
+
+def test_sardinas_patterson():
+    """Sardinas-Patterson distinguishes UD from non-UD codes."""
+    # Uniquely decodable but not prefix-free.
+    ud = SymbolCode({"a": "0", "b": "01", "c": "011"})
+    assert ud.is_uniquely_decodable()
+    assert not ud.is_prefix_free()
+    # A classic non-uniquely-decodable code.
+    not_ud = SymbolCode({"a": "0", "b": "010", "c": "01", "d": "10"})
+    assert not not_ud.is_uniquely_decodable()
+
+
+def test_singular_code_rejected():
+    """Repeated codewords make the code singular."""
+    with pytest.raises(ditException):
+        SymbolCode({"a": "0", "b": "0"})
+
+
+def test_decode_requires_prefix_free():
+    """Decoding a non-prefix-free code raises."""
+    code = SymbolCode({"a": "0", "b": "01", "c": "011"})
+    with pytest.raises(ditException):
+        code.decode("0011")
+
+
+def test_encode_unknown_outcome():
+    """Encoding an unknown outcome raises."""
+    code = huffman(skewed())
+    with pytest.raises(ditException):
+        code.encode(["not-an-outcome"])

--- a/tests/coding/test_tunstall.py
+++ b/tests/coding/test_tunstall.py
@@ -1,0 +1,63 @@
+"""
+Tests for dit.coding Tunstall (variable-to-fixed) codes.
+"""
+
+import pytest
+
+from dit import Distribution as D
+from dit.coding import TunstallCode, tunstall
+from dit.exceptions import ditException
+
+
+def binary_source(p=0.7):
+    return D(["a", "b"], [p, 1 - p])
+
+
+@pytest.mark.parametrize("code_length", [1, 2, 3, 4])
+def test_leaf_count(code_length):
+    """The dictionary fills up to radix ** code_length words."""
+    code = tunstall(binary_source(), code_length=code_length)
+    assert len(code.word_to_code) <= 2**code_length
+    # Each codeword has exactly code_length symbols.
+    assert all(len(w) == code_length for w in code.word_to_code.values())
+
+
+def test_roundtrip():
+    """A sequence of complete words is recovered exactly."""
+    code = tunstall(binary_source(), code_length=3)
+    source = [symbol for word in code.word_to_code for symbol in word]
+    assert code.decode(code.encode(source)) == source
+
+
+def test_rate_approaches_entropy():
+    """Longer codewords drive the rate toward the source entropy."""
+    d = binary_source(0.8)
+    coarse = tunstall(d, code_length=2)
+    fine = tunstall(d, code_length=6)
+    H = coarse.source_entropy()
+    assert fine.rate() >= H - 1e-9
+    assert fine.rate() <= coarse.rate() + 1e-9
+
+
+def test_partial_word_rejected():
+    """A source ending mid-word cannot be encoded."""
+    code = tunstall(binary_source(), code_length=3)
+    # Find the longest word and feed a strict prefix of it.
+    longest = max(code.word_to_code, key=len)
+    if len(longest) > 1:
+        with pytest.raises(ditException):
+            code.encode(list(longest[:-1]))
+
+
+def test_code_length_too_small():
+    """An alphabet larger than the dictionary capacity is rejected."""
+    d = D(list(range(4)), [0.25] * 4)
+    with pytest.raises(ditException):
+        tunstall(d, code_length=1)
+
+
+def test_is_source_coding():
+    """TunstallCode exposes the SourceCoding interface."""
+    code = tunstall(binary_source(), code_length=3)
+    assert isinstance(code, TunstallCode)
+    assert code.redundancy() == pytest.approx(code.rate() - code.source_entropy())

--- a/tests/coding/test_universal.py
+++ b/tests/coding/test_universal.py
@@ -1,0 +1,74 @@
+"""
+Tests for dit.coding universal integer codes.
+"""
+
+import pytest
+
+from dit import Distribution as D
+from dit.coding import (
+    elias_delta,
+    elias_gamma,
+    elias_omega,
+    fibonacci,
+    unary,
+    universal_code,
+)
+from dit.exceptions import ditException
+
+KINDS = ["unary", "gamma", "delta", "omega", "fibonacci"]
+
+
+def test_unary():
+    assert unary(1) == "0"
+    assert unary(2) == "10"
+    assert unary(4) == "1110"
+
+
+def test_elias_gamma():
+    assert elias_gamma(1) == "1"
+    assert elias_gamma(2) == "010"
+    assert elias_gamma(3) == "011"
+    assert elias_gamma(4) == "00100"
+
+
+def test_elias_delta():
+    assert elias_delta(1) == "1"
+    assert elias_delta(2) == "0100"
+    assert elias_delta(4) == "01100"
+
+
+def test_elias_omega():
+    assert elias_omega(1) == "0"
+    assert elias_omega(2) == "100"
+    assert elias_omega(4) == "101000"
+
+
+def test_fibonacci():
+    assert fibonacci(1) == "11"
+    assert fibonacci(2) == "011"
+    assert fibonacci(3) == "0011"
+    assert fibonacci(4) == "1011"
+
+
+@pytest.mark.parametrize("code", [unary, elias_gamma, elias_delta, elias_omega, fibonacci])
+def test_integer_codes_positive_only(code):
+    """Universal integer codes reject non-positive integers."""
+    with pytest.raises(ditException):
+        code(0)
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_universal_code_roundtrip(kind):
+    """Universal codes recover the source sequence and are prefix-free."""
+    d = D(list(range(1, 9)), [1 / 8] * 8)
+    code = universal_code(d, kind=kind)
+    outcomes = d.outcomes
+    seq = [outcomes[i] for i in [0, 4, 2, 7, 1]]
+    assert code.is_prefix_free()
+    assert code.decode(code.encode(seq)) == seq
+
+
+def test_universal_code_unknown_kind():
+    d = D(list(range(1, 4)), [1 / 3] * 3)
+    with pytest.raises(ditException):
+        universal_code(d, kind="nope")

--- a/tests/example_channels/test_binary.py
+++ b/tests/example_channels/test_binary.py
@@ -1,0 +1,100 @@
+"""
+Tests for the binary example channels.
+"""
+
+from math import log2
+
+import numpy as np
+import pytest
+
+from dit.algorithms import channel_capacity
+from dit.coding._channel import channel_arrays
+from dit.example_channels import (
+    binary_asymmetric_channel,
+    binary_erasure_channel,
+    binary_symmetric_channel,
+    binary_symmetric_erasure_channel,
+    z_channel,
+)
+from dit.exceptions import ditException
+
+
+def _binary_entropy(p):
+    if p in (0, 1):
+        return 0.0
+    return -p * log2(p) - (1 - p) * log2(1 - p)
+
+
+def test_bsc_is_conditional():
+    """The BSC is a conditional distribution p(Y|X)."""
+    assert binary_symmetric_channel(0.1).is_conditional()
+
+
+def test_bsc_matrix():
+    """The BSC transition matrix matches its definition."""
+    inputs, outputs, P = channel_arrays(binary_symmetric_channel(0.1))
+    assert list(inputs) == [0, 1]
+    assert list(outputs) == [0, 1]
+    assert np.allclose(P, [[0.9, 0.1], [0.1, 0.9]])
+
+
+def test_bsc_capacity():
+    """The BSC capacity is 1 - H(p)."""
+    cap, _ = channel_capacity(binary_symmetric_channel(0.11))
+    assert cap == pytest.approx(1 - _binary_entropy(0.11))
+
+
+def test_bec_matrix_and_capacity():
+    """The BEC has an erasure column and capacity 1 - epsilon."""
+    inputs, outputs, P = channel_arrays(binary_erasure_channel(0.2))
+    assert list(outputs) == [0, 1, 2]
+    assert np.allclose(P, [[0.8, 0.0, 0.2], [0.0, 0.8, 0.2]])
+    cap, _ = channel_capacity(binary_erasure_channel(0.25))
+    assert cap == pytest.approx(0.75)
+
+
+def test_z_channel_matrix():
+    """The Z-channel passes 0 perfectly and flips 1 with probability p."""
+    _, _, P = channel_arrays(z_channel(0.3))
+    assert np.allclose(P, [[1.0, 0.0], [0.3, 0.7]])
+
+
+def test_z_channel_capacity_bounds():
+    """The Z-channel capacity lies strictly between the useless and noiseless limits."""
+    cap, _ = channel_capacity(z_channel(0.3))
+    assert 0 < cap < 1
+
+
+def test_binary_asymmetric_matrix():
+    """The binary asymmetric channel matches its two crossover probabilities."""
+    _, _, P = channel_arrays(binary_asymmetric_channel(0.1, 0.2))
+    assert np.allclose(P, [[0.9, 0.1], [0.2, 0.8]])
+
+
+def test_bac_specializes_to_bsc():
+    """A symmetric binary asymmetric channel equals the BSC."""
+    _, _, P_bac = channel_arrays(binary_asymmetric_channel(0.15, 0.15))
+    _, _, P_bsc = channel_arrays(binary_symmetric_channel(0.15))
+    assert np.allclose(P_bac, P_bsc)
+
+
+def test_bsec_matrix():
+    """The error-and-erasure channel matches its definition."""
+    _, outputs, P = channel_arrays(binary_symmetric_erasure_channel(0.1, 0.2))
+    assert list(outputs) == [0, 1, 2]
+    assert np.allclose(P, [[0.7, 0.1, 0.2], [0.1, 0.7, 0.2]])
+
+
+def test_bsec_capacity_between_bsc_and_bec():
+    """Adding erasures on top of errors lowers capacity below the pure BSC."""
+    cap_bsec, _ = channel_capacity(binary_symmetric_erasure_channel(0.1, 0.2))
+    cap_bsc, _ = channel_capacity(binary_symmetric_channel(0.1))
+    assert 0 < cap_bsec < cap_bsc
+
+
+def test_invalid_parameters_raise():
+    """Out-of-range parameters raise."""
+    with pytest.raises(ditException):
+        binary_symmetric_channel(1.5)
+    with pytest.raises(ditException):
+        binary_symmetric_erasure_channel(0.6, 0.6)

--- a/tests/example_channels/test_qary.py
+++ b/tests/example_channels/test_qary.py
@@ -1,0 +1,91 @@
+"""
+Tests for the q-ary example channels.
+"""
+
+from math import log2
+
+import numpy as np
+import pytest
+
+from dit.algorithms import channel_capacity
+from dit.coding._channel import channel_arrays
+from dit.example_channels import (
+    binary_erasure_channel,
+    binary_symmetric_channel,
+    noisy_typewriter,
+    q_ary_erasure_channel,
+    q_ary_symmetric_channel,
+)
+from dit.exceptions import ditException
+
+
+def _binary_entropy(p):
+    if p in (0, 1):
+        return 0.0
+    return -p * log2(p) - (1 - p) * log2(1 - p)
+
+
+def test_qsc_row():
+    """Each q-ary symmetric row keeps 1-p on the diagonal and spreads p evenly."""
+    _, _, P = channel_arrays(q_ary_symmetric_channel(4, 0.3))
+    assert np.allclose(P[0], [0.7, 0.1, 0.1, 0.1])
+
+
+def test_qsc_capacity():
+    """The q-ary symmetric capacity matches the closed form."""
+    cap, _ = channel_capacity(q_ary_symmetric_channel(4, 0.3))
+    expected = log2(4) - _binary_entropy(0.3) - 0.3 * log2(3)
+    assert cap == pytest.approx(expected)
+
+
+def test_qsc_specializes_to_bsc():
+    """The q=2 symmetric channel equals the BSC."""
+    _, _, P_q = channel_arrays(q_ary_symmetric_channel(2, 0.2))
+    _, _, P_b = channel_arrays(binary_symmetric_channel(0.2))
+    assert np.allclose(P_q, P_b)
+
+
+def test_qec_outputs_and_capacity():
+    """The q-ary erasure channel has an erasure symbol q and capacity (1-eps) log q."""
+    _, outputs, P = channel_arrays(q_ary_erasure_channel(4, 0.25))
+    assert list(outputs) == [0, 1, 2, 3, 4]
+    assert np.allclose(P[0], [0.75, 0, 0, 0, 0.25])
+    cap, _ = channel_capacity(q_ary_erasure_channel(4, 0.25))
+    assert cap == pytest.approx(0.75 * log2(4))
+
+
+def test_qec_specializes_to_bec():
+    """The q=2 erasure channel equals the BEC."""
+    _, _, P_q = channel_arrays(q_ary_erasure_channel(2, 0.2))
+    _, _, P_b = channel_arrays(binary_erasure_channel(0.2))
+    assert np.allclose(P_q, P_b)
+
+
+def test_noisy_typewriter_matrix():
+    """Each typewriter letter maps to itself or the next, each with probability 1/2."""
+    _, _, P = channel_arrays(noisy_typewriter(4))
+    assert np.allclose(
+        P,
+        [
+            [0.5, 0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.5, 0.0],
+            [0.0, 0.0, 0.5, 0.5],
+            [0.5, 0.0, 0.0, 0.5],
+        ],
+    )
+
+
+def test_noisy_typewriter_capacity():
+    """The noisy typewriter capacity is log2(n/2)."""
+    cap, _ = channel_capacity(noisy_typewriter(6))
+    assert cap == pytest.approx(log2(6 / 2))
+
+
+def test_invalid_parameters_raise():
+    """Bad alphabet sizes or probabilities raise."""
+    with pytest.raises(ditException):
+        q_ary_symmetric_channel(1, 0.1)
+    with pytest.raises(ditException):
+        q_ary_erasure_channel(4, 1.5)
+    with pytest.raises(ditException):
+        noisy_typewriter(1)

--- a/tests/example_channels/test_trivial.py
+++ b/tests/example_channels/test_trivial.py
@@ -1,0 +1,51 @@
+"""
+Tests for the trivial endpoint channels and back-compatibility.
+"""
+
+from math import log2
+
+import numpy as np
+import pytest
+
+from dit.algorithms import channel_capacity
+from dit.coding._channel import channel_arrays
+from dit.example_channels import identity_channel, useless_channel
+from dit.exceptions import ditException
+
+
+def test_identity_matrix_and_capacity():
+    """The identity channel is the identity matrix with capacity log2(n)."""
+    _, _, P = channel_arrays(identity_channel(4))
+    assert np.allclose(P, np.eye(4))
+    cap, _ = channel_capacity(identity_channel(4))
+    assert cap == pytest.approx(log2(4))
+
+
+def test_useless_matrix_and_capacity():
+    """The useless channel has a uniform, input-independent output and zero capacity."""
+    _, _, P = channel_arrays(useless_channel(3))
+    assert np.allclose(P, np.full((3, 3), 1 / 3))
+    cap, _ = channel_capacity(useless_channel(3))
+    assert cap == pytest.approx(0.0, abs=1e-9)
+
+
+def test_invalid_size_raises():
+    """A non-positive alphabet size raises."""
+    with pytest.raises(ditException):
+        identity_channel(0)
+    with pytest.raises(ditException):
+        useless_channel(0)
+
+
+def test_backwards_compatible_imports():
+    """The BSC/BEC remain importable from dit.coding after relocation."""
+    from dit.coding import binary_erasure_channel, binary_symmetric_channel
+    from dit.example_channels import (
+        binary_erasure_channel as bec,
+    )
+    from dit.example_channels import (
+        binary_symmetric_channel as bsc,
+    )
+
+    assert binary_symmetric_channel is bsc
+    assert binary_erasure_channel is bec


### PR DESCRIPTION
## Summary

Adds a new `dit.coding` subpackage providing both source and channel codes built on top of `dit.Distribution`, along with their information-theoretic properties.

**Source coding** — `SourceCoding` base plus:
- Symbol codes: `shannon`, `fano`, `shannon_fano_elias`, `huffman`, `length_limited_huffman` (package-merge), `golomb`/`rice`
- Universal integer codes: `unary`, `elias_gamma`, `elias_delta`, `elias_omega`, `fibonacci`
- `tunstall` (variable-to-fixed)
- Properties: rate, redundancy, efficiency, Kraft sum, completeness, prefix-free, unique decodability (Sardinas-Patterson), optimality

**Channel coding** — `ChannelCoding` base plus binary (GF(2)) codes:
- `LinearCode` core with syndrome + ML decoding, `minimum_distance`, `weight_enumerator`, `error_correcting_capability`
- Block constructors: `repetition`, `parity_check`, `hamming`, `reed_muller`, `golay` (`[23,12,7]` / extended `[24,12,8]`)
- `LDPCCode` (sum-product belief propagation) with `ldpc`/`gallager` constructors
- `PolarCode` (Bhattacharyya frozen-set selection + successive cancellation)
- `ConvolutionalCode` (Viterbi, hard and soft decision)

**Evaluation layer** — codes are evaluated against an arbitrary channel given as a conditional `Distribution` `p(Y|X)`:
- `capacity_gap(channel)` = `channel_capacity - rate`
- `probability_of_error(channel, method)` — exact enumeration for small codes, Monte Carlo otherwise
- Channel helpers: `binary_symmetric_channel`, `binary_erasure_channel`

GF(2) only; Reed-Solomon/BCH are out of scope. Brute-force `minimum_distance` / exact error probability are guarded to small codes (raise `ditException` otherwise). Polar construction is exact for the BEC and Bhattacharyya-approximate elsewhere.

## Test plan

- [ ] `pytest tests/coding/` (111 tests passing locally)
- [ ] Hamming `[7,4,3]` corrects every single error; exact block-error probability matches `1 - (1-p)^7 - 7p(1-p)^6`
- [ ] Golay distances 7/8; RM(1,3) = `[8,4,4]`; repetition/parity distances
- [ ] LDPC BP exact when noiseless; error rate monotone in noise
- [ ] Polar SC: frozen-set size `n-k`, exact noiseless roundtrip
- [ ] Convolutional `(7,5)`: corrects all single errors via Viterbi (hard and soft)
- [ ] Docs build (`docs/coding.rst`)

Made with [Cursor](https://cursor.com)