### PR TITLE
Update dit self-references from master to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -359,7 +359,7 @@ If you'd like to get in contact about anything, you can reach us through our `sl
    :target: https://github.com/dit/dit/actions/workflows/build.yml
    :alt: Continuous Integration Status
 
-.. |codecov| image:: https://codecov.io/gh/dit/dit/branch/master/graph/badge.svg
+.. |codecov| image:: https://codecov.io/gh/dit/dit/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/dit/dit
    :alt: Test Coverage Status
 

--- a/site/src/MathJax/local/dit.js
+++ b/site/src/MathJax/local/dit.js
@@ -87,4 +87,4 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
 
 });
 
-MathJax.Ajax.loadComplete("https://raw.githubusercontent.com/dit/dit/master/site/src/MathJax/local/dit.js");
+MathJax.Ajax.loadComplete("https://raw.githubusercontent.com/dit/dit/main/site/src/MathJax/local/dit.js");


### PR DESCRIPTION
## Summary

- The default branch was renamed from `master` to `main`.
- Update the Codecov badge URL in `README.rst` to point at the `main` branch.
- Update the self-referential raw URL in `site/src/MathJax/local/dit.js` to point at `main`.

## Notes

Remaining `master` references in the repo are intentionally left unchanged: `docs/conf.py`'s `master_doc` (a Sphinx option, not a branch), the `.pylintrc` `[MASTER]` section header, and the empirical-dataset URLs in `penguins.py`/`titanic.py`/`corelli.py`, which point at other repositories.

Made with [Cursor](https://cursor.com)