### PR TITLE
Add Amari m-flat duals: Dual DD, m-projections, binding mixtures

### DIFF
--- a/dit/algorithms/__init__.py
+++ b/dit/algorithms/__init__.py
@@ -12,6 +12,17 @@ from .maxentropyfw import *
 from .minimal_sufficient_statistic import *
 from .optimization import *
 from .distribution_optimizers import *
+from .mixture_of_products import fit_mixture_of_products, mixture_of_products_dists
+from .marginal_lifts import fit_marginal_lift_mixture, lift_marginal, marginal_lift_dists
+from .mprojection import (
+    m_projection,
+    m_projection_eps_limit,
+    m_projection_from_subsets,
+    mflat_design_matrix,
+    mflat_mprojection_dists,
+    mflat_subsets_from_dependency,
+    symmetric_smooth,
+)
 from .prune_expand import expanded_samplespace, pruned_samplespace
 from .stats import (
     cdf,

--- a/dit/algorithms/marginal_lifts.py
+++ b/dit/algorithms/marginal_lifts.py
@@ -1,0 +1,182 @@
+"""
+Convex combinations of lifts of a joint's own marginals.
+
+At order :math:`k`, form building blocks
+
+.. math::
+
+    \\bigl\\{ U \\bigr\\} \\cup
+    \\bigl\\{ \\mathrm{Lift}(P_S) : 1 \\le |S| \\le k \\bigr\\}
+
+and fit nonnegative weights summing to one by least squares:
+
+.. math::
+
+    Q^{(k)} = \\arg\\min_{\\alpha \\ge 0,\\ \\sum \\alpha = 1}
+    \\bigl\\| P - \\textstyle\\sum_S \\alpha_S \\mathrm{Lift}(P_S) \\bigr\\|_2^2.
+
+Lifts:
+
+* ``uniform`` — :math:`P_S \\otimes U_{X \\setminus S}`
+* ``product`` — :math:`P_S \\otimes \\prod_{i \\notin S} P_i`
+"""
+
+from collections import defaultdict
+from copy import deepcopy
+from itertools import combinations, product
+
+import numpy as np
+from scipy.optimize import minimize
+
+from ..algorithms.optutil import prepare_dist
+from ..distribution import Distribution
+from ..exceptions import ditException
+
+__all__ = (
+    "lift_marginal",
+    "fit_marginal_lift_mixture",
+    "marginal_lift_dists",
+)
+
+
+def _cartesian(dist):
+    d = prepare_dist(deepcopy(dist))
+    n = d.outcome_length()
+    alph = [tuple(sorted({o[i] for o in d.outcomes})) for i in range(n)]
+    outs = list(product(*alph))
+    pmf_map = {tuple(o): float(p) for o, p in zip(d.outcomes, d.pmf, strict=True)}
+    pmf = np.array([pmf_map.get(o, 0.0) for o in outs], dtype=float)
+    pmf /= pmf.sum()
+    return outs, pmf, alph, d
+
+
+def lift_marginal(outs, pmf, alph, S, mode="uniform"):
+    """
+    Lift a marginal on coordinates ``S`` to a full joint pmf.
+
+    Parameters
+    ----------
+    outs, pmf, alph
+        Dense Cartesian table for the joint.
+    S : tuple of int
+        Variable indices of the marginal.
+    mode : {'uniform', 'product'}
+        How to extend off ``S``.
+    """
+    n = len(alph)
+    S = tuple(S)
+    marg = defaultdict(float)
+    for o, p in zip(outs, pmf, strict=True):
+        marg[tuple(o[i] for i in S)] += p
+    rest = [i for i in range(n) if i not in S]
+    if mode == "uniform":
+        rest_size = int(np.prod([len(alph[i]) for i in rest])) if rest else 1
+        return np.array([marg[tuple(o[i] for i in S)] / rest_size for o in outs], dtype=float)
+    if mode != "product":
+        msg = f"unknown lift mode {mode!r}"
+        raise ditException(msg)
+    ones = []
+    for i in range(n):
+        m1 = defaultdict(float)
+        for o, p in zip(outs, pmf, strict=True):
+            m1[o[i]] += p
+        ones.append(m1)
+    q = np.empty(len(outs), dtype=float)
+    for t, o in enumerate(outs):
+        val = marg[tuple(o[i] for i in S)]
+        for i in rest:
+            val *= ones[i][o[i]]
+        q[t] = val
+    return q / q.sum()
+
+
+def fit_marginal_lift_mixture(dist, order, mode="uniform", n_init=12, seed=0):
+    """
+    Fit a convex combination of lifts of marginals of order at most ``order``.
+
+    Returns
+    -------
+    result : dict
+        Keys ``dist``, ``labels``, ``alpha``, ``L2``.
+    """
+    if order < 0:
+        msg = "order must be nonnegative"
+        raise ditException(msg)
+    outs, pmf, alph, template = _cartesian(dist)
+    n = len(alph)
+    order = min(order, n)
+
+    blocks, labels = [], []
+    blocks.append(np.ones(len(outs)) / len(outs))
+    labels.append(())
+    for k in range(1, order + 1):
+        for S in combinations(range(n), k):
+            blocks.append(lift_marginal(outs, pmf, alph, S, mode=mode))
+            labels.append(S)
+    A = np.column_stack(blocks)
+    nb = A.shape[1]
+
+    def loss(x):
+        return float(np.sum((A @ x - pmf) ** 2))
+
+    cons = {"type": "eq", "fun": lambda x: float(x.sum() - 1.0)}
+    best = None
+    rng = np.random.default_rng(seed)
+    for _ in range(n_init):
+        x0 = rng.dirichlet(np.ones(nb))
+        res = minimize(
+            loss,
+            x0,
+            bounds=[(0.0, None)] * nb,
+            constraints=cons,
+            method="SLSQP",
+            options={"maxiter": 2000, "ftol": 1e-14, "disp": False},
+        )
+        if best is None or res.fun < best[0]:
+            best = (res.fun, res.x)
+
+    alpha = np.maximum(best[1], 0.0)
+    alpha = alpha / alpha.sum()
+    q = A @ alpha
+    q = np.maximum(q, 0.0)
+    q = q / q.sum()
+    qd = Distribution(outs, q, base="linear", validate=False)
+    qd.normalize()
+    if template.get_rv_names() is not None:
+        qd.set_rv_names(template.get_rv_names())
+    return {
+        "dist": qd,
+        "labels": labels,
+        "alpha": alpha,
+        "L2": float(np.sqrt(best[0])),
+    }
+
+
+def marginal_lift_dists(dist, k_max=None, mode="uniform", n_init=12, seed=0):
+    """
+    Ladder of marginal-lift mixtures for orders :math:`0,\\ldots,k_{\\max}`.
+
+    Order 0 is the uniform distribution. Order :math:`n` includes the full
+    joint as a block and recovers :math:`P` exactly.
+    """
+    n = dist.outcome_length()
+    if k_max is None:
+        k_max = n
+    k_max = min(int(k_max), n)
+
+    dists = []
+    metas = []
+    for k in range(0, k_max + 1):
+        if k == 0:
+            outs, _, _, template = _cartesian(dist)
+            q = Distribution(outs, np.ones(len(outs)) / len(outs), base="linear", validate=False)
+            q.normalize()
+            if template.get_rv_names() is not None:
+                q.set_rv_names(template.get_rv_names())
+            dists.append(q)
+            metas.append({"labels": [()], "alpha": np.array([1.0]), "L2": None})
+        else:
+            fit = fit_marginal_lift_mixture(dist, k, mode=mode, n_init=n_init, seed=seed + k)
+            dists.append(fit["dist"])
+            metas.append({key: fit[key] for key in ("labels", "alpha", "L2")})
+    return dists, metas

--- a/dit/algorithms/mixture_of_products.py
+++ b/dit/algorithms/mixture_of_products.py
@@ -1,0 +1,255 @@
+"""
+Mixtures of fully factorized distributions (latent-class / naive-Bayes).
+
+The family
+
+.. math::
+
+    \\mathcal{F}_k = \\Bigl\\{
+        Q : Q(x) = \\sum_{\\alpha=1}^{k} \\pi_\\alpha
+        \\prod_{i=1}^{n} Q_i(x_i \\mid \\alpha)
+    \\Bigr\\}
+
+is the standard representation underlying Wyner common information: variables
+are independent given a discrete latent of cardinality :math:`k`.  Maximum
+likelihood under :math:`P` is equivalent to the forward-KL projection
+
+.. math::
+
+    Q^{(k)} = \\arg\\min_{Q \\in \\mathcal{F}_k} D(P \\Vert Q)
+
+and is fit by EM.  No support jitter is required: :math:`Q` may place mass
+outside the support of a sparse :math:`P`.
+
+See Rosas et al. (2019) for the shared-randomness / binding interpretation of
+dual total correlation, and Wyner (1975) / Abdallah & Plumbley (2012) for the
+common-information side.
+"""
+
+from copy import deepcopy
+from itertools import product
+
+import numpy as np
+
+from ..distribution import Distribution
+from .optutil import prepare_dist
+
+__all__ = (
+    "fit_mixture_of_products",
+    "mixture_of_products_dists",
+)
+
+
+def _dense_table(dist):
+    """
+    Expand ``dist`` onto its Cartesian sample space.
+
+    Returns
+    -------
+    outcomes : list of tuple
+    pmf : ndarray, shape (n_outcomes,)
+    X : ndarray, shape (n_outcomes, n_vars), integer-coded symbols
+    sizes : list of int
+    """
+    d = prepare_dist(deepcopy(dist))
+    n = d.outcome_length()
+    alphabets = [tuple(sorted({o[i] for o in d.outcomes})) for i in range(n)]
+    outcomes = list(product(*alphabets))
+    pmf_map = {tuple(o): float(p) for o, p in zip(d.outcomes, d.pmf, strict=True)}
+    pmf = np.array([pmf_map.get(o, 0.0) for o in outcomes], dtype=float)
+    total = pmf.sum()
+    if total <= 0:
+        msg = "Distribution has no mass."
+        raise ValueError(msg)
+    pmf /= total
+    sym_index = [{s: j for j, s in enumerate(a)} for a in alphabets]
+    X = np.array([[sym_index[i][o[i]] for i in range(n)] for o in outcomes], dtype=int)
+    sizes = [len(a) for a in alphabets]
+    return outcomes, pmf, X, sizes
+
+
+def _component_logprob(pi, conds, X):
+    """Log joint component densities ``log(π_α ∏_i Q_i(x_i|α))``, shape (k, n_out)."""
+    log_comp = np.log(pi + 1e-300)[:, None]
+    for i, cond in enumerate(conds):
+        log_comp = log_comp + np.log(cond[:, X[:, i]] + 1e-300)
+    return log_comp
+
+
+def _em_once(pmf, X, sizes, k, *, max_iter, tol, rng):
+    """Single EM run. Returns (loglik, q_pmf, pi, conds, I_xv, H_v)."""
+    n_out, n = X.shape
+    pi = rng.dirichlet(np.ones(k))
+    conds = [rng.dirichlet(np.ones(s), size=k) for s in sizes]
+    prev_ll = -np.inf
+
+    for _ in range(max_iter):
+        log_comp = _component_logprob(pi, conds, X)
+        m = log_comp.max(axis=0, keepdims=True)
+        comp = np.exp(log_comp - m)
+        r = comp / (comp.sum(axis=0, keepdims=True) + 1e-300)
+
+        w = r * pmf[None, :]
+        pi = w.sum(axis=1)
+        pi = pi / (pi.sum() + 1e-300)
+
+        for i in range(n):
+            s = sizes[i]
+            c = np.zeros((k, s))
+            for a in range(k):
+                for v in range(s):
+                    c[a, v] = w[a, X[:, i] == v].sum()
+                c[a] /= c[a].sum() + 1e-300
+            conds[i] = c
+
+        log_comp = _component_logprob(pi, conds, X)
+        m = log_comp.max(axis=0)
+        ll = float(np.sum(pmf * (m + np.log(np.exp(log_comp - m).sum(axis=0) + 1e-300))))
+        if abs(ll - prev_ll) < tol:
+            break
+        prev_ll = ll
+
+    log_comp = _component_logprob(pi, conds, X)
+    m = log_comp.max(axis=0)
+    q = np.exp(m) * np.exp(log_comp - m).sum(axis=0)
+    q = q / q.sum()
+
+    # Responsibilities under the data for I(X; V).
+    m = log_comp.max(axis=0, keepdims=True)
+    r = np.exp(log_comp - m)
+    r = r / (r.sum(axis=0, keepdims=True) + 1e-300)
+    p_a = (r * pmf[None, :]).sum(axis=1)
+    p_a = p_a / (p_a.sum() + 1e-300)
+    hv = float(-np.sum(p_a[p_a > 0] * np.log2(p_a[p_a > 0])))
+    hv_x = 0.0
+    for t in range(n_out):
+        if pmf[t] <= 0:
+            continue
+        rt = r[:, t]
+        rt = rt[rt > 0]
+        hv_x += float(pmf[t] * (-np.sum(rt * np.log2(rt))))
+    ixv = hv - hv_x
+
+    return ll, q, pi, conds, float(ixv), hv
+
+
+def fit_mixture_of_products(
+    dist,
+    k,
+    *,
+    n_init=12,
+    max_iter=200,
+    tol=1e-10,
+    seed=0,
+):
+    """
+    Fit a :math:`k`-mixture of product distributions to ``dist`` by EM.
+
+    Parameters
+    ----------
+    dist : Distribution
+        Target joint.
+    k : int
+        Number of mixture components.
+    n_init, max_iter : int
+        Random restarts and EM iteration cap.
+    tol : float
+        Log-likelihood convergence tolerance.
+    seed : int
+        RNG seed for restarts.
+
+    Returns
+    -------
+    result : dict
+        Keys ``dist`` (fitted :class:`Distribution`), ``pi``, ``conds``,
+        ``I_xv`` (:math:`I(X;V)` under data-weighted responsibilities),
+        ``H_v``, ``loglik``.
+    """
+    if k < 1:
+        msg = "k must be >= 1"
+        raise ValueError(msg)
+
+    outcomes, pmf, X, sizes = _dense_table(dist)
+    rng = np.random.default_rng(seed)
+    best = None
+    for _ in range(n_init):
+        run_rng = np.random.default_rng(rng.integers(0, 2**31 - 1))
+        cand = _em_once(pmf, X, sizes, k, max_iter=max_iter, tol=tol, rng=run_rng)
+        if best is None or cand[0] > best[0]:
+            best = cand
+
+    ll, q_pmf, pi, conds, ixv, hv = best
+    q = Distribution(outcomes, q_pmf, base="linear", validate=False)
+    q.normalize()
+    return {
+        "dist": q,
+        "pi": pi,
+        "conds": conds,
+        "I_xv": ixv,
+        "H_v": hv,
+        "loglik": ll,
+    }
+
+
+def mixture_of_products_dists(
+    dist,
+    k_max=None,
+    *,
+    n_init=12,
+    max_iter=200,
+    tol=1e-10,
+    seed=0,
+    early_stop=True,
+    kl_tol=1e-8,
+):
+    """
+    Fit the mixture-of-products ladder :math:`Q^{(1)},\\ldots,Q^{(k_{\\max})}`.
+
+    Parameters
+    ----------
+    dist : Distribution
+    k_max : int or None
+        Maximum number of components.  Default ``min(8, |X|)``.
+    n_init, max_iter, tol, seed
+        Passed to :func:`fit_mixture_of_products` (seed offset by ``k``).
+    early_stop : bool
+        If True, stop once :math:`D(P\\Vert Q^{(k)}) <` ``kl_tol``.
+    kl_tol : float
+        Forward-KL threshold for early stopping.
+
+    Returns
+    -------
+    dists : list of Distribution
+        ``dists[k-1]`` is the MLE in :math:`\\mathcal{F}_k`.
+    meta : list of dict
+        Per-``k`` diagnostics (``I_xv``, ``H_v``, ``loglik``, ``pi``, ``conds``).
+    """
+    from ..divergences import kullback_leibler_divergence as D
+
+    outcomes, pmf, _, _ = _dense_table(dist)
+    p_dense = Distribution(outcomes, pmf, base="linear", validate=False)
+    p_dense.normalize()
+
+    if k_max is None:
+        k_max = min(8, len(outcomes))
+    k_max = max(1, int(k_max))
+
+    dists = []
+    meta = []
+    for k in range(1, k_max + 1):
+        fit = fit_mixture_of_products(
+            dist,
+            k,
+            n_init=n_init,
+            max_iter=max_iter,
+            tol=tol,
+            seed=seed + 17 * k,
+        )
+        dists.append(fit["dist"])
+        entry = {key: fit[key] for key in ("I_xv", "H_v", "loglik", "pi", "conds")}
+        entry["forward_kl"] = float(D(p_dense, fit["dist"]))
+        meta.append(entry)
+        if early_stop and entry["forward_kl"] < kl_tol:
+            break
+
+    return dists, meta

--- a/dit/algorithms/mprojection.py
+++ b/dit/algorithms/mprojection.py
@@ -1,0 +1,609 @@
+"""
+Amari m-flat hierarchy via reverse-KL m-projections.
+
+The e-flat (log-linear / MaxEnt) ladder matches k-way marginals and zeros
+higher-order natural parameters. Dually, the m-flat mixture hierarchy truncates
+the ANOVA / Hoeffding decomposition of the *probability mass function* itself:
+distributions in :math:`\\mathcal{M}_k` are exactly those writable as
+
+.. math::
+
+    Q(x) = \\sum_{|S| \\le k} h_S(x_S).
+
+The m-projection of :math:`P` onto :math:`\\mathcal{M}_k` is
+
+.. math::
+
+    Q^{(k)} = \\arg\\min_{Q \\in \\mathcal{M}_k} D_{\\mathrm{KL}}(Q \\Vert P).
+
+See Amari, "Information geometry on hierarchy of probability distributions"
+(IEEE TIT, 2001).
+"""
+
+from copy import deepcopy
+from itertools import combinations, product
+
+import numpy as np
+from scipy.optimize import minimize
+from scipy.special import xlogy
+
+from ..distribution import Distribution
+from ..exceptions import ditException
+from .optutil import prepare_dist
+
+__all__ = (
+    "m_projection",
+    "m_projection_from_subsets",
+    "m_projection_eps_limit",
+    "mflat_mprojection_dists",
+    "mflat_design_matrix",
+    "mflat_design_matrix_from_subsets",
+    "mflat_subsets_from_dependency",
+    "symmetric_smooth",
+)
+
+
+
+def _outcome_tuples(dist):
+    """Return outcomes as tuples of hashable symbols."""
+    return [tuple(o) if not isinstance(o, tuple) else o for o in dist.outcomes]
+
+
+def _alphabets(dist):
+    """Per-variable alphabets from a dense Cartesian sample space."""
+    n = dist.outcome_length()
+    alphabets = []
+    for i in range(n):
+        alphabets.append(tuple(sorted({o[i] for o in _outcome_tuples(dist)})))
+    return alphabets
+
+
+def mflat_subsets_from_dependency(dependency, index_map=None):
+    """
+    Downward-closed collection of index-tuples for an antichain dependency.
+
+    For a node :math:`\\pi`, the m-flat family is spanned by additive components
+    on every nonempty :math:`S \\subseteq T` for some block :math:`T \\in \\pi`
+    (plus a constant).
+
+    Parameters
+    ----------
+    dependency : iterable of iterables
+        Lattice node: an antichain of variable blocks (names or indices).
+    index_map : dict or None
+        Map from block element → integer coordinate index. Defaults to identity.
+
+    Returns
+    -------
+    subsets : frozenset of tuple
+        Sorted index tuples, all nonempty.
+    """
+    if index_map is None:
+        index_map = {}
+    subsets = set()
+    for block in dependency:
+        idxs = tuple(sorted(index_map.get(x, x) for x in block))
+        for s in range(1, len(idxs) + 1):
+            for sub in combinations(idxs, s):
+                subsets.add(sub)
+    return frozenset(subsets)
+
+
+def mflat_design_matrix_from_subsets(alphabets, subsets):
+    """
+    Design matrix for the m-flat family spanned by the given variable subsets.
+
+    Parameters
+    ----------
+    alphabets : sequence of sequences
+        Per-variable alphabets.
+    subsets : iterable of tuple
+        Nonempty index tuples whose indicator features are free. The constant
+        feature is always included.
+
+    Returns
+    -------
+    A : np.ndarray
+        Design matrix over the Cartesian product of ``alphabets``.
+    outcomes : list of tuple
+        Row-aligned outcomes.
+    """
+    n = len(alphabets)
+    outcomes = list(product(*alphabets))
+    n_out = len(outcomes)
+    index = {o: i for i, o in enumerate(outcomes)}
+
+    columns = [np.ones(n_out, dtype=float)]
+    for subset in sorted(subsets, key=lambda s: (len(s), s)):
+        subset = tuple(subset)
+        if not subset or any(i < 0 or i >= n for i in subset):
+            continue
+        sub_alph = [alphabets[i] for i in subset]
+        free = [i for i in range(n) if i not in subset]
+        for assignment in product(*sub_alph):
+            col = np.zeros(n_out, dtype=float)
+            if not free:
+                full = [None] * n
+                for j, v in zip(subset, assignment, strict=True):
+                    full[j] = v
+                col[index[tuple(full)]] = 1.0
+            else:
+                free_alph = [alphabets[i] for i in free]
+                for free_vals in product(*free_alph):
+                    full = [None] * n
+                    for j, v in zip(subset, assignment, strict=True):
+                        full[j] = v
+                    for j, v in zip(free, free_vals, strict=True):
+                        full[j] = v
+                    col[index[tuple(full)]] = 1.0
+            columns.append(col)
+
+    A = np.column_stack(columns) if columns else np.ones((n_out, 1))
+    return A, outcomes
+
+
+def mflat_design_matrix(alphabets, order):
+    """
+    Build the linear design matrix for the order-``order`` m-flat family.
+
+    Columns are indicator features :math:`1_{x_S = a}` for every subset
+    :math:`S` with :math:`|S| \\le` ``order`` and every assignment ``a`` on the
+    corresponding alphabets. Any pmf in :math:`\\mathcal{M}_{\\mathrm{order}}`
+    is then :math:`q = A\\theta` for some coefficient vector ``θ`` (subject to
+    nonnegativity and normalization of ``q``).
+
+    Parameters
+    ----------
+    alphabets : sequence of sequences
+        The alphabet of each variable.
+    order : int
+        Maximum interaction order kept in the additive pmf expansion.
+
+    Returns
+    -------
+    A : np.ndarray, shape (n_outcomes, n_features)
+        Design matrix over the Cartesian product of ``alphabets``.
+    outcomes : list of tuple
+        Row-aligned Cartesian outcomes.
+    """
+    n = len(alphabets)
+    if order < 0:
+        msg = "order must be nonnegative"
+        raise ditException(msg)
+    if order > n:
+        order = n
+
+    subsets = []
+    for s in range(1, order + 1):
+        subsets.extend(combinations(range(n), s))
+    return mflat_design_matrix_from_subsets(alphabets, subsets)
+
+
+def _reverse_kl(q, p, eps=1e-16):
+    """
+    Compute :math:`D_{\\mathrm{KL}}(q \\Vert p)` in bits for dense linear pmfs.
+    """
+    q = np.asarray(q, dtype=float)
+    p = np.asarray(p, dtype=float)
+    # xlogy handles 0 log 0; where p is tiny and q is not, contribution → +∞.
+    if np.any((q > eps) & (p <= eps)):
+        return np.inf
+    return float(np.sum(xlogy(q, q) - xlogy(q, np.maximum(p, eps))) / np.log(2))
+
+
+def _theta_for_pmf(A, q):
+    """Least-squares coefficients realizing ``q`` approximately as ``A θ``."""
+    theta, *_ = np.linalg.lstsq(A, q, rcond=None)
+    return theta
+
+
+def _forward_kl(p, q, eps=1e-300):
+    """Forward KL :math:`D(P \\Vert Q)` in bits for dense linear pmfs."""
+    p = np.asarray(p, dtype=float)
+    q = np.asarray(q, dtype=float)
+    mask = p > 0
+    return float(np.sum(p[mask] * np.log2(p[mask] / np.maximum(q[mask], eps))))
+
+
+def _jsd(p, q):
+    """Jensen–Shannon divergence in bits for dense linear pmfs."""
+    from ..divergences.jensen_shannon_divergence import jensen_shannon_divergence_pmf
+
+    return float(jensen_shannon_divergence_pmf(np.vstack([p, q])))
+
+
+def _divergence(p, q, criterion):
+    """Dispatch divergence used as a projection objective / residual."""
+    if criterion == "reverse_kl":
+        val = _reverse_kl(q, p)
+        return val if np.isfinite(val) else 1e6
+    if criterion == "forward_kl":
+        return _forward_kl(p, q)
+    if criterion == "jsd":
+        return _jsd(p, q)
+    msg = f"unknown criterion {criterion!r}; expected reverse_kl, forward_kl, or jsd"
+    raise ditException(msg)
+
+
+def _project_onto_mflat(
+    pmf,
+    A,
+    nrestarts=16,
+    maxiter=3000,
+    tol=1e-14,
+    seed=0,
+    warm_pmf=None,
+    criterion="reverse_kl",
+):
+    """
+    Project onto ``{q = A θ : q ≥ 0, ∑q = 1}`` under ``criterion``.
+
+    Parameters
+    ----------
+    pmf : np.ndarray
+        Target dense linear pmf (same row order as ``A``).
+    A : np.ndarray
+        Design matrix for :math:`\\mathcal{M}_k`.
+    nrestarts, maxiter, tol, seed
+        Optimizer controls.
+    warm_pmf : np.ndarray or None
+        Optional previous-ladder pmf used as an extra warm start.
+    criterion : {'reverse_kl', 'forward_kl', 'jsd'}
+        Projection objective. ``reverse_kl`` is the Amari m-projection;
+        ``jsd`` is preferred for sparse supports (finite with no smoothing).
+
+    Returns
+    -------
+    q : np.ndarray
+        Optimized pmf on the same sample space.
+    """
+    n_out, n_feat = A.shape
+    rng = np.random.default_rng(seed)
+
+    def feasible_pmf(theta):
+        q = A @ theta
+        if np.any(q < -1e-10):
+            q = np.maximum(q, 0.0)
+        s = q.sum()
+        if s <= 0:
+            return None
+        return q / s
+
+    def objective(theta):
+        q = feasible_pmf(theta)
+        if q is None:
+            return 1e6
+        return _divergence(pmf, q, criterion)
+
+    cons = [{"type": "eq", "fun": lambda th: float((A @ th).sum() - 1.0)}]
+    for i in range(n_out):
+        cons.append({"type": "ineq", "fun": lambda th, i=i: float((A @ th)[i])})
+
+    initials = [_theta_for_pmf(A, pmf), np.zeros(n_feat)]
+    theta_u = np.zeros(n_feat)
+    theta_u[0] = 1.0 / n_out
+    initials.append(theta_u)
+    if warm_pmf is not None:
+        initials.insert(0, _theta_for_pmf(A, warm_pmf))
+    for _ in range(max(0, nrestarts - len(initials))):
+        initials.append(rng.normal(0.0, 0.05, size=n_feat))
+
+    best_q = None
+    best_val = np.inf
+    for theta0 in initials:
+        q0 = A @ theta0
+        if abs(q0.sum()) > 0:
+            theta0 = theta0 / q0.sum()
+        res = minimize(
+            objective,
+            theta0,
+            method="SLSQP",
+            constraints=cons,
+            options={"maxiter": maxiter, "ftol": tol, "disp": False},
+        )
+        q = feasible_pmf(res.x)
+        if q is None:
+            continue
+        val = _divergence(pmf, q, criterion)
+        if val < best_val:
+            best_val = val
+            best_q = q
+
+    if best_q is None:
+        msg = "m-projection failed to find a feasible point in M_k"
+        raise ditException(msg)
+    return best_q
+
+
+
+def symmetric_smooth(dist, eps):
+    """
+    Symmetric full-support smoothing :math:`P_\\varepsilon = (1-\\varepsilon)P + \\varepsilon U`.
+
+    Here :math:`U` is uniform on the Cartesian product of the alphabets. This
+    preserves permutation symmetries of ``dist`` (e.g. W).
+
+    Parameters
+    ----------
+    dist : Distribution
+    eps : float
+        Mixture weight on the uniform. Must satisfy ``0 <= eps < 1``.
+        ``eps=0`` returns a dense copy of ``dist`` (still sparse if ``dist`` is).
+
+    Returns
+    -------
+    smoothed : Distribution
+        Dense linear distribution on the Cartesian sample space.
+    """
+    eps = float(eps)
+    if eps < 0 or eps >= 1:
+        msg = "eps must satisfy 0 <= eps < 1"
+        raise ditException(msg)
+
+    d = prepare_dist(deepcopy(dist))
+    alphabets = _alphabets(d)
+    outcomes = list(product(*alphabets))
+    p = _aligned_pmf(d, outcomes)
+    if eps == 0:
+        return _dist_from_pmf(outcomes, p, d)
+    u = np.ones(len(outcomes), dtype=float) / len(outcomes)
+    pe = (1.0 - eps) * p + eps * u
+    return _dist_from_pmf(outcomes, pe, d)
+
+
+def _resolve_reverse_kl_target(dist, eps=None):
+    """
+    Build the reverse-KL target: symmetric :math:`P_\\varepsilon`.
+
+    If ``eps`` is ``None``, defaults to ``1e-8``.
+    """
+    if eps is None:
+        eps = 1e-8
+    return symmetric_smooth(dist, eps), float(eps)
+
+
+def _aligned_pmf(dist, outcomes):
+    """Dense linear pmf of ``dist`` aligned to ``outcomes`` order."""
+    pmf_map = {tuple(o) if not isinstance(o, tuple) else o: p for o, p in zip(dist.outcomes, dist.pmf, strict=True)}
+    pmf = np.array([pmf_map.get(o, 0.0) for o in outcomes], dtype=float)
+    if pmf.sum() <= 0:
+        msg = "target distribution has empty pmf"
+        raise ditException(msg)
+    return pmf / pmf.sum()
+
+
+def _dist_from_pmf(outcomes, pmf, template):
+    """Build a Distribution with optional RV names copied from ``template``."""
+    q = Distribution(outcomes, pmf, base="linear", validate=False)
+    q.normalize()
+    if template.get_rv_names() is not None:
+        q.set_rv_names(template.get_rv_names())
+    return q
+
+
+def m_projection(
+    dist,
+    order,
+    nrestarts=16,
+    maxiter=3000,
+    warm_start=None,
+    criterion="reverse_kl",
+    eps=None,
+):
+    """
+    Project ``dist`` onto the order-``order`` m-flat mixture family.
+
+    Parameters
+    ----------
+    dist : Distribution
+        The target distribution :math:`P`.
+    order : int
+        Maximum ANOVA order kept in :math:`\\mathcal{M}_{\\mathrm{order}}`.
+    nrestarts, maxiter : int
+        Optimizer controls.
+    warm_start : Distribution or None
+        Optional warm start.
+    criterion : {'reverse_kl', 'forward_kl', 'jsd'}
+        Projection objective.
+    eps : float or None
+        For ``reverse_kl``, weight in :math:`P_\\varepsilon=(1-\\varepsilon)P+\\varepsilon U`.
+        Defaults to ``1e-8`` when ``None``.
+
+    Returns
+    -------
+    q : Distribution
+    """
+    n = dist.outcome_length()
+    if order < 0:
+        msg = "order must be nonnegative"
+        raise ditException(msg)
+    if order > n:
+        order = n
+    subsets = [sub for s in range(1, order + 1) for sub in combinations(range(n), s)]
+    return m_projection_from_subsets(
+        dist,
+        subsets,
+        nrestarts=nrestarts,
+        maxiter=maxiter,
+        warm_start=warm_start,
+        criterion=criterion,
+        eps=eps,
+    )
+
+
+def m_projection_from_subsets(
+    dist,
+    subsets,
+    nrestarts=16,
+    maxiter=3000,
+    warm_start=None,
+    criterion="reverse_kl",
+    eps=None,
+):
+    """
+    Project ``dist`` onto the m-flat family spanned by ``subsets``.
+    """
+    if criterion == "reverse_kl":
+        target, _eps = _resolve_reverse_kl_target(dist, eps=eps)
+    else:
+        target = prepare_dist(deepcopy(dist))
+
+    n = target.outcome_length()
+    alphabets = _alphabets(target)
+    subsets = frozenset(tuple(s) for s in subsets if s)
+
+    if frozenset(range(n)) in {frozenset(s) for s in subsets}:
+        outcomes = list(product(*alphabets))
+        return _dist_from_pmf(outcomes, _aligned_pmf(target, outcomes), target)
+
+    A, outcomes = mflat_design_matrix_from_subsets(alphabets, subsets)
+    if criterion == "reverse_kl":
+        pmf = _aligned_pmf(target, outcomes)
+    else:
+        dense = prepare_dist(deepcopy(dist))
+        pmf_map = {
+            tuple(o) if not isinstance(o, tuple) else o: float(p)
+            for o, p in zip(dense.outcomes, dense.pmf, strict=True)
+        }
+        pmf = np.array([pmf_map.get(o, 0.0) for o in outcomes], dtype=float)
+        pmf = pmf / pmf.sum()
+
+    if not subsets:
+        q_pmf = np.ones(len(outcomes), dtype=float) / len(outcomes)
+    else:
+        warm_pmf = None if warm_start is None else _aligned_pmf(warm_start, outcomes)
+        q_pmf = _project_onto_mflat(
+            pmf,
+            A,
+            nrestarts=nrestarts,
+            maxiter=maxiter,
+            warm_pmf=warm_pmf,
+            criterion=criterion,
+        )
+
+    return _dist_from_pmf(outcomes, q_pmf, target)
+
+
+def m_projection_eps_limit(
+    dist,
+    subsets=None,
+    order=None,
+    eps_schedule=(1e-4, 1e-6, 1e-8),
+    nrestarts=16,
+    maxiter=3000,
+    warm_start=None,
+):
+    """
+    Reverse-KL m-projection with symmetric :math:`P_\\varepsilon`, taking
+    :math:`\\varepsilon \\downarrow 0` along ``eps_schedule``.
+    """
+    from ..divergences import kullback_leibler_divergence as D
+
+    schedule = tuple(float(e) for e in eps_schedule)
+    if not schedule:
+        msg = "eps_schedule must be nonempty"
+        raise ditException(msg)
+
+    if subsets is None:
+        if order is None:
+            order = dist.outcome_length()
+        n = dist.outcome_length()
+        subsets = [sub for s in range(1, order + 1) for sub in combinations(range(n), s)]
+
+    path = []
+    q = warm_start
+    target = None
+    for eps in schedule:
+        q = m_projection_from_subsets(
+            dist,
+            subsets,
+            eps=eps,
+            nrestarts=nrestarts,
+            maxiter=maxiter,
+            warm_start=q,
+            criterion="reverse_kl",
+        )
+        target = symmetric_smooth(dist, eps)
+        path.append((eps, q))
+
+    return {
+        "dist": q,
+        "target": target,
+        "eps": schedule[-1],
+        "rKL": float(D(q, target)),
+        "path": path,
+    }
+
+
+def mflat_mprojection_dists(
+    dist,
+    k_max=None,
+    nrestarts=16,
+    maxiter=3000,
+    criterion="reverse_kl",
+    eps=None,
+    eps_schedule=None,
+):
+    """
+    Return the m-flat projection ladder :math:`Q^{(0)},\\ldots,Q^{(k_{\\max})}`.
+    """
+    n = dist.outcome_length()
+    if k_max is None:
+        k_max = n
+    if k_max < 0:
+        msg = "k_max must be nonnegative"
+        raise ditException(msg)
+    if k_max > n:
+        k_max = n
+
+    if criterion == "reverse_kl":
+        if eps_schedule is not None:
+            target = symmetric_smooth(dist, float(eps_schedule[-1]))
+        else:
+            target, _ = _resolve_reverse_kl_target(dist, eps=eps)
+    else:
+        target = prepare_dist(deepcopy(dist))
+
+    alphabets = _alphabets(target)
+    outcomes = list(product(*alphabets))
+
+    dense = prepare_dist(deepcopy(dist))
+    pmf_map = {
+        tuple(o) if not isinstance(o, tuple) else o: float(p)
+        for o, p in zip(dense.outcomes, dense.pmf, strict=True)
+    }
+    raw_pmf = np.array([pmf_map.get(o, 0.0) for o in outcomes], dtype=float)
+    raw_pmf = raw_pmf / raw_pmf.sum()
+
+    dists = []
+    for k in range(k_max + 1):
+        if k == 0:
+            q = _dist_from_pmf(outcomes, np.ones(len(outcomes)) / len(outcomes), target)
+        elif k == n:
+            if criterion == "reverse_kl":
+                q = _dist_from_pmf(outcomes, _aligned_pmf(target, outcomes), target)
+            else:
+                q = _dist_from_pmf(outcomes, raw_pmf, dist)
+        else:
+            warm = dists[-1] if dists else None
+            if criterion == "reverse_kl" and eps_schedule is not None:
+                q = m_projection_eps_limit(
+                    dist,
+                    order=k,
+                    eps_schedule=eps_schedule,
+                    nrestarts=nrestarts,
+                    maxiter=maxiter,
+                    warm_start=warm,
+                )["dist"]
+            else:
+                q = m_projection(
+                    dist,
+                    k,
+                    eps=eps,
+                    nrestarts=nrestarts,
+                    maxiter=maxiter,
+                    warm_start=warm,
+                    criterion=criterion,
+                )
+        dists.append(q)
+    return dists

--- a/dit/profiles/__init__.py
+++ b/dit/profiles/__init__.py
@@ -3,9 +3,12 @@ This module contains various information ``profiles'', decomposing the total
 information into the information contained at different scales.
 """
 
+from .binding_mixture import *
 from .complexity_profile import *
 from .entropy_triangle import *
 from .information_partitions import *
+from .marginal_lift import *
 from .marginal_utility_of_information import *
+from .mflat import *
 from .schneidman import *
 from .shapley_info_decomposition import *

--- a/dit/profiles/binding_mixture.py
+++ b/dit/profiles/binding_mixture.py
@@ -1,0 +1,138 @@
+"""
+Shared-randomness (binding) profile via mixtures of product distributions.
+
+Rosas et al. (2019) split multivariate dependence into two faces:
+
+* *Collective constraints* — total correlation :math:`T`, built from MaxEnt /
+  e-flat marginal ladders (:class:`~dit.profiles.ConnectedInformations`,
+  :class:`~dit.profiles.DependencyDecomposition`).
+* *Shared randomness* — dual total correlation / binding entropy :math:`B`,
+  which lives in shared latent structure.
+
+This module implements the randomness face: MLE projections onto
+:math:`k`-mixtures of fully factorized distributions
+(:func:`~dit.algorithms.mixture_of_products.mixture_of_products_dists`), with
+profile atoms equal to consecutive increments of :math:`B`.
+"""
+
+import numpy as np
+
+from ..algorithms.mixture_of_products import mixture_of_products_dists
+from ..multivariate import dual_total_correlation as B
+from .base_profile import BaseProfile, profile_docstring
+from .information_partitions import DependencyDecomposition
+
+__all__ = (
+    "BindingMixtureProfile",
+    "SharedRandomnessDecomposition",
+)
+
+
+class BindingMixtureProfile(BaseProfile):  # noqa: D101
+    __doc__ = profile_docstring.format(
+        name="BindingMixtureProfile",
+        static_attributes="",
+        attributes="",
+        methods="",
+    ) + (
+        "\n\nNotes\n-----\n"
+        "Atoms are :math:`\\Delta B(Q^{(k)}) = B(Q^{(k)}) - B(Q^{(k-1)})` along\n"
+        "the MLE mixture-of-products ladder "
+        "(:func:`~dit.algorithms.mixture_of_products.mixture_of_products_dists`).\n"
+        "They are nonnegative and sum to :math:`B(P)` once the fit saturates.\n"
+        "Distinct from :class:`~dit.profiles.ConnectedDualInformations` (MaxEnt\n"
+        "ladder with measure :math:`B`) and from "
+        ":class:`~dit.profiles.MFlatConnectedInformations` (Amari additive\n"
+        "m-flat / reverse KL)."
+    )
+
+    _name = "Binding Mixture Profile"
+    xlabel = "mixture components k"
+
+    def __init__(
+        self,
+        dist,
+        k_max=None,
+        *,
+        n_init=12,
+        max_iter=200,
+        seed=0,
+        early_stop=True,
+    ):
+        """
+        Parameters
+        ----------
+        dist : Distribution
+            The distribution to profile.
+        k_max : int or None
+            Maximum mixture cardinality (default ``min(8, |X|)``).
+        n_init, max_iter, seed, early_stop
+            Passed through to
+            :func:`~dit.algorithms.mixture_of_products.mixture_of_products_dists`.
+        """
+        self._k_max = k_max
+        self._n_init = n_init
+        self._max_iter = max_iter
+        self._seed = seed
+        self._early_stop = early_stop
+        super().__init__(dist)
+
+    def _compute(self):
+        """
+        Compute :math:`\\Delta B` along the mixture-of-products ladder.
+        """
+        dists, meta = mixture_of_products_dists(
+            self.dist,
+            k_max=self._k_max,
+            n_init=self._n_init,
+            max_iter=self._max_iter,
+            seed=self._seed,
+            early_stop=self._early_stop,
+        )
+        bindings = [float(B(d)) for d in dists]
+        # B(Q_0) := 0 with the empty / undefined mixture; first atom is B(Q_1).
+        prev = 0.0
+        profile = {}
+        for k, b in enumerate(bindings, start=1):
+            profile[k] = b - prev
+            prev = b
+
+        self.profile = profile
+        self.widths = np.ones(len(self.profile))
+        self.dists = dists
+        self.meta = meta
+        self.bindings = bindings
+        self.forward_kl = [m["forward_kl"] for m in meta]
+        self.I_xv = [m["I_xv"] for m in meta]
+
+
+class SharedRandomnessDecomposition(DependencyDecomposition):
+    """
+    Dependency-lattice dual of collective-constraint decompositions, measuring
+    shared randomness :math:`B`.
+
+    At each antichain :math:`\\pi`, the reconstruction is the product of exact
+    block marginals
+
+    .. math::
+
+        Q_\\pi = \\bigotimes_{b \\in \\pi} P_b,
+
+    which is the *saturated* mixture-of-products model within each block
+    (any discrete block marginal is a finite mixture of product components)
+    with independence across blocks.  Default atom measure is dual total
+    correlation :math:`B(Q_\\pi)`.
+
+    This is the structural dual of :class:`DependencyDecomposition` on the
+    same lattice: MaxEnt with within-block marginals yields the same
+    :math:`Q_\\pi`, but here the reported quantity is binding / shared
+    randomness rather than entropy or total correlation.
+
+    For the *unsaturated* cardinality ladder (growing shared latent size),
+    see :class:`BindingMixtureProfile`.
+    """
+
+    def __init__(self, dist, rvs=None, measures=None, cover=True, maxiter=None):
+        if measures is None:
+            measures = {"B": B}
+        super().__init__(dist, rvs=rvs, measures=measures, cover=cover, maxiter=maxiter)

--- a/dit/profiles/information_partitions.py
+++ b/dit/profiles/information_partitions.py
@@ -13,6 +13,11 @@ from boltons.iterutils import pairwise_iter
 from lattices.lattices import dependency_lattice, powerset_lattice
 
 from ..algorithms import degrees_of_freedom, maxent_dist
+from ..algorithms.mprojection import (
+    m_projection_eps_limit,
+    mflat_subsets_from_dependency,
+    symmetric_smooth,
+)
 from ..divergences import kullback_leibler_divergence
 from ..multivariate.transmission import transmission
 from ..other import extropy
@@ -25,6 +30,7 @@ __all__ = (
     "ShannonPartition",
     "ExtropyPartition",
     "DependencyDecomposition",
+    "DualDependencyDecomposition",
 )
 
 
@@ -428,6 +434,176 @@ class DependencyDecomposition:
         f = self._stringify if string else lambda d: d
 
         return set(map(f, self.atoms.keys()))
+
+
+class DualDependencyDecomposition(DependencyDecomposition):
+    """
+    m-flat dual of :class:`DependencyDecomposition`.
+
+    Uses the same dependency lattice, but at each node :math:`\\pi` reconstructs
+    via the reverse-KL m-projection onto the additive (mixture) family
+
+    .. math::
+
+        \\mathcal{M}_\\pi = \\Bigl\\{ Q : Q(x) = \\sum_{S \\subseteq T,\\ T\\in\\pi}
+        h_S(x_S) \\Bigr\\}
+
+    rather than MaxEnt with marginal constraints. Sparse targets use symmetric
+    smoothing :math:`P_\\varepsilon=(1-\\varepsilon)P+\\varepsilon U` and take
+    :math:`\\varepsilon\\downarrow 0` along ``eps_schedule``. Default atom
+    measure is :math:`D(Q_\\pi \\Vert P_\\varepsilon)` at the final ``eps``.
+
+    See Amari (2001) and :class:`~dit.profiles.MFlatConnectedInformations` for
+    the order-chain special case.
+    """
+
+    # Sentinel: measure the reverse KL from the node reconstruction to the data.
+    REVERSE_KL = object()
+
+    def __init__(
+        self,
+        dist,
+        rvs=None,
+        measures=None,
+        cover=True,
+        eps_schedule=(1e-4, 1e-6, 1e-8),
+        eps=None,
+        nrestarts=8,
+        maxiter=2000,
+    ):
+        """
+        Parameters
+        ----------
+        dist : Distribution
+            Distribution to decompose.
+        rvs : iterable or None
+            Variables to include. Defaults to all.
+        measures : dict or None
+            ``{name: callable}`` applied to each reconstruction. The sentinel
+            ``DualDependencyDecomposition.REVERSE_KL`` (the default under the
+            name ``"rKL"``) records :math:`D(Q \\Vert P_\\varepsilon)`.
+        cover : bool
+            Passed to :func:`~lattices.lattices.dependency_lattice`.
+        eps_schedule : sequence of float or None
+            Decreasing smooth weights for the :math:`\\varepsilon\\downarrow 0`
+            limit. Default ``(1e-4, 1e-6, 1e-8)``. Ignored if ``eps`` is set
+            (single-shot smooth).
+        eps : float or None
+            Single symmetric smooth weight (overrides ``eps_schedule``).
+        nrestarts, maxiter : int
+            m-projection optimizer controls.
+        """
+        if measures is None:
+            measures = {"rKL": self.REVERSE_KL}
+        self.eps_schedule = None if eps_schedule is None else tuple(eps_schedule)
+        self.eps = eps
+        self._nrestarts = nrestarts
+        self._mp_maxiter = maxiter
+        # Replicate DependencyDecomposition.__init__ so we do not call MaxEnt.
+        self.dist = dist
+        self.rvs = sum(dist.rvs, []) if rvs is None else rvs
+        self.measures = measures
+        self.cover = cover
+        self._partition()
+        self._measure_of_interest = self.atoms
+
+    def _index_map(self):
+        """Map lattice element labels to dense outcome-coordinate indices."""
+        names = self.dist.get_rv_names()
+        if names:
+            return {name: i for i, name in enumerate(names)}
+        return {rv: rv for rv in self.rvs}
+
+    def _project_node(self, subsets, warm):
+        """Reverse-KL project onto the mixture family for one lattice node."""
+        if self.eps is not None or self.eps_schedule is None:
+            from ..algorithms.mprojection import m_projection_from_subsets
+
+            return m_projection_from_subsets(
+                self.dist,
+                subsets,
+                eps=self.eps if self.eps is not None else 1e-8,
+                nrestarts=self._nrestarts,
+                maxiter=self._mp_maxiter,
+                warm_start=warm,
+                criterion="reverse_kl",
+            ), None
+
+        result = m_projection_eps_limit(
+            self.dist,
+            subsets=subsets,
+            eps_schedule=self.eps_schedule,
+            nrestarts=self._nrestarts,
+            maxiter=self._mp_maxiter,
+            warm_start=warm,
+        )
+        return result["dist"], result
+
+    def _partition(self, maxiter=None):  # noqa: ARG002
+        """
+        m-project onto each dependency node's mixture family.
+        """
+        names = self.dist.get_rv_names()
+        rvs = [names[i] for i in self.rvs] if names else self.rvs
+
+        self._lattice = dependency_lattice(rvs, cover=self.cover)
+        index_map = self._index_map()
+        n = self.dist.outcome_length()
+        dists = {}
+        meta = {}
+
+        for node in reversed(list(self._lattice)):
+            try:
+                parent = next(iter(self._lattice._lattice[node].keys()))
+                warm = dists[parent]
+            except (IndexError, StopIteration, KeyError):
+                warm = None
+
+            subsets = mflat_subsets_from_dependency(node, index_map=index_map)
+            if any(len(s) == n for s in subsets):
+                # Full joint: exact recovery of the working reverse-KL target.
+                if self.eps is not None or self.eps_schedule is None:
+                    from ..algorithms.mprojection import _resolve_reverse_kl_target
+
+                    target, final_eps = _resolve_reverse_kl_target(self.dist, eps=self.eps)
+                    dists[node] = target
+                    meta[node] = {"eps": final_eps, "target": target, "rKL": 0.0}
+                else:
+                    target = symmetric_smooth(self.dist, self.eps_schedule[-1])
+                    dists[node] = target
+                    meta[node] = {"eps": self.eps_schedule[-1], "target": target, "rKL": 0.0}
+            else:
+                q, info = self._project_node(subsets, warm)
+                dists[node] = q
+                meta[node] = info
+
+        self.dists = dists
+        self._node_meta = meta
+
+        # Shared reverse-KL target at the final eps.
+        if self.eps is not None or self.eps_schedule is None:
+            from ..algorithms.mprojection import _resolve_reverse_kl_target
+
+            target, final_eps = _resolve_reverse_kl_target(self.dist, eps=self.eps)
+        else:
+            final_eps = self.eps_schedule[-1]
+            target = symmetric_smooth(self.dist, final_eps)
+        self.target = target
+        self.eps_final = final_eps
+
+        atoms = defaultdict(dict)
+        for name, measure in self.measures.items():
+            for node in self._lattice:
+                if measure is degrees_of_freedom:
+                    atoms[node][name] = degrees_of_freedom(self.dist, node)
+                elif measure is self.REVERSE_KL:
+                    atoms[node][name] = kullback_leibler_divergence(dists[node], target)
+                elif measure is transmission:
+                    atoms[node][name] = kullback_leibler_divergence(target, dists[node])
+                else:
+                    atoms[node][name] = measure(dists[node])
+
+        self.atoms = atoms
 
 
 class ShapleyDecomposition(DependencyDecomposition):

--- a/dit/profiles/marginal_lift.py
+++ b/dit/profiles/marginal_lift.py
@@ -1,0 +1,91 @@
+"""
+Profile from convex combinations of lifts of a joint's own marginals.
+
+Sibling of :class:`~dit.profiles.MFlatConnectedInformations`: both approximate
+:math:`P` by linear structure in the pmf, but here the building blocks are
+*fixed* lifts of the data marginals :math:`P_S` rather than free ANOVA tables.
+"""
+
+import numpy as np
+
+from ..algorithms.marginal_lifts import marginal_lift_dists
+from .base_profile import BaseProfile, profile_docstring
+
+__all__ = ("MarginalLiftProfile",)
+
+
+class MarginalLiftProfile(BaseProfile):  # noqa: D101
+    __doc__ = profile_docstring.format(
+        name="MarginalLiftProfile",
+        static_attributes="",
+        attributes="",
+        methods="",
+    ) + (
+        "\n\nNotes\n-----\n"
+        "At order :math:`k`, fit nonnegative weights on lifts of all marginals\n"
+        "with :math:`|S|\\le k` (plus uniform) by least squares. Profile atoms\n"
+        "are consecutive drops in the :math:`L^2` residual to :math:`P`.\n"
+        "Fitted coefficients ``alphas[k]`` show which marginals carry mass\n"
+        "(e.g. Copy puts all weight on the copied pair at order 2)."
+    )
+
+    _name = "Marginal Lift Profile"
+    xlabel = "marginal order k"
+
+    def __init__(self, dist, k_max=None, mode="uniform", n_init=12, seed=0):
+        """
+        Parameters
+        ----------
+        dist : Distribution
+        k_max : int or None
+            Highest marginal order (default: number of variables).
+        mode : {'uniform', 'product'}
+            Lift of each marginal to the full joint.
+        n_init, seed
+            Convex-combination optimizer controls.
+        """
+        self._k_max = k_max
+        self._mode = mode
+        self._n_init = n_init
+        self._seed = seed
+        super().__init__(dist)
+
+    def _compute(self):
+        dists, metas = marginal_lift_dists(
+            self.dist,
+            k_max=self._k_max,
+            mode=self._mode,
+            n_init=self._n_init,
+            seed=self._seed,
+        )
+        # L2 residual of each rung vs P (order 0 computed explicitly).
+        from copy import deepcopy
+        from itertools import product
+
+        from ..algorithms.optutil import prepare_dist
+
+        dense = prepare_dist(deepcopy(self.dist))
+        alph = [tuple(sorted({o[i] for o in dense.outcomes})) for i in range(dense.outcome_length())]
+        outs = list(product(*alph))
+        pmf_map = {tuple(o): float(p) for o, p in zip(dense.outcomes, dense.pmf, strict=True)}
+        p = np.array([pmf_map.get(o, 0.0) for o in outs], dtype=float)
+        p /= p.sum()
+
+        residuals = []
+        for q in dists:
+            qmap = {
+                tuple(o) if not isinstance(o, tuple) else o: float(pr) for o, pr in zip(q.outcomes, q.pmf, strict=True)
+            }
+            qpmf = np.array([qmap.get(o, 0.0) for o in outs], dtype=float)
+            qpmf /= qpmf.sum()
+            residuals.append(float(np.linalg.norm(p - qpmf)))
+
+        diffs = [residuals[i] - residuals[i + 1] for i in range(len(residuals) - 1)]
+        self.profile = {i + 1: float(v) for i, v in enumerate(diffs)}
+        self.widths = np.ones(len(self.profile))
+        self.dists = dists
+        self.metas = metas
+        self.residuals = residuals
+        self.alphas = [m["alpha"] for m in metas]
+        self.labels = [m["labels"] for m in metas]
+        self.mode = self._mode

--- a/dit/profiles/mflat.py
+++ b/dit/profiles/mflat.py
@@ -1,0 +1,127 @@
+"""
+Amari m-flat connected informations: divergence gaps along the additive ANOVA ladder.
+
+Distinct from :class:`~dit.profiles.ConnectedDualInformations`, which differences
+dual total correlation along the *e-flat* MaxEnt (marginal) ladder, and from
+:class:`~dit.profiles.MarginalLiftProfile`, which uses fixed lifts of the data's
+own marginals rather than free ANOVA tables.
+"""
+
+import numpy as np
+
+from ..algorithms import mflat_mprojection_dists
+from ..algorithms.mprojection import _aligned_pmf, _alphabets, _divergence
+from ..divergences import kullback_leibler_divergence as D
+from .base_profile import BaseProfile, profile_docstring
+
+__all__ = (
+    "MFlatConnectedInformations",
+    "AmariMFlatProfile",
+)
+
+
+class MFlatConnectedInformations(BaseProfile):  # noqa: D101
+    __doc__ = profile_docstring.format(
+        name="MFlatConnectedInformations",
+        static_attributes="",
+        attributes="",
+        methods="",
+    ) + (
+        "\n\nNotes\n-----\n"
+        "Gaps along Amari's m-flat ladder "
+        "(:func:`~dit.algorithms.mflat_mprojection_dists`) under a chosen\n"
+        "divergence ``criterion`` (default ``'jsd'``: Jensen–Shannon; also\n"
+        "``'forward_kl'`` / ``'reverse_kl'``). Atoms are consecutive drops in\n"
+        "the residual divergence to :math:`P`:\n"
+        ":math:`C_k = D(P, Q^{(k-1)}) - D(P, Q^{(k)})`.\n"
+        "For ``criterion='reverse_kl'`` this recovers the classical Amari\n"
+        "m-projection gaps (Pythagorean under symmetric :math:`P_\\varepsilon`)."
+    )
+
+    _name = "M-Flat Connected Informations"
+
+    def __init__(
+        self,
+        dist,
+        nrestarts=16,
+        maxiter=3000,
+        criterion="jsd",
+        eps=None,
+        eps_schedule=(1e-4, 1e-6, 1e-8),
+    ):
+        """
+        Parameters
+        ----------
+        dist : Distribution
+            The distribution to profile.
+        nrestarts, maxiter : int
+            Optimizer controls for each projection.
+        criterion : {'jsd', 'forward_kl', 'reverse_kl'}
+            Projection / residual divergence. Default ``jsd`` is finite on
+            sparse supports. Use ``reverse_kl`` for Amari's true m-projection
+            with symmetric :math:`P_\\varepsilon`.
+        eps : float or None
+            Single smooth weight for ``reverse_kl`` (overrides ``eps_schedule``).
+        eps_schedule : sequence of float or None
+            Decreasing smooth weights for ``reverse_kl`` when ``eps`` is unset.
+            Default ``(1e-4, 1e-6, 1e-8)``.
+        """
+        self._nrestarts = nrestarts
+        self._maxiter = maxiter
+        self._criterion = criterion
+        self._eps = eps
+        self._eps_schedule = None if eps_schedule is None else tuple(eps_schedule)
+        super().__init__(dist)
+
+    def _residual(self, p_pmf, q_dist, outcomes):
+        q_pmf = _aligned_pmf(q_dist, outcomes)
+        if self._criterion == "reverse_kl":
+            return _divergence(p_pmf, q_pmf, "reverse_kl")
+        return _divergence(p_pmf, q_pmf, self._criterion)
+
+    def _compute(self):
+        """
+        Compute consecutive residual drops along the m-flat ladder.
+        """
+        kwargs = {
+            "nrestarts": self._nrestarts,
+            "maxiter": self._maxiter,
+            "criterion": self._criterion,
+        }
+        if self._criterion == "reverse_kl":
+            if self._eps is not None:
+                kwargs["eps"] = self._eps
+            else:
+                kwargs["eps_schedule"] = self._eps_schedule
+        dists = mflat_mprojection_dists(self.dist, **kwargs)
+        alphabets = _alphabets(dists[0])
+        from itertools import product
+
+        outcomes = list(product(*alphabets))
+        # Dense target pmf aligned to the ladder sample space.
+        from copy import deepcopy
+
+        from ..algorithms.optutil import prepare_dist
+
+        dense = prepare_dist(deepcopy(self.dist))
+        pmf_map = {
+            tuple(o) if not isinstance(o, tuple) else o: float(p)
+            for o, p in zip(dense.outcomes, dense.pmf, strict=True)
+        }
+        p_pmf = np.array([pmf_map.get(o, 0.0) for o in outcomes], dtype=float)
+        p_pmf = p_pmf / p_pmf.sum()
+
+        if self._criterion == "reverse_kl":
+            # Preserve Pythagorean consecutive reverse-KL gaps between rungs.
+            diffs = [D(dists[i], dists[i + 1]) for i in range(len(dists) - 1)]
+        else:
+            residuals = [self._residual(p_pmf, q, outcomes) for q in dists]
+            diffs = [residuals[i] - residuals[i + 1] for i in range(len(residuals) - 1)]
+
+        self.profile = {i + 1: float(v) for i, v in enumerate(diffs)}
+        self.widths = np.ones(len(self.profile))
+        self._dists = dists
+        self.criterion = self._criterion
+
+
+AmariMFlatProfile = MFlatConnectedInformations

--- a/dit/profiles/schneidman.py
+++ b/dit/profiles/schneidman.py
@@ -42,15 +42,24 @@ SchneidmanProfile = ConnectedInformations
 
 
 class ConnectedDualInformations(BaseProfile):  # noqa: D101
-    __doc__ = profile_docstring.format(
-        name="ConnectedDualInformations", static_attributes="", attributes="", methods=""
+    __doc__ = (
+        profile_docstring.format(
+            name="ConnectedDualInformations", static_attributes="", attributes="", methods=""
+        )
+        + "\n\nNotes\n-----\n"
+        "Increments of dual total correlation along the e-flat MaxEnt ladder\n"
+        "``marginal_maxent_dists``. This is *not* Amari's m-flat / reverse-KL\n"
+        "hierarchy; see :class:`~dit.profiles.MFlatConnectedInformations`."
     )
 
     _name = "Connected Dual Informations"
 
     def _compute(self):
         """
-        Compute the connected dual information decomposition.
+        Compute DTC increments along the MaxEnt (e-flat) ladder.
+
+        For reverse-KL m-projections onto additive pmf truncations, use
+        :class:`~dit.profiles.MFlatConnectedInformations` instead.
         """
         dists = marginal_maxent_dists(self.dist)
         diffs = np.diff([B(d) for d in dists])

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -76,6 +76,31 @@ The second constructs several maximum entropy distributions, each with all subse
 where ``k0`` is the maxent dist corresponding the same alphabets as ``xor``; ``k1`` fixes :math:`p(x_0)`, :math:`p(x_1)`, and :math:`p(x_2)`; ``k2`` fixes :math:`p(x_0, x_1)`, :math:`p(x_0, x_2)`, and :math:`p(x_1, x_2)` (as in the ``maxent_dist`` example above), and finally ``k3`` fixes :math:`p(x_0, x_1, x_2)` (e.g. is the distribution we started with).
 
 =================================
+M-Flat m-Projections
+=================================
+
+The dual of the MaxEnt / e-flat ladder is Amari's m-flat hierarchy
+:cite:`Amari2001`. Instead of matching :math:`k`-way marginals, one truncates
+the additive (ANOVA) expansion of the pmf and takes the reverse-KL m-projection
+onto that mixture family. Sparse supports use the symmetric smooth
+:math:`P_\varepsilon=(1-\varepsilon)P+\varepsilon U` (or the
+:math:`\varepsilon\downarrow 0` schedule via ``m_projection_eps_limit``):
+
+.. ipython::
+
+    In [9a]: from dit.algorithms import m_projection, m_projection_eps_limit, mflat_mprojection_dists
+
+    In [9b]: q2 = m_projection(xor, 2, eps=1e-6)
+
+    In [9c]: q2_lim = m_projection_eps_limit(xor, order=2)
+
+    In [9d]: ladder = mflat_mprojection_dists(xor, eps_schedule=(1e-4, 1e-6, 1e-8))
+
+See :doc:`profiles` (:class:`~dit.profiles.MFlatConnectedInformations` and
+:class:`~dit.profiles.DualDependencyDecomposition`) for reverse-KL gaps along
+the order chain and the full dependency lattice.
+
+=================================
 Maximum Entropy Solver (IPF)
 =================================
 
@@ -102,6 +127,39 @@ The maximum entropy reconstruction underlies reconstructability analysis, which 
     In [14]: from dit.multivariate import entropy
 
     In [15]: print(DependencyDecomposition(xor, measures={'H': entropy, 'T': transmission, 'df': degrees_of_freedom}))
+
+=================================
+Mixtures of product distributions
+=================================
+
+Shared-randomness profiles fit *mixtures of fully factorized* distributions
+(naive-Bayes / latent-class models) by EM. Maximum likelihood equals the
+forward-KL projection onto
+
+.. math::
+
+   \mathcal{F}_k = \Bigl\{
+       Q : Q(x) = \sum_{\alpha=1}^{k} \pi_\alpha \prod_i Q_i(x_i \mid \alpha)
+   \Bigr\}.
+
+Helpers :func:`~dit.algorithms.fit_mixture_of_products` and
+:func:`~dit.algorithms.mixture_of_products_dists` feed
+:class:`~dit.profiles.BindingMixtureProfile` (see :doc:`profiles`).
+
+For *additive* building blocks (Amari ANOVA / fixed marginal lifts), see
+:func:`~dit.algorithms.m_projection` (criteria ``jsd``, ``forward_kl``,
+``reverse_kl``) and :func:`~dit.algorithms.fit_marginal_lift_mixture`.
+
+.. ipython::
+
+    In [15a]: from dit.algorithms import fit_mixture_of_products
+
+    In [15b]: gb = dit.Distribution(['000', '111'], [0.5, 0.5])
+
+    In [15c]: q2 = fit_mixture_of_products(gb, k=2, n_init=8, seed=0)['dist']
+
+    In [15d]: print(round(dit.divergences.kullback_leibler_divergence(gb, q2), 8))
+    0.0
 
 =====================
 Optimization Backends

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -246,6 +246,134 @@ And for the ``xor``, all bits appear independent until fixing the three-way marg
    @savefig schneidman_profile_example_4.png width=500 align=center
    In [25]: SchneidmanProfile(ex4).draw();
 
+.. py:module:: dit.profiles.mflat
+
+M-Flat Connected Informations
+=============================
+
+The Schneidman profile above walks the *e-flat* MaxEnt ladder (match
+:math:`k`-way marginals, set higher-order natural parameters to zero). Amari's
+dual construction walks the *m-flat* mixture hierarchy instead
+:cite:`Amari2001`: distributions whose ANOVA / Hoeffding expansion of the
+*pmf itself* has no interactions above order :math:`k`,
+
+.. math::
+
+   \mathcal{M}_k = \Bigl\{ Q : Q(x) = \sum_{|S|\le k} h_S(x_S) \Bigr\}.
+
+:class:`MFlatConnectedInformations` projects :math:`P` onto each
+:math:`\mathcal{M}_k` under a chosen divergence ``criterion``:
+
+* ``'jsd'`` (default) — Jensen–Shannon; finite on sparse supports with no smoothing
+* ``'forward_kl'`` — :math:`D(P \Vert Q)`
+* ``'reverse_kl'`` — Amari's true m-projection :math:`D(Q \Vert P)` (uses
+  symmetric :math:`P_\varepsilon` / ``eps_schedule`` on sparse supports)
+
+Profile atoms are consecutive drops in the residual to :math:`P` (for
+``reverse_kl``, consecutive reverse-KL gaps between rungs, recovering the
+Pythagorean decomposition).
+
+Giant Bit / Copy saturate at order 2; XOR / W need order 3.
+
+.. ipython::
+
+   In [25a]: from dit.profiles import MFlatConnectedInformations
+
+   In [25b]: from dit.algorithms import m_projection, mflat_mprojection_dists
+
+   In [25c]: print(sorted(MFlatConnectedInformations(ex4, criterion='jsd').profile))
+   [1, 2, 3]
+
+Helpers :func:`~dit.algorithms.m_projection` /
+:func:`~dit.algorithms.m_projection_from_subsets` and
+:func:`~dit.algorithms.mflat_mprojection_dists` live under
+:doc:`optimization`. The full dependency-lattice version with reverse KL is
+:class:`~dit.profiles.DualDependencyDecomposition`.
+
+Marginal Lift Profile
+=====================
+
+A complementary *fixed-block* construction: at order :math:`k`, form lifts of
+the data's own marginals :math:`P_S` (:math:`|S|\le k`) plus the uniform, and
+fit a convex combination by least squares
+(:class:`~dit.profiles.MarginalLiftProfile`). Coefficients show which
+marginals carry the approximation (Copy puts all mass on the copied pair at
+order 2). Unlike Amari's free ANOVA tables, Giant Bit / XOR are *not* recovered
+from pair lifts alone — only when the full joint is an allowed block.
+
+.. ipython::
+
+   In [25m]: from dit.profiles import MarginalLiftProfile
+
+   In [25n]: copy = dit.Distribution(['000', '001', '110', '111'], [1/4]*4)
+
+   In [25o]: print(round(MarginalLiftProfile(copy).residuals[2], 8))
+   0.0
+
+Binding Mixture Profile
+=======================
+
+Rosas et al. :cite:`rosas2019quantifying` distinguish *collective constraints*
+(total correlation :math:`T`) from *shared randomness* (dual total correlation /
+binding entropy :math:`B`). The MaxEnt Schneidman ladder decomposes the
+constraint face. The shared-randomness face is captured by mixtures of product
+distributions (latent-class / naive-Bayes models underlying Wyner common
+information):
+
+.. math::
+
+   \mathcal{F}_k = \Bigl\{
+       Q : Q(x) = \sum_{\alpha=1}^{k} \pi_\alpha \prod_i Q_i(x_i \mid \alpha)
+   \Bigr\}.
+
+:class:`BindingMixtureProfile` fits the MLE
+:math:`Q^{(k)} = \arg\min_{Q\in\mathcal{F}_k} D(P\Vert Q)` by EM and reports
+
+.. math::
+
+   \Delta B_k = B\bigl(Q^{(k)}\bigr) - B\bigl(Q^{(k-1)}\bigr)
+
+(with :math:`B(Q^{(0)}) := 0`). These atoms are nonnegative and sum to
+:math:`B(P)` once the fit saturates. Giant bit concentrates at :math:`k=2`;
+XOR needs :math:`k=4`; copy :math:`X=Y \perp Z` saturates at :math:`k=2`.
+
+This is distinct from :class:`ConnectedDualInformations` (still the MaxEnt
+ladder, only the *measure* is :math:`B`) and from
+:class:`MFlatConnectedInformations` (Amari additive m-flat geometry).
+
+.. ipython::
+
+   In [25d]: from dit.profiles import BindingMixtureProfile
+
+   In [25e]: from dit.algorithms import fit_mixture_of_products, mixture_of_products_dists
+
+   In [25f]: gb = BindingMixtureProfile(ex2, k_max=4, n_init=8, seed=0)
+
+   In [25g]: print(round(gb.profile[2], 6))
+   1.0
+
+   In [25h]: xor_prof = BindingMixtureProfile(ex4, k_max=4, n_init=10, seed=0, early_stop=False)
+
+   In [25i]: print(round(sum(xor_prof.profile.values()), 6))
+   2.0
+
+Shared Randomness Decomposition
+===============================
+
+:class:`SharedRandomnessDecomposition` is the dependency-lattice counterpart:
+at each antichain :math:`\pi` the reconstruction is the product of exact block
+marginals (the *saturated* mixture-of-products model within each block, with
+independence across blocks), and the default atom measure is :math:`B`.
+It shares reconstructions with :class:`DependencyDecomposition` but reports
+binding rather than entropy / total correlation.
+
+.. ipython::
+
+   In [25j]: from dit.profiles import SharedRandomnessDecomposition
+
+   In [25k]: print('B' in next(iter(SharedRandomnessDecomposition(ex2).atoms.values())))
+   True
+
 .. py:module:: dit.profiles.entropy_triangle
 
 Entropy Triangle and Entropy Triangle2
@@ -389,3 +517,43 @@ And finally in the case of the exclusive or, only constraining the 012 marginal 
    |    01:2    |  3.000 |
    |   0:1:2    |  3.000 |
    +------------+--------+
+
+Dual Dependency Decomposition
+=============================
+
+:class:`DualDependencyDecomposition` uses the *same* dependency lattice, but
+reconstructs each node by an m-flat reverse-KL m-projection rather than MaxEnt
+:cite:`Amari2001`. At node :math:`\pi` the model is
+
+.. math::
+
+   \mathcal{M}_\pi = \Bigl\{ Q : Q(x) = \sum_{S \subseteq T,\ T\in\pi} h_S(x_S) \Bigr\},
+
+with target the symmetrically smoothed :math:`P_\varepsilon=(1-\varepsilon)P+\varepsilon U`
+and :math:`\varepsilon\downarrow 0` along ``eps_schedule`` (default
+``(1e-4, 1e-6, 1e-8)``). The default atom is
+:math:`D(Q_\pi \Vert P_\varepsilon)` at the final ``eps``. Symmetric
+smoothing preserves permutation symmetries (e.g. the W distribution),
+unlike random support jitter. The order-chain profile
+:class:`MFlatConnectedInformations` is the rank-aggregated special case
+(all blocks of size :math:`\le k`).
+
+For the giant bit (``ex2``), the full pairwise cover ``01:02:12`` already
+achieves reverse KL zero. For ``xor`` (``ex4``), every node short of the full
+triple keeps a large reverse KL:
+
+.. ipython::
+
+   In [38]: from dit.profiles import DualDependencyDecomposition
+
+   In [39]: gb = DualDependencyDecomposition(ex2, nrestarts=4)
+
+   In [40]: pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+
+   In [41]: print(round(gb[pairs]['rKL'], 6))
+   0.0
+
+   In [42]: xor = DualDependencyDecomposition(ex4, nrestarts=4)
+
+   In [43]: print(round(xor[pairs]['rKL'], 3) > 1)
+   True

--- a/examples/linear_building_blocks_probe.py
+++ b/examples/linear_building_blocks_probe.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Probe: linear building-block approximations of a joint.
+
+(1) Amari m-flat ANOVA family M_k, projected under forward KL / reverse KL / JSD.
+(2) Convex combinations of lifts of the data's own marginals P_S.
+
+Suite: Giant Bit, XOR, W, Copy, AND — plus BindingMixtureProfile as contrast.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from itertools import combinations, product
+
+import numpy as np
+from scipy.optimize import minimize
+
+from dit import Distribution
+from dit.algorithms.mprojection import (
+    _aligned_pmf,
+    _alphabets,
+    _dist_from_pmf,
+    _outcome_tuples,
+    _project_onto_mflat,
+    mflat_design_matrix,
+    symmetric_smooth,
+)
+from dit.algorithms.optutil import prepare_dist
+from dit.divergences import kullback_leibler_divergence as D
+from dit.divergences.jensen_shannon_divergence import jensen_shannon_divergence_pmf
+from dit.multivariate import dual_total_correlation as B
+from dit.multivariate import total_correlation as T
+from dit.profiles import BindingMixtureProfile
+from dit.shannon import entropy as H
+
+
+def make_and():
+    outs, p = [], []
+    for x in "01":
+        for y in "01":
+            z = "1" if (x == "1" and y == "1") else "0"
+            outs.append(x + y + z)
+            p.append(0.25)
+    return Distribution(outs, p)
+
+
+DISTS = {
+    "GB": Distribution(["000", "111"], [0.5, 0.5]),
+    "XOR": Distribution(["000", "011", "101", "110"], [0.25] * 4),
+    "W": Distribution(["001", "010", "100"], [1 / 3] * 3),
+    "Copy": Distribution(["000", "001", "110", "111"], [0.25] * 4),
+    "AND": make_and(),
+}
+
+
+def cartesian(dist):
+    d = prepare_dist(deepcopy(dist))
+    n = d.outcome_length()
+    alph = [tuple(sorted({o[i] for o in d.outcomes})) for i in range(n)]
+    outs = list(product(*alph))
+    pmf_map = {tuple(o): float(p) for o, p in zip(d.outcomes, d.pmf, strict=True)}
+    pmf = np.array([pmf_map.get(o, 0.0) for o in outs], dtype=float)
+    pmf /= pmf.sum()
+    return outs, pmf, alph
+
+
+def _jsd_pmf(p, q):
+    return float(jensen_shannon_divergence_pmf(np.vstack([p, q])))
+
+
+def _fwd_kl(p, q, eps=1e-300):
+    mask = p > 0
+    return float(np.sum(p[mask] * np.log2(p[mask] / np.maximum(q[mask], eps))))
+
+
+def _rev_kl(q, p, eps=1e-16):
+    if np.any((q > eps) & (p <= eps)):
+        return float("inf")
+    from scipy.special import xlogy
+
+    return float(np.sum(xlogy(q, q) - xlogy(q, np.maximum(p, eps))) / np.log(2))
+
+
+def metrics(outs, p, q):
+    P = Distribution(outs, p, base="linear", validate=False)
+    Q = Distribution(outs, q, base="linear", validate=False)
+    P.normalize()
+    Q.normalize()
+    return {
+        "B": float(B(Q)),
+        "T": float(T(Q)),
+        "H": float(H(Q)),
+        "Df": _fwd_kl(p, q),
+        "Dr": _rev_kl(q, p),
+        "JSD": _jsd_pmf(p, q),
+        "L2": float(np.linalg.norm(p - q)),
+        "BP": float(B(P)),
+        "TP": float(T(P)),
+    }
+
+
+def project_amari(outs, pmf, alph, order, criterion, eps=1e-6, nrestarts=10, maxiter=2500):
+    """Project onto M_order under fwd KL / rev KL / JSD."""
+    A, _ = mflat_design_matrix(alph, order)
+    n_out, n_feat = A.shape
+    rng = np.random.default_rng(0)
+
+    target = pmf.copy()
+    if criterion == "rev" and eps:
+        dtmp = Distribution(outs, pmf, base="linear", validate=False)
+        dtmp = symmetric_smooth(dtmp, eps)
+        target = _aligned_pmf(dtmp, outs)
+
+    def feasible(th):
+        q = A @ th
+        if np.any(q < -1e-10):
+            q = np.maximum(q, 0.0)
+        s = q.sum()
+        if s <= 0:
+            return None
+        return q / s
+
+    def objective(th):
+        q = feasible(th)
+        if q is None:
+            return 1e6
+        if criterion == "fwd":
+            return _fwd_kl(pmf, q)
+        if criterion == "rev":
+            val = _rev_kl(q, target)
+            return val if np.isfinite(val) else 1e6
+        if criterion == "jsd":
+            return _jsd_pmf(pmf, q)
+        raise ValueError(criterion)
+
+    cons = [{"type": "eq", "fun": lambda th: float((A @ th).sum() - 1.0)}]
+    for i in range(n_out):
+        cons.append({"type": "ineq", "fun": lambda th, i=i: float((A @ th)[i])})
+
+    initials = [np.linalg.lstsq(A, pmf, rcond=None)[0], np.zeros(n_feat)]
+    initials[1][0] = 1.0 / n_out
+    for _ in range(max(0, nrestarts - len(initials))):
+        initials.append(rng.normal(0.0, 0.05, size=n_feat))
+
+    best_q, best_val = None, np.inf
+    for th0 in initials:
+        q0 = A @ th0
+        if abs(q0.sum()) > 0:
+            th0 = th0 / q0.sum()
+        res = minimize(
+            objective,
+            th0,
+            method="SLSQP",
+            constraints=cons,
+            options={"maxiter": maxiter, "ftol": 1e-14, "disp": False},
+        )
+        q = feasible(res.x)
+        if q is None:
+            continue
+        val = objective(res.x)
+        if val < best_val:
+            best_val = val
+            best_q = q
+
+    if best_q is None:
+        raise RuntimeError(f"Amari projection failed ({criterion}, order={order})")
+    return best_q, float(best_val)
+
+
+def embed_PS(outs, pmf, alph, S, mode):
+    n = len(alph)
+    marg = defaultdict(float)
+    for o, p in zip(outs, pmf, strict=True):
+        marg[tuple(o[i] for i in S)] += p
+    rest = [i for i in range(n) if i not in S]
+    if mode == "uniform":
+        rest_size = int(np.prod([len(alph[i]) for i in rest])) if rest else 1
+        return np.array([marg[tuple(o[i] for i in S)] / rest_size for o in outs])
+    ones = []
+    for i in range(n):
+        m1 = defaultdict(float)
+        for o, p in zip(outs, pmf, strict=True):
+            m1[o[i]] += p
+        ones.append(m1)
+    q = []
+    for o in outs:
+        val = marg[tuple(o[i] for i in S)]
+        for i in rest:
+            val *= ones[i][o[i]]
+        q.append(val)
+    q = np.asarray(q, dtype=float)
+    return q / q.sum()
+
+
+def fit_option2(outs, pmf, alph, order, mode, n_init=12):
+    blocks, labels = [], []
+    blocks.append(np.ones(len(outs)) / len(outs))
+    labels.append("∅")
+    for k in range(1, order + 1):
+        for S in combinations(range(len(alph)), k):
+            blocks.append(embed_PS(outs, pmf, alph, S, mode))
+            labels.append("".join(map(str, S)))
+    A = np.column_stack(blocks)
+    nb = A.shape[1]
+
+    def loss(x):
+        return np.sum((A @ x - pmf) ** 2)
+
+    cons = {"type": "eq", "fun": lambda x: x.sum() - 1}
+    best = None
+    rng = np.random.default_rng(0)
+    for _ in range(n_init):
+        x0 = rng.dirichlet(np.ones(nb))
+        r = minimize(
+            loss,
+            x0,
+            bounds=[(0, None)] * nb,
+            constraints=cons,
+            method="SLSQP",
+            options={"maxiter": 2000, "ftol": 1e-14},
+        )
+        if best is None or r.fun < best[0]:
+            best = (r.fun, r.x)
+    alpha = np.maximum(best[1], 0.0)
+    alpha /= alpha.sum()
+    q = A @ alpha
+    q = np.maximum(q, 0.0)
+    q /= q.sum()
+    return labels, alpha, q, float(np.sqrt(best[0]))
+
+
+def fmt_alpha(labels, alpha, thresh=0.05):
+    parts = [f"{l}:{a:.2f}" for l, a in sorted(zip(labels, alpha, strict=True), key=lambda t: -t[1]) if a >= thresh]
+    return "[" + ", ".join(parts) + "]"
+
+
+def main():
+    print("=" * 88)
+    print("LINEAR BUILDING-BLOCK PROBE")
+    print("=" * 88)
+
+    for name, dist in DISTS.items():
+        outs, pmf, alph = cartesian(dist)
+        n = len(alph)
+        print(f"\n##### {name}  |supp|={int((pmf > 0).sum())}  B={B(dist):.4f} T={T(dist):.4f} H={H(dist):.4f}")
+
+        print("\n-- (1) Amari M_k --")
+        print(f"{'k':>2} {'crit':>4} {'obj':>8} {'B(Q)':>8} {'T(Q)':>8} {'Df':>8} {'Dr':>8} {'JSD':>8} {'L2':>8}")
+        for order in range(1, n + 1):
+            for crit in ("fwd", "rev", "jsd"):
+                q, obj = project_amari(outs, pmf, alph, order, crit)
+                m = metrics(outs, pmf, q)
+                print(
+                    f"{order:2d} {crit:>4} {obj:8.4f} {m['B']:8.4f} {m['T']:8.4f} "
+                    f"{m['Df']:8.4f} {m['Dr']:8.4f} {m['JSD']:8.4f} {m['L2']:8.4f}"
+                )
+
+        print("\n-- (2) Convex combo of Lift(P_S) --")
+        print(f"{'k':>2} {'lift':>7} {'B(Q)':>8} {'T(Q)':>8} {'Df':>8} {'JSD':>8} {'L2':>8}  alpha")
+        for order in range(1, n + 1):
+            for mode in ("uniform", "product"):
+                labels, alpha, q, l2 = fit_option2(outs, pmf, alph, order, mode)
+                m = metrics(outs, pmf, q)
+                print(
+                    f"{order:2d} {mode:>7} {m['B']:8.4f} {m['T']:8.4f} {m['Df']:8.4f} "
+                    f"{m['JSD']:8.4f} {m['L2']:8.4f}  {fmt_alpha(labels, alpha)}"
+                )
+
+        print("\n-- Contrast: BindingMixtureProfile ΔB --")
+        bmp = BindingMixtureProfile(dist, k_max=min(8, max(4, int((pmf > 0).sum()))), n_init=8, seed=0)
+        for k in sorted(bmp.profile):
+            print(
+                f"  k={k}: ΔB={bmp.profile[k]:.4f}  B(Q)={bmp.bindings[k - 1]:.4f}  "
+                f"D(P||Q)={bmp.forward_kl[k - 1]:.4f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/algorithms/test_mixture_of_products.py
+++ b/tests/algorithms/test_mixture_of_products.py
@@ -1,0 +1,124 @@
+"""
+Tests for mixture-of-products fitting and BindingMixtureProfile.
+"""
+
+import pytest
+
+from dit import Distribution
+from dit.algorithms import fit_mixture_of_products, mixture_of_products_dists
+from dit.divergences import kullback_leibler_divergence as D
+from dit.multivariate import dual_total_correlation as B
+from dit.profiles import BindingMixtureProfile, SharedRandomnessDecomposition
+from dit.shannon import entropy as H
+
+
+def _giant_bit():
+    return Distribution(["000", "111"], [0.5, 0.5])
+
+
+def _xor():
+    return Distribution(["000", "011", "101", "110"], [0.25] * 4)
+
+
+def _w():
+    return Distribution(["001", "010", "100"], [1 / 3] * 3)
+
+
+def _copy():
+    return Distribution(["000", "001", "110", "111"], [0.25] * 4)
+
+
+def _and():
+    outs, p = [], []
+    for x in "01":
+        for y in "01":
+            z = "1" if (x == "1" and y == "1") else "0"
+            outs.append(x + y + z)
+            p.append(0.25)
+    return Distribution(outs, p)
+
+
+def test_fit_k1_is_product():
+    d = _xor()
+    fit = fit_mixture_of_products(d, k=1, n_init=4, seed=1)
+    # Product of marginals: D(P||Q) = T(P) = 1 for XOR.
+    assert D(d, fit["dist"]) == pytest.approx(1.0, abs=1e-5)
+    assert B(fit["dist"]) == pytest.approx(0.0, abs=1e-5)
+
+
+def test_giant_bit_exact_at_k2():
+    d = _giant_bit()
+    fit = fit_mixture_of_products(d, k=2, n_init=8, seed=0)
+    assert D(d, fit["dist"]) == pytest.approx(0.0, abs=1e-6)
+    assert B(fit["dist"]) == pytest.approx(1.0, abs=1e-5)
+    assert fit["I_xv"] == pytest.approx(1.0, abs=1e-5)
+
+
+def test_xor_needs_k4():
+    d = _xor()
+    dists, meta = mixture_of_products_dists(d, k_max=4, n_init=10, seed=0, early_stop=False)
+    assert meta[0]["forward_kl"] == pytest.approx(1.0, abs=1e-4)
+    assert meta[3]["forward_kl"] == pytest.approx(0.0, abs=1e-5)
+    assert B(dists[3]) == pytest.approx(2.0, abs=1e-5)
+
+
+def test_binding_mixture_profile_sums_to_b():
+    """ΔB atoms are nonnegative and sum to B(P)."""
+    for factory in (_giant_bit, _xor, _w, _copy, _and):
+        d = factory()
+        prof = BindingMixtureProfile(d, k_max=8, n_init=10, seed=0)
+        vals = [prof.profile[k] for k in sorted(prof.profile)]
+        assert all(v >= -1e-6 for v in vals)
+        assert sum(vals) == pytest.approx(B(d), abs=1e-3)
+
+
+def test_binding_mixture_giant_bit_mass_at_k2():
+    d = _giant_bit()
+    prof = BindingMixtureProfile(d, k_max=4, n_init=8, seed=0)
+    assert prof.profile[1] == pytest.approx(0.0, abs=1e-5)
+    assert prof.profile[2] == pytest.approx(1.0, abs=1e-4)
+    # Early stop once D≈0, so higher k may be absent.
+    assert prof.forward_kl[-1] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_binding_mixture_copy_at_k2():
+    d = _copy()
+    prof = BindingMixtureProfile(d, k_max=4, n_init=8, seed=0)
+    assert sum(prof.profile[k] for k in prof.profile if k <= 2) == pytest.approx(1.0, abs=1e-3)
+
+
+def test_binding_mixture_xor_late():
+    d = _xor()
+    prof = BindingMixtureProfile(d, k_max=4, n_init=10, seed=0, early_stop=False)
+    # Little binding at k=2; most arrives by k=4.
+    assert prof.profile[2] < 0.5
+    assert sum(prof.profile.values()) == pytest.approx(2.0, abs=1e-3)
+
+
+def test_shared_randomness_decomposition_default_b():
+    d = _giant_bit()
+    srd = SharedRandomnessDecomposition(d)
+    assert "B" in next(iter(srd.atoms.values()))
+    # Fully independent node has B=0; full joint has B=1.
+    nodes = list(srd.atoms.keys())
+    full = max(nodes, key=lambda n: max((len(b) for b in n), default=0))
+    singles = min(nodes, key=lambda n: max((len(b) for b in n), default=0))
+    assert srd.atoms[full]["B"] == pytest.approx(1.0, abs=1e-5)
+    assert srd.atoms[singles]["B"] == pytest.approx(0.0, abs=1e-5)
+
+
+def test_shared_randomness_matches_dd_with_b():
+    from dit.profiles import DependencyDecomposition
+
+    d = _w()
+    srd = SharedRandomnessDecomposition(d)
+    dd = DependencyDecomposition(d, measures={"B": B})
+    for node in srd.atoms:
+        assert srd.atoms[node]["B"] == pytest.approx(dd.atoms[node]["B"], abs=1e-6)
+
+
+def test_ladder_entropy_decreases():
+    d = _and()
+    dists, _ = mixture_of_products_dists(d, k_max=3, n_init=8, seed=1)
+    ents = [H(q) for q in dists]
+    assert ents[0] >= ents[-1] - 1e-6

--- a/tests/algorithms/test_mprojection.py
+++ b/tests/algorithms/test_mprojection.py
@@ -1,0 +1,114 @@
+"""
+Tests for dit.algorithms.mprojection (Amari m-flat m-projections).
+"""
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from dit import Distribution
+from dit.algorithms import m_projection, mflat_mprojection_dists, symmetric_smooth
+from dit.divergences import kullback_leibler_divergence as D
+from dit.exceptions import ditException
+
+
+def _weakly_dependent_binary():
+    outcomes = ["".join(o) for o in product("01", repeat=3)]
+    pmf = np.ones(8) / 8.0
+    pmf[0] += 0.05
+    pmf[7] += 0.05
+    pmf = pmf / pmf.sum()
+    return Distribution(outcomes, pmf)
+
+
+def test_design_matrix_order_zero_is_constant():
+    from dit.algorithms import mflat_design_matrix
+
+    A, outcomes = mflat_design_matrix([("0", "1"), ("0", "1")], order=0)
+    assert A.shape == (4, 1)
+    assert np.allclose(A, 1.0)
+    assert len(outcomes) == 4
+
+
+def test_m_projection_order_zero_is_uniform():
+    d = _weakly_dependent_binary()
+    q = m_projection(d, 0, eps=0.0)
+    assert np.allclose(q.pmf, 1.0 / len(q.outcomes))
+
+
+def test_m_projection_order_n_recovers_target():
+    d = _weakly_dependent_binary()
+    q = m_projection(d, 3, eps=0.0)
+    assert q.is_approx_equal(d, rtol=1e-10, atol=1e-10)
+
+
+def test_jsd_projection_giant_bit():
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    ladder = mflat_mprojection_dists(d, criterion="jsd")
+    from dit.divergences.jensen_shannon_divergence import jensen_shannon_divergence
+
+    # Exact by order 2
+    assert jensen_shannon_divergence([d, ladder[2]]) == pytest.approx(0.0, abs=1e-5)
+    assert jensen_shannon_divergence([d, ladder[1]]) > 0.1
+
+
+def test_forward_kl_projection_copy():
+    d = Distribution(["000", "001", "110", "111"], [0.25] * 4)
+    q2 = m_projection(d, 2, criterion="forward_kl")
+    assert D(d, q2) == pytest.approx(0.0, abs=1e-5)
+
+
+def test_pythagorean_identity_full_support():
+    d = _weakly_dependent_binary()
+    ladder = mflat_mprojection_dists(d, eps=0.0)
+    total = D(ladder[0], ladder[-1])
+    parts = sum(D(ladder[i], ladder[i + 1]) for i in range(len(ladder) - 1))
+    assert parts == pytest.approx(total, rel=1e-4, abs=1e-4)
+
+
+def test_giant_bit_mass_in_pairwise():
+    """Giant Bit is pairwise in the mixture sense: C*_3 ≈ 0, C*_2 dominates."""
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    ladder = mflat_mprojection_dists(d, eps_schedule=(1e-4, 1e-6, 1e-8))
+    c2 = D(ladder[1], ladder[2])
+    c3 = D(ladder[2], ladder[3])
+    assert c3 == pytest.approx(0.0, abs=1e-4)
+    assert c2 > 1.0
+
+
+def test_xor_mass_in_triplewise():
+    """XOR is pure triplewise in the mixture sense."""
+    d = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    ladder = mflat_mprojection_dists(d, eps_schedule=(1e-4, 1e-6, 1e-8))
+    c2 = D(ladder[1], ladder[2])
+    c3 = D(ladder[2], ladder[3])
+    assert c2 < 0.1
+    assert c3 > 1.0
+
+
+def test_nonbinary_alphabet():
+    """m-projection works for a ternary variable pair."""
+    outcomes = [(a, b) for a in "012" for b in "012"]
+    pmf = np.ones(9) / 9.0
+    pmf[0] += 0.1
+    pmf[8] += 0.1
+    pmf /= pmf.sum()
+    d = Distribution(outcomes, pmf)
+    q1 = m_projection(d, 1, eps=0.0)
+    assert D(q1, d) >= 0
+    q2 = m_projection(d, 2, eps=0.0)
+    assert D(q2, d) == pytest.approx(0.0, abs=1e-8)
+
+
+def test_invalid_order_raises():
+    d = _weakly_dependent_binary()
+    with pytest.raises(ditException):
+        m_projection(d, -1)
+
+
+def test_symmetric_smooth_full_support():
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    pe = symmetric_smooth(d, 1e-5)
+    assert np.all(pe.pmf > 0)
+    assert abs(pe.pmf.sum() - 1.0) < 1e-12

--- a/tests/profiles/test_binding_mixture.py
+++ b/tests/profiles/test_binding_mixture.py
@@ -1,0 +1,32 @@
+"""
+Tests for BindingMixtureProfile and SharedRandomnessDecomposition (profiles).
+"""
+
+import pytest
+
+from dit import Distribution
+from dit.multivariate import dual_total_correlation as B
+from dit.profiles import BindingMixtureProfile, SharedRandomnessDecomposition
+
+ex_gb = Distribution(["000", "111"], [1 / 2] * 2)
+ex_xor = Distribution(["000", "011", "101", "110"], [1 / 4] * 4)
+ex_copy = Distribution(["000", "001", "110", "111"], [1 / 4] * 4)
+
+
+def test_profile_repr_keys():
+    prof = BindingMixtureProfile(ex_gb, k_max=3, n_init=6, seed=0)
+    assert set(prof.profile.keys()) <= {1, 2, 3}
+    assert len(prof.dists) == len(prof.profile)
+
+
+def test_w_saturates_at_k3():
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    prof = BindingMixtureProfile(w, k_max=5, n_init=10, seed=0)
+    assert sum(prof.profile.values()) == pytest.approx(B(w), abs=1e-3)
+    assert prof.forward_kl[-1] == pytest.approx(0.0, abs=1e-5)
+
+
+def test_shared_randomness_string():
+    s = str(SharedRandomnessDecomposition(ex_copy))
+    assert "B" in s
+    assert "Shared Randomness" in s or "dependency" in s.lower()

--- a/tests/profiles/test_dual_dependency_decomposition.py
+++ b/tests/profiles/test_dual_dependency_decomposition.py
@@ -1,0 +1,128 @@
+"""
+Tests for DualDependencyDecomposition (m-flat dependency lattice).
+"""
+
+import numpy as np
+import pytest
+
+from dit import Distribution
+from dit.algorithms import m_projection, m_projection_eps_limit, symmetric_smooth
+from dit.algorithms.mprojection import mflat_subsets_from_dependency
+from dit.divergences import kullback_leibler_divergence as D
+from dit.example_dists import n_mod_m
+from dit.profiles import DependencyDecomposition, DualDependencyDecomposition
+from dit.shannon import entropy as H
+
+
+def test_mflat_subsets_downward_closure():
+    node = frozenset([frozenset([0, 1]), frozenset([2])])
+    subs = mflat_subsets_from_dependency(node)
+    assert (0, 1) in subs
+    assert (0,) in subs and (1,) in subs and (2,) in subs
+    assert (0, 2) not in subs
+
+
+def test_symmetric_smooth_preserves_w_symmetry():
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    pe = symmetric_smooth(w, 1e-6)
+    pm = {"".join(o) if not isinstance(o, str) else o: float(p) for o, p in zip(pe.outcomes, pe.pmf)}
+    wt1 = [pm["001"], pm["010"], pm["100"]]
+    zeros = [pm[x] for x in ("000", "011", "101", "110", "111")]
+    assert max(wt1) - min(wt1) < 1e-15
+    assert max(zeros) - min(zeros) < 1e-15
+
+
+def test_dual_dd_top_zero_rkl():
+    d = n_mod_m(3, 2)
+    dd = DualDependencyDecomposition(d, nrestarts=4, maxiter=800)
+    top = frozenset([frozenset([0, 1, 2])])
+    assert dd[top]["rKL"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_dual_dd_xor_needs_triple():
+    """XOR: any node without the full triple keeps large reverse KL."""
+    d = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    dd = DualDependencyDecomposition(d, nrestarts=4, maxiter=800)
+    pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+    top = frozenset([frozenset([0, 1, 2])])
+    assert dd[pairs]["rKL"] > 1.0
+    assert dd[top]["rKL"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_dual_dd_giant_bit_pairs_suffice():
+    """Giant Bit lies in the pairwise additive family."""
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    dd = DualDependencyDecomposition(d, nrestarts=4, maxiter=800)
+    pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+    assert dd[pairs]["rKL"] == pytest.approx(0.0, abs=1e-3)
+
+
+def test_dual_dd_w_pairs_symmetric():
+    """W pair-cover projection should respect S3 symmetry under symmetric P_ε."""
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    dd = DualDependencyDecomposition(w, nrestarts=6, maxiter=1500)
+    pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+    q = dd.dists[pairs]
+    pm = {"".join(o) if not isinstance(o, str) else o: float(p) for o, p in zip(q.outcomes, q.pmf)}
+    wt1 = np.array([pm.get("001", 0), pm.get("010", 0), pm.get("100", 0)])
+    wt2 = np.array([pm.get("011", 0), pm.get("101", 0), pm.get("110", 0)])
+    assert np.ptp(wt1) < 1e-3
+    assert np.ptp(wt2) < 1e-3
+    assert dd[pairs]["rKL"] > 1.0  # pairs do not recover W in m-flat
+
+
+def test_dual_dd_pairs_match_order2_eps_limit():
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    schedule = (1e-4, 1e-6, 1e-8)
+    dd = DualDependencyDecomposition(d, eps_schedule=schedule, nrestarts=4, maxiter=800)
+    pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+    q2 = m_projection_eps_limit(d, order=2, eps_schedule=schedule, nrestarts=4, maxiter=800)["dist"]
+    assert dd.dists[pairs].is_approx_equal(q2, rtol=1e-5, atol=1e-5)
+    assert dd[pairs]["rKL"] == pytest.approx(D(q2, dd.target), abs=1e-5)
+
+
+def test_dual_dd_single_eps():
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    dd = DualDependencyDecomposition(d, eps=1e-6, eps_schedule=None, nrestarts=4, maxiter=800)
+    top = frozenset([frozenset([0, 1, 2])])
+    assert dd[top]["rKL"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_dual_dd_differs_from_dependency_decomposition():
+    d = n_mod_m(3, 2)
+    dual = DualDependencyDecomposition(d, nrestarts=4, maxiter=800)
+    primal = DependencyDecomposition(d, measures={"H": H})
+    assert dual.get_dependencies() == primal.get_dependencies()
+    pairs = frozenset([frozenset([0, 1]), frozenset([0, 2]), frozenset([1, 2])])
+    assert dual[pairs]["rKL"] != pytest.approx(primal[pairs]["H"], abs=0.1)
+
+
+def test_dual_dd_named_rvs():
+    d = n_mod_m(3, 2)
+    d.set_rv_names("XYZ")
+    dd = DualDependencyDecomposition(d, nrestarts=4, maxiter=800)
+    top = frozenset([frozenset(["X", "Y", "Z"])])
+    assert dd[top]["rKL"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_dual_dd_custom_measure():
+    d = Distribution(["000", "111"], [0.5, 0.5])
+    dd = DualDependencyDecomposition(
+        d,
+        measures={"H": H, "rKL": DualDependencyDecomposition.REVERSE_KL},
+        nrestarts=4,
+        maxiter=800,
+    )
+    bottom = frozenset([frozenset([0]), frozenset([1]), frozenset([2])])
+    assert "H" in dd[bottom] and "rKL" in dd[bottom]
+    assert dd[bottom]["H"] > 0
+
+
+def test_m_projection_eps_limit_w_order2():
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    res = m_projection_eps_limit(w, order=2, eps_schedule=(1e-4, 1e-6), nrestarts=8, maxiter=1500)
+    q = res["dist"]
+    pm = {"".join(o) if not isinstance(o, str) else o: float(p) for o, p in zip(q.outcomes, q.pmf)}
+    wt2 = [pm.get(x, 0) for x in ("011", "101", "110")]
+    assert np.ptp(wt2) < 1e-3
+    assert res["rKL"] > 1.0

--- a/tests/profiles/test_marginal_lift.py
+++ b/tests/profiles/test_marginal_lift.py
@@ -1,0 +1,50 @@
+"""
+Tests for MarginalLiftProfile and marginal-lift fitting.
+"""
+
+import pytest
+
+from dit import Distribution
+from dit.algorithms import fit_marginal_lift_mixture, marginal_lift_dists
+from dit.divergences import kullback_leibler_divergence as D
+from dit.profiles import MarginalLiftProfile
+
+
+def test_copy_puts_mass_on_pair():
+    copy = Distribution(["000", "001", "110", "111"], [0.25] * 4)
+    fit = fit_marginal_lift_mixture(copy, order=2, mode="uniform")
+    assert D(copy, fit["dist"]) == pytest.approx(0.0, abs=1e-6)
+    # label (0, 1) should carry essentially all weight
+    idx = fit["labels"].index((0, 1))
+    assert fit["alpha"][idx] == pytest.approx(1.0, abs=1e-3)
+
+
+def test_xor_needs_full_joint():
+    xor = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    fit2 = fit_marginal_lift_mixture(xor, order=2)
+    fit3 = fit_marginal_lift_mixture(xor, order=3)
+    assert fit2["L2"] > 0.2
+    assert fit3["L2"] == pytest.approx(0.0, abs=1e-6)
+    assert D(xor, fit3["dist"]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_marginal_lift_profile_copy():
+    copy = Distribution(["000", "001", "110", "111"], [0.25] * 4)
+    prof = MarginalLiftProfile(copy, mode="uniform")
+    assert set(prof.profile.keys()) == {1, 2, 3}
+    # Residual should be ~0 by order 2
+    assert prof.residuals[2] == pytest.approx(0.0, abs=1e-5)
+    assert all(v >= -1e-6 for v in prof.profile.values())
+
+
+def test_giant_bit_order3():
+    gb = Distribution(["000", "111"], [0.5, 0.5])
+    dists, metas = marginal_lift_dists(gb, k_max=3)
+    assert metas[2]["L2"] > 0.3
+    assert metas[3]["L2"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_product_lift_mode():
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    prof = MarginalLiftProfile(w, mode="product", n_init=8)
+    assert prof.residuals[-1] == pytest.approx(0.0, abs=1e-5)

--- a/tests/profiles/test_mflat_connected.py
+++ b/tests/profiles/test_mflat_connected.py
@@ -1,0 +1,89 @@
+"""
+Tests for dit.profiles.MFlatConnectedInformations.
+"""
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from dit import Distribution
+from dit.divergences import kullback_leibler_divergence as D
+from dit.profiles import (
+    ConnectedDualInformations,
+    ConnectedInformations,
+    MFlatConnectedInformations,
+)
+
+
+def _weakly_dependent_binary():
+    outcomes = ["".join(o) for o in product("01", repeat=3)]
+    pmf = np.ones(8) / 8.0
+    pmf[0] += 0.05
+    pmf[7] += 0.05
+    pmf = pmf / pmf.sum()
+    return Distribution(outcomes, pmf)
+
+
+def test_mflat_profile_pythagorean():
+    d = _weakly_dependent_binary()
+    prof = MFlatConnectedInformations(d, criterion="reverse_kl", eps=0.0)
+    total = sum(prof.profile.values())
+    assert total == pytest.approx(D(prof._dists[0], prof._dists[-1]), rel=1e-4, abs=1e-4)
+
+
+def test_mflat_profile_keys():
+    d = _weakly_dependent_binary()
+    prof = MFlatConnectedInformations(d, criterion="jsd")
+    assert set(prof.profile) == {1, 2, 3}
+
+
+def test_mflat_jsd_nonnegative_atoms():
+    d = _weakly_dependent_binary()
+    prof = MFlatConnectedInformations(d, criterion="jsd", nrestarts=8)
+    assert all(v >= -1e-6 for v in prof.profile.values())
+
+
+def test_mflat_differs_from_schneidman_dual():
+    """m-flat reverse-KL profile is not the MaxEnt DTC-increment profile."""
+    d = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    mflat = MFlatConnectedInformations(d, criterion="reverse_kl")
+    dual = ConnectedDualInformations(d)
+    mvals = np.array([mflat.profile[i] for i in (1, 2, 3)])
+    dvals = np.array([dual.profile[i] for i in (1, 2, 3)])
+    assert not np.allclose(mvals, dvals, atol=1e-2)
+
+
+def test_mflat_differs_from_connected_informations():
+    d = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    mflat = MFlatConnectedInformations(d, criterion="jsd")
+    conn = ConnectedInformations(d)
+    mvals = np.array([mflat.profile[i] for i in (1, 2, 3)])
+    cvals = np.array([conn.profile[i] for i in (1, 2, 3)])
+    assert not np.allclose(mvals, cvals, atol=1e-2)
+
+
+def test_giant_bit_and_xor_shapes_jsd():
+    gb = Distribution(["000", "111"], [0.5, 0.5])
+    xor = Distribution(["000", "011", "101", "110"], [0.25] * 4)
+    gb_p = MFlatConnectedInformations(gb, criterion="jsd", nrestarts=8)
+    xor_p = MFlatConnectedInformations(xor, criterion="jsd", nrestarts=8)
+    # Giant Bit: mass at pairwise order
+    assert gb_p.profile[3] == pytest.approx(0.0, abs=1e-3)
+    assert gb_p.profile[2] > 0.1
+    # XOR: triplewise dominates
+    assert xor_p.profile[3] > xor_p.profile[2]
+    assert xor_p.profile[3] > xor_p.profile[1]
+
+
+def test_w_has_nonzero_triplewise():
+    w = Distribution(["001", "010", "100"], [1 / 3] * 3)
+    prof = MFlatConnectedInformations(w, criterion="jsd", nrestarts=8)
+    assert prof.profile[3] > 0.1
+
+
+def test_copy_exact_at_order_2():
+    copy = Distribution(["000", "001", "110", "111"], [0.25] * 4)
+    prof = MFlatConnectedInformations(copy, criterion="jsd", nrestarts=8)
+    assert prof.profile[3] == pytest.approx(0.0, abs=1e-3)
+    assert prof.profile[2] > 0.1


### PR DESCRIPTION
## Summary
- Add Amari m-flat reverse-KL projections (`m_projection`, `m_projection_eps_limit`) with symmetric \(P_\varepsilon=(1-\varepsilon)P+\varepsilon U\) and \(\varepsilon\to 0\).
- Add `DualDependencyDecomposition`: same dependency lattice as DD, but m-flat reverse KL per node (default atom \(D(Q_\pi\|P_\varepsilon)\)).
- Add related dual profiles: `MFlatConnectedInformations`, `BindingMixtureProfile` / mixture-of-products EM, and `MarginalLiftProfile`, plus docs and tests.

## Test plan
- [x] `pytest tests/algorithms/test_mprojection.py tests/profiles/test_dual_dependency_decomposition.py tests/profiles/test_mflat_connected.py`
- [x] `pytest tests/algorithms/test_mixture_of_products.py tests/profiles/test_binding_mixture.py tests/profiles/test_marginal_lift.py`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)