### PR TITLE
Fix exact common information optimizer on product landscapes.

### DIFF
--- a/dit/multivariate/common_informations/exact_common_information.py
+++ b/dit/multivariate/common_informations/exact_common_information.py
@@ -18,6 +18,8 @@ class ExactCommonInformation(MarkovVarOptimizer):
     render the X_i conditionally independent.
     """
 
+    _shotgun = 10
+
     name = "exact"
     description = "min H[V] where V renders all `rvs` independent"
 

--- a/tests/multivariate/common_informations/test_exact_common_information.py
+++ b/tests/multivariate/common_informations/test_exact_common_information.py
@@ -53,3 +53,11 @@ def test_eci2(i, x0):
     eci.optimize(x0=x0["x0"])
     x0["x0"] = eci._optima
     assert eci.objective(eci._optima) == pytest.approx(G_sbec(p), abs=1e-3)
+
+
+def test_eci_not_subadditive_under_product():
+    """
+    Kumar et al.: G(d ⊗ d) can be strictly less than 2 G(d) for independent pairs.
+    """
+    d = D(["00", "01", "10"], [1 / 3] * 3)
+    assert G(d @ d, [[0, 2], [1, 3]]) < 2 * G(d, [[0], [1]])


### PR DESCRIPTION
Enable shotgun multi-start on ExactCommonInformation to escape the local optimum at ~2·G(d), and add Kumar et al.'s subadditivity counterexample as a regression test.